### PR TITLE
Add 'flex' to allow custom keys

### DIFF
--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { workspace = true, features = ["sync"] }
 metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.0" }
 metrique-macro = { path = "../metrique-macro", version = "0.1.0" }
 metrique-core = { path = "../metrique-core", version = "0.1.0" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.0" }
 metrique-timesource = { path = "../metrique-timesource", version = "0.1.0" }
 ryu = { workspace = true }
 itoa = { workspace = true }
@@ -25,9 +26,16 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
-metrique-timesource = { path = "../metrique-timesource", version = "0.1.0", features = ["custom-timesource", "tokio", "test-util"] }
-metrique-writer-core = { path = "../metrique-writer-core", features = ["private-test-util"] }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf", features = [] }
+metrique-timesource = { path = "../metrique-timesource", version = "0.1.0", features = [
+    "custom-timesource",
+    "tokio",
+    "test-util",
+] }
+metrique-writer-core = { path = "../metrique-writer-core", features = [
+    "private-test-util",
+] }
+metrique-writer-format-emf = { path = "../metrique-writer-format-emf", features = [
+] }
 tracing = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }
 trybuild = { workspace = true }

--- a/metrique/examples/flex-dynamic-fields.rs
+++ b/metrique/examples/flex-dynamic-fields.rs
@@ -1,0 +1,319 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This example demonstrates the use of `Flex` for dynamic metric field names.
+//!
+//! `Flex` is useful when you need to create metric fields with names that are only
+//! known at runtime, such as user-provided tags, dynamic dimensions, or computed
+//! field names based on configuration.
+
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use metrique::{flex::Flex, unit::Count, unit_of_work::metrics};
+use metrique_writer::{
+    AttachGlobalEntrySinkExt, Entry, EntryIoStreamExt, FormatExt, GlobalEntrySink,
+    sink::global_entry_sink,
+};
+use metrique_writer_format_emf::Emf;
+
+global_entry_sink! { ServiceMetrics }
+
+#[metrics(rename_all = "PascalCase")]
+struct DynamicMetrics {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+
+    operation: &'static str,
+
+    // Static field for comparison
+    #[metrics(unit = Count)]
+    static_counter: usize,
+
+    // Dynamic field - the key name is determined at runtime
+    #[metrics(flatten)]
+    dynamic_field: Flex<usize>,
+
+    // Multiple dynamic fields can be used
+    #[metrics(flatten)]
+    user_tag: Flex<String>,
+
+    #[metrics(flatten)]
+    computed_metric: Flex<f64>,
+}
+
+impl DynamicMetrics {
+    fn init(operation: &'static str) -> DynamicMetricsGuard {
+        Self {
+            timestamp: SystemTime::now(),
+            operation,
+            static_counter: 0,
+            // Create Flex fields with just keys - values will be set later based on runtime conditions
+            dynamic_field: Flex::new("records_processed"),
+            user_tag: Flex::new("environment"),
+            computed_metric: Flex::new(format!("{}Duration", operation.to_lowercase())),
+        }
+        .append_on_drop(ServiceMetrics::sink())
+    }
+}
+
+#[derive(Entry)]
+#[entry(rename_all = "PascalCase")]
+struct Globals {
+    service: String,
+    region: String,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let globals = Globals {
+        service: "DynamicService".into(),
+        region: "us-west-2".into(),
+    };
+
+    let _handle = ServiceMetrics::attach_to_stream(
+        Emf::all_validations("DynamicMetrics".to_string(), vec![vec![]])
+            .output_to_makewriter(std::io::stdout)
+            .merge_globals(globals),
+    );
+
+    // Example 1: Basic dynamic field usage
+    basic_dynamic_example().await;
+
+    // Example 2: Configuration-driven dynamic fields
+    config_driven_example().await;
+
+    // Example 3: User-provided tags
+    user_tags_example().await;
+
+    // Example 4: A/B test metrics
+    ab_test_example().await;
+
+    // Example 5: Builder API
+    builder_api_example().await;
+
+    // Example 6: Optional fields
+    optional_fields_example().await;
+
+    // Example 7: Helper function usage
+    let _error_metric = create_error_metric("timeout", 3);
+
+    // Example 8: Create with unset values, then set later
+    unset_then_set_example().await;
+}
+
+async fn basic_dynamic_example() {
+    println!("=== Basic Dynamic Field Example ===");
+
+    let mut metrics = DynamicMetrics::init("ProcessData");
+
+    // Simulate processing some records and setting values based on results
+    let records_processed = 42;
+    let environment = "production";
+    let processing_duration = 123.45;
+
+    // Set values based on runtime conditions
+    metrics.dynamic_field.set_value(records_processed);
+    metrics.user_tag.set_value(environment.to_string());
+    metrics.computed_metric.set_value(processing_duration);
+    metrics.static_counter = 1;
+
+    // The output will include:
+    // - StaticCounter: 1
+    // - records_processed: 42 (set at runtime)
+    // - environment: "production" (set at runtime)
+    // - processdataDuration: 123.45 (set at runtime)
+}
+
+async fn config_driven_example() {
+    println!("=== Configuration-Driven Example ===");
+
+    // Simulate configuration that determines metric field names
+    let config = HashMap::from([
+        ("metric_prefix".to_string(), "api_".to_string()),
+        ("counter_suffix".to_string(), "_total".to_string()),
+    ]);
+
+    let field_name = format!(
+        "{}requests{}",
+        config.get("metric_prefix").unwrap(),
+        config.get("counter_suffix").unwrap()
+    );
+
+    let mut metrics = DynamicMetrics::init("HandleRequest");
+
+    // Update the dynamic field name based on configuration
+    metrics.dynamic_field = Flex::new(field_name).with_value(156); // "api_requests_total"
+    metrics.user_tag.set_value("v1.2.3".to_string());
+    metrics.computed_metric.set_value(89.2);
+    metrics.static_counter = 2;
+}
+
+async fn user_tags_example() {
+    println!("=== User-Provided Tags Example ===");
+
+    // Simulate user-provided tags that become metric fields
+    let user_tags = vec![
+        ("customer_tier", "premium"),
+        ("feature_flag", "new_ui_enabled"),
+    ];
+
+    for (tag_key, tag_value) in user_tags {
+        let mut metrics = DynamicMetrics::init("UserAction");
+
+        // Set the user-provided tag as a dynamic field
+        metrics.user_tag = Flex::new(tag_key).with_value(tag_value.to_string());
+        metrics.dynamic_field.set_value(1); // action_count
+        metrics.computed_metric.set_value(45.6);
+        metrics.static_counter = 3;
+    }
+}
+
+async fn ab_test_example() {
+    println!("=== A/B Test Metrics Example ===");
+
+    // Different variants of an A/B test create different metric fields
+    let variants = vec![
+        ("variant_a_conversions", 45),
+        ("variant_b_conversions", 52),
+        ("control_conversions", 38),
+    ];
+
+    for (variant_field, conversion_count) in variants {
+        let mut metrics = DynamicMetrics::init("ABTest");
+
+        // Set the variant-specific field name and value
+        metrics.dynamic_field = Flex::new(variant_field).with_value(conversion_count);
+        metrics.user_tag.set_value("checkout_flow_v2".to_string());
+        metrics.computed_metric.set_value(234.1);
+        metrics.static_counter = 4;
+    }
+}
+
+// Example of a helper function for creating commonly used dynamic metrics
+fn create_error_metric(error_type: &str, error_count: usize) -> DynamicMetricsGuard {
+    let mut metrics = DynamicMetrics::init("ErrorTracking");
+
+    // Set error-specific field name and values
+    let error_field = format!("{}_errors", error_type.to_lowercase());
+    metrics.dynamic_field = Flex::new(error_field).with_value(error_count);
+    metrics.user_tag.set_value("high".to_string()); // error_severity
+    metrics.computed_metric.set_value(123.45);
+
+    metrics
+}
+
+// Example showing how to use Flex builder API
+async fn builder_api_example() {
+    println!("=== Builder API Example ===");
+
+    let mut metrics = DynamicMetrics::init("ConvenienceTest");
+
+    // Using builder API for flexible construction - set values after creation
+    metrics.dynamic_field = Flex::new("api_requests").with_value(150usize);
+    metrics.user_tag = Flex::new("deployment").with_value("v2.1.0".to_string());
+    metrics.computed_metric = Flex::new("response_time_ms").with_value(45.2f64);
+    metrics.static_counter = 5;
+}
+
+// Example showing optional fields that may or may not be present
+async fn optional_fields_example() {
+    println!("=== Optional Fields Example ===");
+
+    // Simulate a scenario where some fields might not be available
+    let user_id: Option<String> = Some("user456".to_string());
+    let session_id: Option<String> = None; // Not available
+
+    let mut metrics = DynamicMetrics::init("OptionalFields");
+
+    // Set values based on what's available
+    metrics.dynamic_field.set_value(1usize); // page_views
+    metrics.user_tag = Flex::new("user_id").with_optional_value(user_id);
+    metrics.computed_metric =
+        Flex::new("session_id").with_optional_value(session_id.map(|s| s.len() as f64));
+    metrics.static_counter = 6;
+
+    // Only user_id will appear in the output, session_id will be omitted
+}
+
+// Example showing the key benefit: create metrics with unset Flex fields, then set values later
+async fn unset_then_set_example() {
+    println!("=== Unset Then Set Example ===");
+
+    // Create metrics struct with unset Flex fields - this is the key use case!
+    let mut metrics = DynamicMetrics {
+        timestamp: SystemTime::now(),
+        operation: "ProcessRequest",
+        static_counter: 0,
+        dynamic_field: Flex::new("items_processed"), // No value initially
+        user_tag: Flex::new("request_source"),       // No value initially
+        computed_metric: Flex::new("processing_time"), // No value initially
+    }
+    .append_on_drop(ServiceMetrics::sink());
+
+    // Simulate business logic that determines values at runtime
+    let items_to_process = vec!["item1", "item2", "item3"];
+    let request_came_from_api = true;
+
+    // Process items and set count
+    let processed_count = items_to_process.len();
+    metrics.dynamic_field.set_value(processed_count);
+
+    // Set source based on runtime condition
+    if request_came_from_api {
+        metrics.user_tag.set_value("api".to_string());
+    } else {
+        metrics.user_tag.set_value("batch".to_string());
+    }
+
+    // Simulate some processing time measurement
+    let start_time = std::time::Instant::now();
+    // ... do some work ...
+    let processing_duration = start_time.elapsed();
+    metrics
+        .computed_metric
+        .set_value(processing_duration.as_millis() as f64);
+
+    metrics.static_counter = 7;
+
+    // When metrics drops, all the dynamically set fields will be included
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrique_writer::test_util;
+
+    #[test]
+    fn test_flex_dynamic_fields() {
+        let test_util::TestEntrySink { inspector, sink } = test_util::test_entry_sink();
+
+        let metrics = DynamicMetrics {
+            timestamp: SystemTime::now(),
+            operation: "TestOp",
+            static_counter: 100,
+            dynamic_field: Flex::new("custom_metric").with_value(42usize),
+            user_tag: Flex::new("user_id").with_value("user123".to_string()),
+            computed_metric: Flex::new("computed_value").with_value(3.14),
+        }
+        .append_on_drop(sink);
+
+        drop(metrics);
+
+        let entries = inspector.entries();
+        assert_eq!(entries.len(), 1);
+
+        let entry = &entries[0];
+
+        // Check static fields
+        assert_eq!(entry.values["Operation"], "TestOp");
+        assert_eq!(entry.metrics["StaticCounter"].as_u64(), 100);
+
+        // Check dynamic fields
+        assert_eq!(entry.metrics["custom_metric"].as_u64(), 42);
+        assert_eq!(entry.values["user_id"], "user123");
+        assert_eq!(entry.metrics["computed_value"].as_f64(), 3.14);
+    }
+}

