### PR TITLE
doc/fix: round 1

### DIFF
--- a/metrique-core/README.md
+++ b/metrique-core/README.md
@@ -1,0 +1,4 @@
+This crate contains core trait and struct definitions for `metrique`,
+to allow for compatibility between (future) different major versions
+of `metrique`. You should be using `metrique` directly rather than
+this crate.

--- a/metrique-core/src/lib.rs
+++ b/metrique-core/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
-
-//! This crate contains the traits for the `metrique` set of libraries. Generally, you
-//! should not depend on this crate directly. Instead, use `metrique`
+#![doc = include_str!("../README.md")]
 
 use metrique_writer_core::{EntryWriter, entry::SampleGroupElement};
 

--- a/metrique-macro/README.md
+++ b/metrique-macro/README.md
@@ -1,0 +1,3 @@
+This crate defines the `#[metrics]` macro. You should be using
+`metrique::unit_of_work::metrics` from the `metrique` crate,
+rather than referring to this crate directly.

--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc = include_str!("../README.md")]
+
 mod emf;
 mod entry_impl;
 

--- a/metrique-writer-core/README.md
+++ b/metrique-writer-core/README.md
@@ -1,0 +1,4 @@
+This crate contains core trait and struct definitions for `metrique-writer`,
+to allow for compatibility between (future) different major versions
+of `metrique-writer`. You should be using `metrique-writer` directly rather than
+this crate.

--- a/metrique-writer-core/src/lib.rs
+++ b/metrique-writer-core/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc = include_str!("../README.md")]
+
 pub use crate::entry::{BoxEntry, Entry, EntryConfig, EntryWriter};
 pub use crate::global::GlobalEntrySink;
 pub use crate::sink::{AnyEntrySink, BoxEntrySink, EntrySink};

--- a/metrique-writer-format-emf/README.md
+++ b/metrique-writer-format-emf/README.md
@@ -1,0 +1,8 @@
+A `metrique` [Format] for formatting `metrique` metrics to [Amazon CloudWatch Embedded Metric Format (EMF)].
+
+For more details, read the docs for [Emf].
+
+[Amazon CloudWatch Embedded Metric Format (EMF)]
+: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+[Format]: metrique_writer::Format
+[Emf]: crate::Emf

--- a/metrique-writer-format-emf/src/lib.rs
+++ b/metrique-writer-format-emf/src/lib.rs
@@ -1,12 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc = include_str!("../README.md")]
+#![deny(missing_docs)]
+
 mod buf;
 mod emf;
 mod json_string;
 
 pub use emf::{
-    AllowSplitEntries, Emf, EmfBuilder, EmfOptions, EntryDimensions, HighStorageResolution,
+    AllowSplitEntries, Emf, EmfBuilder, EntryDimensions, HighStorageResolution,
     HighStorageResolutionCtor, MetricDefinition, MetricDirective, NoMetric, NoMetricCtor,
     SampledEmf, StorageResolution,
 };

--- a/metrique-writer-macro/README.md
+++ b/metrique-writer-macro/README.md
@@ -1,0 +1,2 @@
+This crate defines the `#[derive(Entry)]` macro. You should be using the
+`metrique-writer` crate, rather than referring to this crate directly.

--- a/metrique-writer-macro/src/lib.rs
+++ b/metrique-writer-macro/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![doc = include_str!("../README.md")]
+
 use std::collections::HashSet;
 
 use darling::{FromAttributes as _, util::SpannedValue};


### PR DESCRIPTION
1. Add some README.md
2. Add some examples
3. Add deny(missing_docs) to metrique-writer-format-emf

Small changes:

1. fix JSON encoding of MetricDirective (doc test exists)
2. make EmfOptions private, as it has no public use

📬 *Issue #, if available:*

✍️ *Description of changes:*

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
