### PR TITLE
feat: allow #[metrics(value)]

### DIFF
--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -55,7 +55,7 @@ fn generate_write_statements(fields: &[MetricsField], root_attrs: &RootAttribute
 
     for field in fields {
         let field_ident = &field.ident;
-        let field_span = field_ident.span();
+        let field_span = field.span;
         let ns = make_ns(root_attrs.rename_all, field_span);
 
         match &field.attrs.kind {
@@ -117,7 +117,7 @@ fn generate_sample_group_statements(fields: &[MetricsField], root_attrs: &RootAt
 
         match &field.attrs.kind {
             MetricsFieldKind::Flatten(span) => {
-                let ns = make_ns(root_attrs.rename_all, field.ident.span());
+                let ns = make_ns(root_attrs.rename_all, field.span);
                 sample_group_fields.push(quote_spanned! {*span=>
                     ::metrique::InflectableEntry::<#ns>::sample_group(&self.#field_ident)
                 });

--- a/metrique-macro/src/inflect.rs
+++ b/metrique-macro/src/inflect.rs
@@ -37,7 +37,7 @@ pub fn metric_name(
     if let Some(name_override) = field.name_override() {
         return name_override.to_owned();
     };
-    let base = &field.ident().to_string();
+    let base = field.name();
     let prefixed_base = format!("{prefix}{base}");
 
     name_style.apply(&prefixed_base)
@@ -45,7 +45,7 @@ pub fn metric_name(
 
 pub trait HasInflectableName {
     fn name_override(&self) -> Option<&str>;
-    fn ident(&self) -> &syn::Ident;
+    fn name(&self) -> String;
 }
 
 impl HasInflectableName for MetricsField {
@@ -60,8 +60,8 @@ impl HasInflectableName for MetricsField {
         }
     }
 
-    fn ident(&self) -> &syn::Ident {
-        &self.ident
+    fn name(&self) -> String {
+        self.name.clone().expect("name must be set here")
     }
 }
 
@@ -70,7 +70,7 @@ impl HasInflectableName for MetricsVariant {
         self.attrs.name.as_deref()
     }
 
-    fn ident(&self) -> &syn::Ident {
-        &self.ident
+    fn name(&self) -> String {
+        self.ident.to_string()
     }
 }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_struct.snap
@@ -1,0 +1,36 @@
+---
+source: metrique-macro/src/lib.rs
+expression: parsed_file
+---
+struct RequestValue {
+    ignore: u32,
+    value: u32,
+}
+#[doc(hidden)]
+pub struct RequestValueValue {
+    #[deprecated(
+        note = "these fields will become private in a future release. To introspect an entry, use `metrique_writer::test_util::test_entry`"
+    )]
+    #[doc(hidden)]
+    value: <u32 as metrique::CloseValue>::Closed,
+}
+impl ::metrique::__writer::Value for RequestValueValue {
+    fn write(&self, writer: impl ::metrique::__writer::ValueWriter) {
+        #[allow(deprecated)] { ::metrique::__writer::Value::write(&self.value, writer) }
+    }
+}
+impl metrique::CloseValue for &'_ RequestValue {
+    type Closed = RequestValueValue;
+    fn close(self) -> Self::Closed {
+        #[allow(deprecated)]
+        RequestValueValue {
+            value: metrique::CloseValue::close(&self.value),
+        }
+    }
+}
+impl metrique::CloseValue for RequestValue {
+    type Closed = RequestValueValue;
+    fn close(self) -> Self::Closed {
+        <&Self>::close(&self)
+    }
+}

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_unnamed_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_unnamed_struct.snap
@@ -2,39 +2,31 @@
 source: metrique-macro/src/lib.rs
 expression: parsed_file
 ---
-enum Foo {
-    Bar,
-}
+struct RequestValue(u32, u32);
 #[doc(hidden)]
-pub enum FooValue {
+pub struct RequestValueValue(
     #[deprecated(
         note = "these fields will become private in a future release. To introspect an entry, use `metrique_writer::test_util::test_entry`"
     )]
     #[doc(hidden)]
-    Bar,
-}
-impl ::metrique::__writer::Value for FooValue {
+    <u32 as metrique::CloseValue>::Closed,
+);
+impl ::metrique::__writer::Value for RequestValueValue {
     fn write(&self, writer: impl ::metrique::__writer::ValueWriter) {
-        writer
-            .string(
-                #[allow(deprecated)]
-                match self {
-                    FooValue::Bar => "Bar",
-                },
-            );
+        #[allow(deprecated)] { ::metrique::__writer::Value::write(&self.1, writer) }
     }
 }
-impl metrique::CloseValue for &'_ Foo {
-    type Closed = FooValue;
+impl metrique::CloseValue for &'_ RequestValue {
+    type Closed = RequestValueValue;
     fn close(self) -> Self::Closed {
         #[allow(deprecated)]
-        match self {
-            Foo::Bar => FooValue::Bar,
+        RequestValueValue {
+            1: metrique::CloseValue::close(&self.1),
         }
     }
 }
-impl metrique::CloseValue for Foo {
-    type Closed = FooValue;
+impl metrique::CloseValue for RequestValue {
+    type Closed = RequestValueValue;
     fn close(self) -> Self::Closed {
         <&Self>::close(&self)
     }

--- a/metrique-macro/src/value_impl.rs
+++ b/metrique-macro/src/value_impl.rs
@@ -1,0 +1,97 @@
+use crate::{
+    MetricsField, MetricsFieldKind, MetricsVariant, NameStyle, RootAttributes, metric_name,
+};
+
+use proc_macro2::TokenStream as Ts2;
+use quote::{quote, quote_spanned};
+use syn::Ident;
+
+pub(crate) fn generate_value_impl_for_enum(
+    root_attrs: &RootAttributes,
+    value_name: &Ident,
+    parsed_variants: &[MetricsVariant],
+) -> Ts2 {
+    let variants_and_strings = parsed_variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        let metric_name = metric_name(root_attrs, root_attrs.rename_all, variant);
+        quote_spanned!(variant.ident.span()=> #value_name::#variant_ident => #metric_name)
+    });
+    quote!(
+        impl ::metrique::__writer::Value for #value_name {
+            fn write(&self, writer: impl ::metrique::__writer::ValueWriter) {
+                writer.string(#[allow(deprecated)] match self {
+                    #(#variants_and_strings),*
+                });
+            }
+        }
+    )
+}
+
+pub fn validate_value_impl_for_struct(
+    root_attrs: &RootAttributes,
+    value_name: &Ident,
+    parsed_fields: &[MetricsField],
+) -> Result<(), syn::Error> {
+    let non_ignore_fields: Vec<&MetricsField> = parsed_fields
+        .iter()
+        .filter(|f| !matches!(f.attrs.kind, MetricsFieldKind::Ignore(_)))
+        .collect::<Vec<_>>();
+    if non_ignore_fields.len() > 1 {
+        return Err(syn::Error::new(
+            non_ignore_fields[1].span,
+            "multiple non-ignored fields for #[metrics(value)]",
+        ));
+    }
+    if root_attrs.emf_dimensions.is_some() {
+        return Err(syn::Error::new(
+            value_name.span(),
+            "emf_dimensions is not supported for #[metrics(value)]",
+        ));
+    }
+    if root_attrs.prefix.is_some() {
+        return Err(syn::Error::new(
+            value_name.span(),
+            "prefix is not supported for #[metrics(value)]",
+        ));
+    }
+    if !matches!(root_attrs.rename_all, NameStyle::Preserve) {
+        return Err(syn::Error::new(
+            value_name.span(),
+            "NameStyle is not supported for #[metrics(value)]",
+        ));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn generate_value_impl_for_struct(
+    _root_attrs: &RootAttributes,
+    value_name: &Ident,
+    parsed_fields: &[MetricsField],
+) -> Result<Ts2, syn::Error> {
+    // support struct with only ignored fields as no value for orthogonality
+    let non_ignore_fields = parsed_fields
+        .iter()
+        .filter(|f| !matches!(f.attrs.kind, MetricsFieldKind::Ignore(_)));
+    let body: Vec<Ts2> = non_ignore_fields.map(|field| {
+        match field.attrs.kind {
+            MetricsFieldKind::Field { unit: None, name: None, format: None } => {
+                let ident = &field.ident;
+                Ok(quote_spanned!{field.span=> ::metrique::__writer::Value::write(&self.#ident, writer) })
+            }
+            _ => {
+                Err(syn::Error::new(field.span, "only plain fields are supported in #[metrics(value)]"))
+            }
+        }
+    }).collect::<Result<Vec<_>, _>>()?;
+
+    Ok(quote! {
+        impl ::metrique::__writer::Value for #value_name {
+            fn write(&self, writer: impl ::metrique::__writer::ValueWriter) {
+                #[allow(deprecated)] {
+                    #(#body);*
+                }
+            }
+        }
+    })
+}

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -59,7 +59,6 @@ use metrique_writer_core::EntrySink;
 use std::sync::Arc;
 
 pub use metrique_core::{CloseValue, CloseValueRef, Counter, InflectableEntry, NameStyle};
-pub use metrique_writer::{Value, ValueWriter};
 
 /// Unit types and utilities for metrics.
 ///
@@ -364,7 +363,7 @@ impl<T: CloseValue> CloseValue for SharedChild<T> {
 
 #[doc(hidden)]
 pub mod __writer {
-    pub use metrique_writer_core::{Entry, EntrySink, EntryWriter};
+    pub use metrique_writer_core::{Entry, EntrySink, EntryWriter, Value, ValueWriter};
 }
 
 /// "Roots" an [`InflectableEntry`] to turn it into an [`Entry`] that can be passed

--- a/metrique/tests/kitchen-sink.rs
+++ b/metrique/tests/kitchen-sink.rs
@@ -58,8 +58,8 @@ struct Nested {
 
 #[derive(Clone, Default)]
 struct ValueWithNoClose;
-impl metrique::Value for ValueWithNoClose {
-    fn write(&self, writer: impl metrique::ValueWriter) {
+impl metrique::__writer::Value for ValueWithNoClose {
+    fn write(&self, writer: impl metrique::__writer::ValueWriter) {
         writer.string("no_close");
     }
 }

--- a/metrique/tests/string-value.rs
+++ b/metrique/tests/string-value.rs
@@ -11,12 +11,20 @@ enum Foo {
     BarBaz,
 }
 
+#[metrics(value)]
+struct NestedValue(u32);
+
+#[metrics(value)]
+struct Empty {}
+
 #[metrics]
 struct Metrics {
     f1: Foo,
     f2: Foo,
     f3: Foo,
     f4: Foo,
+    nested: NestedValue,
+    empty: Empty,
 }
 
 #[test]
@@ -26,10 +34,13 @@ fn string_value() {
         f2: Foo::Bar,
         f3: Foo::Baz,
         f4: Foo::BarBaz,
+        nested: NestedValue(4),
+        empty: Empty {},
     };
     let entry = test_util::to_test_entry(RootEntry::new(metrics.close()));
     assert_eq!(entry.values["f1"], "foo");
     assert_eq!(entry.values["f2"], "bar");
     assert_eq!(entry.values["f3"], "ZAB");
     assert_eq!(entry.values["f4"], "bar_baz");
+    assert_eq!(entry.metrics["nested"].as_u64(), 4);
 }

--- a/metrique/tests/ui/fail/bad_metrics_value.rs
+++ b/metrique/tests/ui/fail/bad_metrics_value.rs
@@ -10,7 +10,37 @@ struct Bar {
 
 #[metrics(value)]
 struct Baz {
+    x: u32,
+    y: u32,
 }
+
+#[metrics(value)]
+struct Baz2 {
+    #[metrics(unit = Second)]
+    x: u32,
+}
+
+#[metrics(value)]
+struct Baz3 {
+    #[metrics(format = Foo)]
+    x: u32,
+}
+
+
+#[metrics(value)]
+struct Baz4 (
+    #[metrics(name = "Bar")]
+    u32,
+);
+
+#[metrics(value)]
+struct Baz5 {
+    #[metrics(p = q)]
+    x: u32,
+}
+
+#[metrics(value)]
+struct Unit; /* not supported right now */
 
 #[metrics(value(string))]
 enum Bad {

--- a/metrique/tests/ui/fail/bad_metrics_value.stderr
+++ b/metrique/tests/ui/fail/bad_metrics_value.stderr
@@ -1,11 +1,3 @@
-error: the only supported value option is value(string)
- --> tests/ui/fail/bad_metrics_value.rs:3:1
-  |
-3 | #[metrics(value)]
-  | ^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: Only structs are supported for entries
  --> tests/ui/fail/bad_metrics_value.rs:4:1
   |
@@ -20,46 +12,74 @@ error: Only enums are supported for values
 9 | | }
   | |_^
 
-error: the only supported value option is value(string)
-  --> tests/ui/fail/bad_metrics_value.rs:11:1
+error: multiple non-ignored fields for #[metrics(value)]
+  --> tests/ui/fail/bad_metrics_value.rs:14:5
    |
-11 | #[metrics(value)]
-   | ^^^^^^^^^^^^^^^^^
+14 |     y: u32,
+   |     ^
+
+error: only plain fields are supported in #[metrics(value)]
+  --> tests/ui/fail/bad_metrics_value.rs:20:5
    |
-   = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
+20 |     x: u32,
+   |     ^
+
+error: only plain fields are supported in #[metrics(value)]
+  --> tests/ui/fail/bad_metrics_value.rs:26:5
+   |
+26 |     x: u32,
+   |     ^
+
+error: only plain fields are supported in #[metrics(value)]
+  --> tests/ui/fail/bad_metrics_value.rs:33:5
+   |
+33 |     u32,
+   |     ^^^
 
 error: Unknown field: `p`
-  --> tests/ui/fail/bad_metrics_value.rs:17:15
+  --> tests/ui/fail/bad_metrics_value.rs:38:15
    |
-17 |     #[metrics(p="q")]
+38 |     #[metrics(p = q)]
    |               ^
 
-error: Cannot combine subfield with value
-  --> tests/ui/fail/bad_metrics_value.rs:21:17
+error: Only named fields are supported
+  --> tests/ui/fail/bad_metrics_value.rs:43:1
    |
-21 | #[metrics(value(string), subfield)]
-   |                 ^^^^^^
+43 | struct Unit; /* not supported right now */
+   | ^^^^^^^^^^^^
+
+error: Unknown field: `p`
+  --> tests/ui/fail/bad_metrics_value.rs:47:15
+   |
+47 |     #[metrics(p="q")]
+   |               ^
+
+error: Cannot combine value with subfield
+  --> tests/ui/fail/bad_metrics_value.rs:51:26
+   |
+51 | #[metrics(value(string), subfield)]
+   |                          ^^^^^^^^
 
 error: Only structs are supported for entries
-  --> tests/ui/fail/bad_metrics_value.rs:22:1
+  --> tests/ui/fail/bad_metrics_value.rs:52:1
    |
-22 | / enum Multi {
-23 | |     X
-24 | | }
+52 | / enum Multi {
+53 | |     X
+54 | | }
    | |_^
 
 error: value does not make sense with dimension-sets
-  --> tests/ui/fail/bad_metrics_value.rs:26:1
+  --> tests/ui/fail/bad_metrics_value.rs:56:1
    |
-26 | #[metrics(value(string), emf::dimension_sets = [["X"]])]
+56 | #[metrics(value(string), emf::dimension_sets = [["X"]])]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Only structs are supported for entries
-  --> tests/ui/fail/bad_metrics_value.rs:27:1
+  --> tests/ui/fail/bad_metrics_value.rs:57:1
    |
-27 | / enum Multi2 {
-28 | |     X
-29 | | }
+57 | / enum Multi2 {
+58 | |     X
+59 | | }
    | |_^


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

allows `#[metric(value)]` on structs, which makes them metric newtypes.

Unfortunately this does not support units well right now (though it could in the future), this is currently mostly intended for properties anyway.

For example

```rust
#[metrics(value)]
struct Foo {
    field: &'static str,
}
```

Tho maybe this is important enough to make work (could be easily made to work, doesn't work ATM)

```rust
#[metrics(value)]
struct FooCount ( #[metrics(unit = Count) u32 );
```


🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