--- a/metrique/src/flex.rs
+++ b/metrique/src/flex.rs
@@ -1,0 +1,165 @@
+//! Utilities for dynamic metric fields
+//!
+//! This module contains `Flex`, a struct that allows dynamically controlling the key field for a given metric.
+//!
+//! `Flex` is useful when you need to create metric fields with names that are only known at runtime,
+//! such as:
+//! - User-provided tags or labels
+//! - Configuration-driven field names
+//! - Computed field names based on business logic
+//! - Dynamic dimensions from external systems
+//! - Runtime-determined metric names based on request context
+//!
+//! # Example
+//!
+//! ```rust
+//! use metrique::{flex::Flex, unit_of_work::metrics};
+//! use std::time::SystemTime;
+//!
+//! #[metrics]
+//! struct DynamicMetrics {
+//!     #[metrics(timestamp)]
+//!     timestamp: SystemTime,
+//!     operation: &'static str,
+//!     
+//!     // Dynamic field - key name determined at runtime
+//!     #[metrics(flatten)]
+//!     dynamic_count: Flex<usize>,
+//! }
+//!
+//! // Usage - flexible builder API
+//! let field_name = format!("{}_requests", "api"); // "api_requests"
+//! let metrics = DynamicMetrics {
+//!     timestamp: SystemTime::now(),
+//!     operation: "ProcessRequest",
+//!     dynamic_count: Flex::new(field_name).with_value(42),
+//! };
+//! ```
+use std::borrow::Cow;
+
+use metrique_core::{CloseValue, InflectableEntry, NameStyle};
+use metrique_writer::{Entry, EntryWriter, Value};
+use metrique_writer_core::entry::SampleGroupElement;
+
+/// A struct that allows dynamic specification of keys
+pub struct Flex<T> {
+    key: Cow<'static, str>,
+    value: Option<T>,
+}
+
+impl<T> Flex<T> {
+    /// Create a new `Flex` with the given key and no value initially.
+    /// Use `with_value()` to set the value.
+    ///
+    /// # Example
+    /// ```rust
+    /// use metrique::flex::Flex;
+    ///
+    /// let metric = Flex::<usize>::new("dynamic_field").with_value(42);
+    /// ```
+    pub fn new(key: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            key: key.into(),
+            value: None,
+        }
+    }
+
+    /// Set the value for this `Flex` field.
+    /// This is useful for builder-style construction.
+    ///
+    /// # Example
+    /// ```rust
+    /// use metrique::flex::Flex;
+    ///
+    /// let metric = Flex::new("field_name").with_value(42usize);
+    /// ```
+    pub fn with_value(mut self, value: T) -> Self {
+        self.value = Some(value);
+        self
+    }
+
+    /// Set an optional value for this `Flex` field.
+    ///
+    /// If the value is `None`, the field will not be included in the output.
+    ///
+    /// # Example
+    /// ```rust
+    /// use metrique::flex::Flex;
+    ///
+    /// let metric = Flex::new("field_name").with_optional_value(Some(42usize));
+    /// let empty_metric = Flex::new("missing_field").with_optional_value(None::<usize>);
+    /// ```
+    pub fn with_optional_value(mut self, value: Option<T>) -> Self {
+        self.value = value;
+        self
+    }
+
+    /// Get a reference to the key name.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    /// Get a reference to the value, if present.
+    pub fn value(&self) -> Option<&T> {
+        self.value.as_ref()
+    }
+
+    /// Update the value.
+    pub fn set_value(&mut self, value: T) {
+        self.value = Some(value);
+    }
+
+    /// Clear the value (set to `None`).
+    pub fn clear_value(&mut self) {
+        self.value = None;
+    }
+}
+
+impl<T: Default> Flex<T> {
+    /// Create a new `Flex` with the given key and a default value.
+    ///
+    /// # Example
+    /// ```rust
+    /// use metrique::flex::Flex;
+    ///
+    /// let metric = Flex::<usize>::new("count").with_default_value();
+    /// // Equivalent to: Flex::new("count").with_value(0usize) for usize
+    /// ```
+    pub fn with_default_value(mut self) -> Self {
+        self.value = Some(T::default());
+        self
+    }
+}
+
+/// The Entry type for [`Flex`]
+pub struct FlexEntry<T> {
+    key: Cow<'static, str>,
+    value: Option<T>,
+}
+
+impl<T: Value> Entry for FlexEntry<T> {
+    fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+        writer.value(Cow::Borrowed(self.key.as_ref()), &self.value);
+    }
+}
+
+impl<T: Value, NS: NameStyle> InflectableEntry<NS> for FlexEntry<T> {
+    fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+        writer.value(Cow::Borrowed(self.key.as_ref()), &self.value);
+    }
+
+    fn sample_group(&self) -> impl Iterator<Item = SampleGroupElement> {
+        vec![].into_iter()
+    }
+}
+
+impl<T: CloseValue> CloseValue for Flex<T> {
+    type Closed = FlexEntry<T::Closed>;
+
+    fn close(self) -> Self::Closed {
+        FlexEntry {
+            key: self.key,
+            value: self.value.close(),
+        }
+    }
+}

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -5,6 +5,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod emf;
+pub mod flex;
 pub mod instrument;
 mod keep_alive;
 
