### PR TITLE
feat: add metric of lost metrics

### DIFF
--- a/metrique-writer/src/sink/immediate_flush.rs
+++ b/metrique-writer/src/sink/immediate_flush.rs
@@ -21,7 +21,7 @@ use super::{
 #[derive(Default)]
 pub struct FlushImmediatelyBuilder {
     metric_name: Option<String>,
-    metric_recorder: Option<Box<dyn MetricRecorder + Send>>,
+    metric_recorder: Option<Box<dyn MetricRecorder>>,
 }
 
 impl FlushImmediatelyBuilder {
@@ -44,7 +44,7 @@ impl FlushImmediatelyBuilder {
     ///
     /// The following metrics exist:
     /// 1. `metrique_flush_time_ms` - histogram of flush operation times in milliseconds
-    pub fn metric_recorder(mut self, recorder: Option<Box<dyn MetricRecorder + Send>>) -> Self {
+    pub fn metric_recorder(mut self, recorder: Option<Box<dyn MetricRecorder>>) -> Self {
         self.metric_recorder = recorder;
         self
     }
@@ -169,7 +169,7 @@ impl FlushImmediatelyBuilder {
 struct SinkState<S> {
     stream: S,
     name: String,
-    recorder: Option<Box<dyn MetricRecorder + Send>>,
+    recorder: Option<Box<dyn MetricRecorder>>,
 }
 
 impl<S: EntryIoStream> SinkState<S> {


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

This adds a metric, `metrique_metrics_lost`, to easily monitor whether metrics have been lost due to a queue being full.

This is a breaking change since it requires `MetricRecorder` to be `Send + Sync`, but this library has not been
released yet so it should not be a problem.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
