### PR TITLE
Fix issue where on_success only actually ran on errors

### DIFF
--- a/metrique/src/instrument.rs
+++ b/metrique/src/instrument.rs
@@ -119,13 +119,13 @@ impl<T, E, U> Instrumented<std::result::Result<T, E>, U> {
     ///     Instrumented::instrument(EventMetrics::default(), |metrics| {
     ///         let event: usize = event.parse()?;
     ///         Ok(event)
-    ///     }).on_success(|_e, metrics|metrics.success = true)
+    ///     }).on_success(|_v, metrics|metrics.success = true)
     /// }
     /// ```
-    pub fn on_success(self, f: impl FnOnce(&E, &mut U)) -> Self {
+    pub fn on_success(self, f: impl FnOnce(&T, &mut U)) -> Self {
         self.finalize_metrics(|res, metrics| {
-            if let Err(e) = res {
-                f(e, metrics);
+            if let Ok(v) = res {
+                f(v, metrics);
             }
         })
     }

--- a/metrique/tests/instrument.rs
+++ b/metrique/tests/instrument.rs
@@ -10,6 +10,7 @@ use metrique::{
 #[derive(Default)]
 pub struct LookupBookMetrics {
     books_considered: usize,
+    success: bool,
     error: bool,
 }
 
@@ -18,10 +19,12 @@ fn instrument_on_error() {
     let (is_odd, metrics) = try_odd(3).into_parts();
     assert_eq!(is_odd, Ok(true));
     assert_eq!(metrics.error, false);
+    assert_eq!(metrics.success, true);
 
     let (is_odd, metrics) = try_odd(4).into_parts();
     assert_eq!(is_odd, Err(4));
     assert_eq!(metrics.error, true);
+    assert_eq!(metrics.success, false);
 }
 
 fn try_odd(n: usize) -> instrument::Result<bool, usize, LookupBookMetrics> {
@@ -30,6 +33,7 @@ fn try_odd(n: usize) -> instrument::Result<bool, usize, LookupBookMetrics> {
         if n % 2 == 0 { Err(n) } else { Ok(true) }
     })
     .on_error(|_res, metrics| metrics.error = true)
+    .on_success(|_res, metrics| metrics.success = true)
 }
 
 #[tokio::test]


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:* Fix on_success to run on success (previously it erroneously ran during errors).

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