@@ -46,6 +47,8 @@ use metrique_writer_core::Entry;
 use metrique_writer_core::EntryWriter;
 use metrique_writer_core::entry::SampleGroupElement;
 pub use slot::{FlushGuard, ForceFlushGuard, LazySlot, OnParentDrop, Slot, SlotGuard};
+
+pub use flex::Flex;
 
 use core::ops::Deref;
 use core::ops::DerefMut;

--- a/metrique/tests/flex.rs
+++ b/metrique/tests/flex.rs
@@ -1,0 +1,139 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the Flex type
+
+use metrique::{Flex, unit_of_work::metrics};
+use metrique_writer::test_util;
+use std::time::SystemTime;
+
+#[metrics]
+struct TestMetrics {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+
+    #[metrics(flatten)]
+    dynamic_field: Flex<usize>,
+}
+
+#[metrics]
+struct MultiFieldMetrics {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+
+    #[metrics(flatten)]
+    set_field: Flex<usize>,
+
+    #[metrics(flatten)]
+    unset_field: Flex<String>,
+}
+
+#[test]
+fn test_flex_dynamic_field_name() {
+    let test_util::TestEntrySink { inspector, sink } = test_util::test_entry_sink();
+
+    let metrics = TestMetrics {
+        timestamp: SystemTime::now(),
+        dynamic_field: Flex::new("runtime_field_name").with_value(42),
+    }
+    .append_on_drop(sink);
+
+    drop(metrics);
+
+    let entries = inspector.entries();
+    let entry = &entries[0];
+
+    // Field appears with the runtime-determined name
+    assert_eq!(entry.metrics["runtime_field_name"].as_u64(), 42);
+}
+
+#[test]
+fn test_flex_set_value_after_creation() {
+    let test_util::TestEntrySink { inspector, sink } = test_util::test_entry_sink();
+
+    let mut metrics = TestMetrics {
+        timestamp: SystemTime::now(),
+        dynamic_field: Flex::new("my_field"), // No value initially
+    }
+    .append_on_drop(sink);
+
+    // Set value later
+    metrics.dynamic_field.set_value(100);
+
+    drop(metrics);
+
+    let entries = inspector.entries();
+    let entry = &entries[0];
+
+    assert_eq!(entry.metrics["my_field"].as_u64(), 100);
+}
+
+#[test]
+fn test_flex_unset_field_omitted() {
+    let test_util::TestEntrySink { inspector, sink } = test_util::test_entry_sink();
+
+    let metrics = MultiFieldMetrics {
+        timestamp: SystemTime::now(),
+        set_field: Flex::new("present_field").with_value(42),
+        unset_field: Flex::new("missing_field"), // No value set
+    }
+    .append_on_drop(sink);
+
+    drop(metrics);
+
+    let entries = inspector.entries();
+    let entry = &entries[0];
+
+    // Set field should appear
+    assert_eq!(entry.metrics["present_field"].as_u64(), 42);
+
+    // Unset field should not appear in output
+    assert!(!entry.metrics.contains_key("missing_field"));
+    assert!(!entry.values.contains_key("missing_field"));
+}
+#[metrics]
+struct TimestampMetrics {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+
+    #[metrics(flatten)]
+    close_time: Flex<metrique::timers::TimestampOnClose>,
+}
+
+#[test]
+fn test_flex_close_value_called() {
+    use metrique::timers::TimestampOnClose;
+    use metrique_timesource::{TimeSource, fakes::StaticTimeSource, set_time_source};
+    use std::time::{Duration, UNIX_EPOCH};
+
+    let test_util::TestEntrySink { inspector, sink } = test_util::test_entry_sink();
+
+    // Set up a mock time source at a specific time
+    let mock_time = UNIX_EPOCH + Duration::from_secs(1234567890);
+    let time_source = TimeSource::custom(StaticTimeSource::at_time(mock_time));
+    let _guard = set_time_source(time_source);
+
+    let mut metrics = TimestampMetrics {
+        timestamp: SystemTime::now(),
+        close_time: Flex::new("close_timestamp"), // No value initially
+    }
+    .append_on_drop(sink);
+
+    // Set a TimestampOnClose value - this should record the time when close() is called, not now
+    metrics.close_time.set_value(TimestampOnClose::default());
+
+    // When metrics is dropped, close() should be called on the TimestampOnClose
+    drop(metrics);
+
+    let entries = inspector.entries();
+    let entry = &entries[0];
+
+    // The field should appear with a timestamp value (proving close() was called)
+    assert!(entry.values.contains_key("close_timestamp"));
+    // The value should be the exact timestamp we mocked (in milliseconds since epoch)
+    let timestamp_value = &entry.values["close_timestamp"];
+    let expected_millis = mock_time.duration_since(UNIX_EPOCH).unwrap().as_millis();
+    // TimestampValue formats as a float, so we expect ".0" at the end
+    let expected_str = format!("{}.0", expected_millis);
+    assert_eq!(timestamp_value, &expected_str);
+}


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:* This adds `Flex` which allows producing custom keys from metric values more easily

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
