### PR TITLE
Update the reporters for metrics.rs to accept AnyEntrySink

### DIFF
--- a/metrique-writer-core/src/sink.rs
+++ b/metrique-writer-core/src/sink.rs
@@ -7,6 +7,7 @@
 //! [`EntryIoStream`]: crate::stream::EntryIoStream
 
 use std::{
+    fmt::Debug,
     ops::{Deref, DerefMut},
     pin::Pin,
     sync::Arc,
@@ -110,6 +111,12 @@ impl<T: AnyEntrySink, E: Entry + Send + 'static> EntrySink<E> for T {
 /// an arbitrary [`Entry`]).
 #[derive(Clone)]
 pub struct BoxEntrySink(Arc<Box<dyn EntrySink<BoxEntry> + Send + Sync + 'static>>);
+
+impl Debug for BoxEntrySink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("BoxEntrySink").finish()
+    }
+}
 
 impl AnyEntrySink for BoxEntrySink {
     fn append_any(&self, entry: impl Entry + Send + 'static) {

--- a/metrique-writer/Cargo.toml
+++ b/metrique-writer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "metrique-writer"
 version = "0.1.1"
 edition = "2024"
-rust-version = "1.87"  # MSRV is 1.87 due to `extend_from_within` [and 1.86 due to trait upcasts]
+rust-version = "1.87"                                                                 # MSRV is 1.87 due to `extend_from_within` [and 1.86 due to trait upcasts]
 license = "Apache-2.0"
 description = "Library for working with unit of work metrics - writer-side interface"
 repository = "https://github.com/awslabs/metrique"
@@ -10,12 +10,18 @@ readme = "README.md"
 
 [dependencies]
 ahash = { workspace = true }
-smallvec = { workspace = true, features = ["union", "const_generics", "const_new"] }
+smallvec = { workspace = true, features = [
+    "union",
+    "const_generics",
+    "const_new",
+] }
 tracing-subscriber = { workspace = true, optional = true }
 rand = { workspace = true }
 crossbeam-queue = { workspace = true, optional = true }
 crossbeam-utils = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, default-features = false, features = ["sync"] }
+tokio = { workspace = true, optional = true, default-features = false, features = [
+    "sync",
+] }
 tokio-util = { workspace = true, optional = true, features = ["rt"] }
 tracing = { workspace = true, optional = true }
 metrics = { workspace = true, optional = true }
@@ -29,9 +35,12 @@ metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.0" }
 [dev-dependencies]
 enum-map = { workspace = true }
 strum_macros = { workspace = true }
-metrique-writer-core = { path = "../metrique-writer-core", features = ["private-test-util", "test-util"] }
+metrique-writer-core = { path = "../metrique-writer-core", features = [
+    "private-test-util",
+    "test-util",
+] }
+metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
 metrique-writer-format-emf = { path = "../metrique-writer-format-emf" }
-metrique-writer = { path = ".", features = ["test-util"] }
 metrics-util = { workspace = true, features = ["debugging"] }
 futures = { workspace = true, features = ["executor"] }
 tokio = { workspace = true, features = ["macros", "test-util"] }
@@ -43,9 +52,26 @@ assert-json-diff = { workspace = true }
 serde_json = { workspace = true }
 
 [features]
-default = ["background_queue", "tracing_subscriber_03", "metrics_rs_024", "metrics_rs_bridge"]
+default = [
+    "background_queue",
+    "tracing_subscriber_03",
+    "metrics_rs_024",
+    "metrics_rs_bridge",
+]
 test-util = []
-metrics_rs_bridge = ["dep:pin-project", "dep:futures", "dep:histogram", "dep:tokio-util", "tokio/time", "futures/executor"]
+metrics_rs_bridge = [
+    "dep:pin-project",
+    "dep:futures",
+    "dep:histogram",
+    "dep:tokio-util",
+    "tokio/time",
+    "futures/executor",
+]
 metrics_rs_024 = ["dep:metrics", "dep:metrics-util"]
-background_queue = ["dep:tokio", "dep:crossbeam-queue", "dep:crossbeam-utils", "dep:tracing"]
+background_queue = [
+    "dep:tokio",
+    "dep:crossbeam-queue",
+    "dep:crossbeam-utils",
+    "dep:tracing",
+]
 tracing_subscriber_03 = ["dep:tracing-subscriber"]

--- a/metrique-writer/src/metrics/mod.rs
+++ b/metrique-writer/src/metrics/mod.rs
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! This mode providesa few [`metrics::Recorder`]s that can be used for emitting metrics
+//! This mode provides a few [`metrics::Recorder`]s that can be used for emitting metrics
 //! via metrique-writer. This includes [`MetricsReporter`]  that is designed for use in EC2/Fargate,
 //! [`lambda_reporter`] that is designed for use in Lambda, and [`capture`] that is
 //! designed for use in unit tests.
+//!
+//! This allows capturing metrics emitted via the metrics.rs facade into metrique.
 //!
 //! [`metrics::Recorder`]: metrics::Recorder
 //! [`MetricsReporter`]: crate::metrics::MetricReporter

--- a/metrique-writer/src/metrics/reporter.rs
+++ b/metrique-writer/src/metrics/reporter.rs
@@ -1,21 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::any::Any;
 use std::fmt;
-use std::pin::pin;
+use std::pin::{Pin, pin};
 use std::time::Duration;
 
-use crate::sink::{BackgroundQueue, BackgroundQueueBuilder};
+use crate::sink::BackgroundQueueBuilder;
 use crate::stream::NullEntryIoStream;
 use futures::future::Either;
 use futures::future::select;
-use metrique_writer_core::EntryIoStream;
-use metrique_writer_core::EntrySink;
+use metrique_writer_core::{AnyEntrySink, EntrySink};
+use metrique_writer_core::{BoxEntrySink, EntryIoStream};
 use tokio::task;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
-use crate::metrics::MetricAccumulatorEntry;
 use crate::metrics::MetricRecorder;
 
 /// A handle to a metric reporter. This struct is mainly used to synchronize shutdown of the metric reporter
@@ -33,6 +33,7 @@ use crate::metrics::MetricRecorder;
 pub struct MetricReporter {
     tasks: TaskTracker,
     cancellation_token: CancellationToken,
+    sink: BoxEntrySink,
 }
 
 const DEFAULT_METRICS_PUBLISH_INTERVAL: Duration = Duration::from_secs(60);
@@ -44,16 +45,12 @@ const DEFAULT_METRICS_PUBLISH_INTERVAL: Duration = Duration::from_secs(60);
 /// Each call to `background_queue.append(..)` results in one new record being produced.
 fn spawn_metric_reporter(
     tracker: &TaskTracker,
-    destination: impl EntryIoStream + Send + 'static,
+    destination: BoxEntrySink,
+    shutdown_handle: ShutdownHandle,
     publish_interval: Duration,
     shutdown_signal: CancellationToken,
-    background_queue_builder: Option<BackgroundQueueBuilder>,
     emit_zero_counters: bool,
-) -> (MetricRecorder, BackgroundQueue<MetricAccumulatorEntry>) {
-    let (background_queue, background_queue_shutdown_hook) = background_queue_builder
-        .unwrap_or_default()
-        .build(destination);
-    let background_queue_clone = background_queue.clone();
+) -> MetricRecorder {
     let recorder = MetricRecorder::new_with_emit_zero_counters(emit_zero_counters);
     let recorder_ = recorder.clone();
     tracker.spawn(async move {
@@ -67,22 +64,27 @@ fn spawn_metric_reporter(
             select(pin!(next_metrics_publish()), pin!(shutdown_initiated())).await
         {
             tracing::trace!("publishing metrics to background queue");
-            background_queue.append(recorder_.readout())
+            destination.append(recorder_.readout())
         }
         // Publish one more time to the background queue during the shutdown process.
-        background_queue.append(recorder_.readout());
+        destination.append(recorder_.readout());
         // Shutdown the background publisher for metrics and flush all data to disk.
-        if let Err(e) = task::spawn_blocking(|| background_queue_shutdown_hook.shut_down()).await {
-            // TODO: recovering the panic message here is not trivial.
-            tracing::error!(
-                "A panic occured while shutting down the background queue: {:?}",
-                e
-            );
-        } else {
-            tracing::debug!("Background queue shutdown complete.");
-        }
+        match shutdown_handle {
+            ShutdownHandle::SyncHandle(shutdown) => {
+                if let Err(e) = task::spawn_blocking(|| (shutdown)()).await {
+                    // TODO: recovering the panic message here is not trivial.
+                    tracing::error!(
+                        "A panic occured while shutting down the background queue: {:?}",
+                        e
+                    );
+                } else {
+                    tracing::debug!("Background queue shutdown complete.");
+                }
+            }
+            ShutdownHandle::AsyncHandle(shutdown) => shutdown.await,
+        };
     });
-    (recorder, background_queue_clone)
+    recorder
 }
 
 /// Marker type to ensure that a metrics destination is always set.
@@ -121,7 +123,7 @@ pub struct YouMustConfigureAMetricsDestination;
 ///
 /// # let log_dir = std::path::PathBuf::from("example");
 /// let logger = MetricReporter::builder()
-///     .metrics_sink(Emf::all_validations("MyNS".to_string(),
+///     .metrics_io_stream(Emf::all_validations("MyNS".to_string(),
 ///                   vec![vec![], vec!["service".to_string()]]).output_to_makewriter(
 ///                         RollingFileAppender::new(Rotation::HOURLY, &log_dir, "metric_log.log")
 ///                   )
@@ -143,10 +145,15 @@ pub struct MetricReporterBuilder<S = YouMustConfigureAMetricsDestination> {
     // We need to keep this generic to allow opaque [`Write`] implementations to be stored. It is only possible
     // to invoke build when `W: Write` — the builder starts with `YouMustConfigureAMetricsDestination` (which is _not_ `Write`).
     // This prevents customers from intializing the MetricReporter without metrics destination at compile time.
-    metrics_sink: S,
-    background_queue_builder: Option<BackgroundQueueBuilder>,
+    metrics_stream: S,
+    box_entry_sink: Option<(BoxEntrySink, ShutdownHandle)>,
     emit_zero_counters: bool,
     metrics_publish_interval: Duration,
+}
+
+enum ShutdownHandle {
+    SyncHandle(Box<dyn FnOnce() + Send + Sync>),
+    AsyncHandle(Pin<Box<dyn Future<Output = ()> + Send + Sync>>),
 }
 
 impl<S> fmt::Debug for MetricReporterBuilder<S> {
@@ -166,17 +173,17 @@ impl MetricReporterBuilder<YouMustConfigureAMetricsDestination> {
     /// Initialize the builder.
     pub fn new() -> Self {
         Self {
-            metrics_sink: YouMustConfigureAMetricsDestination,
-            background_queue_builder: None,
+            metrics_stream: YouMustConfigureAMetricsDestination,
+            box_entry_sink: None,
             metrics_publish_interval: DEFAULT_METRICS_PUBLISH_INTERVAL,
             emit_zero_counters: false,
         }
     }
 
-    /// Sets the destination for emitted metrics
+    /// Write metrics to an [`EntryIoStream`]
     ///
     /// For production, you normally use an EMF emitter backed by a [`tracing_appender::rolling::RollingFileAppender`]. See the
-    /// examples on [`MetricReporterBuilder`].
+    /// examples on [`MetricReporterBuilder`]. Internally, this will connect your provided stream to a [`BackgroundQueue`].
     ///
     /// For testing, either:
     /// - Do not use a `MetricReporterBuilder`, just use use [`capture_metrics`] to capture metrics without installing a global recorder.
@@ -185,21 +192,60 @@ impl MetricReporterBuilder<YouMustConfigureAMetricsDestination> {
     /// [`capture_metrics`]: crate::capture::capture_metrics
     /// [`TestSink`]: crate::util::TestSink
     /// [`MetricReporterBuilder`]: crate::reporter::MetricReporterBuilder
-    pub fn metrics_sink<S: EntryIoStream + Send + 'static>(
+    pub fn metrics_io_stream<S: EntryIoStream + Send + 'static>(
         self,
-        sink: S,
+        stream: S,
     ) -> MetricReporterBuilder<S> {
         MetricReporterBuilder {
-            metrics_sink: sink,
-            background_queue_builder: self.background_queue_builder,
+            metrics_stream: stream,
+            box_entry_sink: self.box_entry_sink,
             metrics_publish_interval: self.metrics_publish_interval,
             emit_zero_counters: self.emit_zero_counters,
         }
     }
 
+    /// Write metrics to an [`AnyEntrySink`]
+    ///
+    /// This API is setup so that you can use it directly in the output of the attach function of a global entry queue
+    pub fn metrics_sink(
+        self,
+        sink: (
+            impl AnyEntrySink + Send + Sync + 'static,
+            impl Any + Send + Sync,
+        ),
+    ) -> MetricReporterBuilder<NullEntryIoStream> {
+        let (sink, handle) = sink;
+        let shutdown_handle = ShutdownHandle::SyncHandle(Box::new(move || {
+            let _ = handle;
+        }));
+        MetricReporterBuilder {
+            metrics_stream: NullEntryIoStream::default(),
+            box_entry_sink: Some((sink.boxed(), shutdown_handle)),
+            emit_zero_counters: self.emit_zero_counters,
+            metrics_publish_interval: self.metrics_publish_interval,
+        }
+    }
+
+    /// Write metrics to a sink that must be shutdown asynchronously
+    pub fn metrics_sink_async_shutdown(
+        self,
+        sink: impl AnyEntrySink + Send + Sync + 'static,
+        shutdown: impl Future<Output = ()> + Send + Sync + 'static,
+    ) -> MetricReporterBuilder<NullEntryIoStream> {
+        let shutdown_handle = ShutdownHandle::AsyncHandle(Box::pin(async {
+            shutdown.await;
+        }));
+        MetricReporterBuilder {
+            metrics_stream: NullEntryIoStream::default(),
+            box_entry_sink: Some((sink.boxed(), shutdown_handle)),
+            emit_zero_counters: self.emit_zero_counters,
+            metrics_publish_interval: self.metrics_publish_interval,
+        }
+    }
+
     /// Creates a metric emitter that drops all metrics. Potentially useful for testing.
     pub fn disable_metrics(self) -> MetricReporterBuilder<NullEntryIoStream> {
-        self.metrics_sink(NullEntryIoStream::default())
+        self.metrics_io_stream(NullEntryIoStream::default())
     }
 }
 
@@ -208,17 +254,6 @@ impl<S> MetricReporterBuilder<S> {
     /// This does not affect gauges or histograms, which are always emitted.
     pub fn emit_zero_counters(mut self, emit_zero_counters: bool) -> Self {
         self.emit_zero_counters = emit_zero_counters;
-        self
-    }
-
-    /// Override the [`BackgroundQueueBuilder`] used to write metrics
-    ///
-    /// [`BackgroundQueueBuilder`]: crate::sink::BackgroundQueueBuilder
-    pub fn background_queue_builder(
-        mut self,
-        background_queue_builder: BackgroundQueueBuilder,
-    ) -> Self {
-        self.background_queue_builder = Some(background_queue_builder);
         self
     }
 
@@ -237,7 +272,7 @@ impl<S: EntryIoStream + Send + 'static> MetricReporterBuilder<S> {
     /// Use the returned MetricReporter to synchronize shutdown.
     #[track_caller]
     pub fn build_and_install(self) -> MetricReporter {
-        let (res, accumulator, _) = MetricReporter::new(self);
+        let (res, accumulator) = MetricReporter::new(self);
         metrics::set_global_recorder(accumulator).expect("failed to set global recorder");
         res
     }
@@ -246,7 +281,7 @@ impl<S: EntryIoStream + Send + 'static> MetricReporterBuilder<S> {
     /// which can be manually used. Metrics recorded to the recorder will be reported
     /// both periodically and when shutting down the MetricReporter.
     pub fn build_without_installing(self) -> (MetricReporter, MetricRecorder) {
-        let (reporter, recorder, _) = MetricReporter::new(self);
+        let (reporter, recorder) = MetricReporter::new(self);
         (reporter, recorder)
     }
 }
@@ -258,22 +293,31 @@ impl MetricReporter {
     /// background queue to allow them to flush it when needed.
     fn new(
         builder: MetricReporterBuilder<impl EntryIoStream + Send + 'static>,
-    ) -> (
-        Self,
-        MetricRecorder,
-        BackgroundQueue<MetricAccumulatorEntry>,
-    ) {
+    ) -> (Self, MetricRecorder) {
         let tracker = TaskTracker::new();
         let cancellation = CancellationToken::new();
 
         let metrics_token = cancellation.clone();
+        let (sink, handle) = match builder.box_entry_sink {
+            Some((sink, handle)) => (sink, handle),
+            None => {
+                let (sink, handle) =
+                    BackgroundQueueBuilder::default().build_boxed(builder.metrics_stream);
+                (
+                    sink,
+                    ShutdownHandle::SyncHandle(Box::new(move || {
+                        let _ = handle;
+                    })),
+                )
+            }
+        };
 
-        let (recorder, queue) = spawn_metric_reporter(
+        let recorder = spawn_metric_reporter(
             &tracker,
-            builder.metrics_sink,
+            sink.clone(),
+            handle,
             builder.metrics_publish_interval,
             metrics_token,
-            builder.background_queue_builder,
             builder.emit_zero_counters,
         );
         tracker.close();
@@ -282,9 +326,9 @@ impl MetricReporter {
             Self {
                 tasks: tracker,
                 cancellation_token: cancellation.clone(),
+                sink,
             },
             recorder,
-            queue,
         )
     }
 
@@ -292,6 +336,11 @@ impl MetricReporter {
     pub async fn shutdown(&self) {
         self.cancellation_token.cancel();
         self.tasks.wait().await
+    }
+
+    /// Flush all outstanding metrics to the configured storage
+    pub async fn flush(&self) {
+        AnyEntrySink::flush_async(&self.sink).await
     }
 
     /// Creates a [builder](crate::MetricReporterBuilder) for [`MetricReporter`]
@@ -302,17 +351,18 @@ impl MetricReporter {
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
-
-    use metrique_writer_core::{
-        EntrySink,
-        test_stream::{DummyFormat, TestSink},
+    use std::{
+        sync::{Arc, atomic::AtomicBool},
+        time::Duration,
     };
+
+    use metrique_writer_core::test_stream::{DummyFormat, TestSink};
     use test_case::test_case;
 
     use crate::{
         FormatExt,
         metrics::{MetricReporter, MetricReporterBuilder},
+        test_util::{TestEntrySink, test_entry_sink},
     };
 
     // not using BackgroundQueue here since it uses the real-time clock.
@@ -325,13 +375,13 @@ mod test {
         let builder = MetricReporterBuilder::new()
             .emit_zero_counters(emit_zero_counters)
             .metrics_publish_interval(Duration::from_secs(60))
-            .metrics_sink(writer);
-        let (reporter, recorder, bg_queue) = MetricReporter::new(builder);
+            .metrics_io_stream(writer);
+        let (reporter, recorder) = MetricReporter::new(builder);
         metrics::with_local_recorder(&recorder, || {
             metrics::counter!("counter_1").increment(1);
         });
         tokio::time::sleep(Duration::from_secs(65)).await;
-        bg_queue.flush_async().await;
+        reporter.flush().await;
         let d = sink.take_string();
         assert!(d.contains(r#"("counter_1", "[Unsigned(1)] None []")"#));
         metrics::with_local_recorder(&recorder, || {
@@ -339,7 +389,7 @@ mod test {
             metrics::counter!("counter_2").increment(1);
         });
         tokio::time::sleep(Duration::from_secs(65)).await;
-        bg_queue.flush_async().await;
+        reporter.flush().await;
         let d = sink.take_string();
         if emit_zero_counters {
             assert!(d.contains(r#"("counter_1", "[Unsigned(0)] None []")"#));
@@ -348,5 +398,96 @@ mod test {
         }
         assert!(d.contains(r#"("counter_2", "[Unsigned(1)] None []")"#));
         reporter.shutdown().await;
+    }
+
+    struct TestHandle {
+        shutdown_called: Arc<AtomicBool>,
+        async_shutdown_called: Arc<AtomicBool>,
+    }
+
+    impl TestHandle {
+        fn new() -> (Self, Arc<AtomicBool>, Arc<AtomicBool>) {
+            let drop_shutdown: Arc<AtomicBool> = Default::default();
+            let async_shutdown: Arc<AtomicBool> = Default::default();
+            (
+                Self {
+                    shutdown_called: drop_shutdown.clone(),
+                    async_shutdown_called: async_shutdown.clone(),
+                },
+                drop_shutdown,
+                async_shutdown,
+            )
+        }
+
+        pub async fn shutdown(&mut self) {
+            self.async_shutdown_called
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    impl Drop for TestHandle {
+        fn drop(&mut self) {
+            eprintln!("dropped");
+            self.shutdown_called
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    /// Tests metrics when using `metrics_sink`
+    async fn test_metrics_sink() {
+        let TestEntrySink { inspector, sink } = test_entry_sink();
+        let (shutdown_hook, shutdown, async_shutdown) = TestHandle::new();
+        let builder = MetricReporterBuilder::new()
+            .metrics_publish_interval(Duration::from_secs(60))
+            .metrics_sink((sink, shutdown_hook));
+        let (reporter, recorder) = MetricReporter::new(builder);
+        metrics::with_local_recorder(&recorder, || {
+            metrics::counter!("counter_1").increment(1);
+        });
+        tokio::time::sleep(Duration::from_secs(65)).await;
+        reporter.flush().await;
+        let entries = inspector.entries();
+        assert_eq!(inspector.entries().len(), 1);
+        assert_eq!(entries[0].metrics["counter_1"], 1);
+        metrics::with_local_recorder(&recorder, || {
+            metrics::counter!("counter_1").increment(0);
+            metrics::counter!("counter_2").increment(1);
+        });
+        tokio::time::sleep(Duration::from_secs(65)).await;
+        reporter.flush().await;
+        let entries = inspector.entries();
+        assert_eq!(inspector.entries().len(), 2);
+        assert_eq!(entries[1].metrics["counter_2"], 1);
+        // counter_1 is 0
+        assert_eq!(entries[1].metrics.contains_key("counter_1"), false);
+        reporter.shutdown().await;
+        assert_eq!(shutdown.load(std::sync::atomic::Ordering::Relaxed), true);
+        assert_eq!(
+            async_shutdown.load(std::sync::atomic::Ordering::Relaxed),
+            false
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_with_async_shutdown() {
+        let TestEntrySink { sink, .. } = test_entry_sink();
+        let (mut shutdown_hook, shutdown, async_shutdown) = TestHandle::new();
+        let builder = MetricReporterBuilder::new()
+            .metrics_publish_interval(Duration::from_secs(60))
+            .metrics_sink_async_shutdown(sink, async move { shutdown_hook.shutdown().await });
+        let (reporter, _recorder) = MetricReporter::new(builder);
+        assert_eq!(shutdown.load(std::sync::atomic::Ordering::Relaxed), false);
+        assert_eq!(
+            async_shutdown.load(std::sync::atomic::Ordering::Relaxed),
+            false
+        );
+        reporter.shutdown().await;
+        // this isn't done explicitly, just a side effect of dropping the handle.
+        assert_eq!(shutdown.load(std::sync::atomic::Ordering::Relaxed), true);
+        assert_eq!(
+            async_shutdown.load(std::sync::atomic::Ordering::Relaxed),
+            true
+        );
     }
 }


### PR DESCRIPTION
✍️ *Description of changes:* Update `MetricReporterBuilder` with a few changes:
1. I removed the ability to customize the BackgroundQueueBuilder — this API was unused and is now considered an implementation detail. If you want to customize the queue behavior, you can instead use the `metrics_sink` API.
2. I added a `metrics_sink` API and a `metrics_sink_async_shutdown` API — the metrics_sink API works with existing sinks. The `async_shutdown` API works with upcoming sinks that are writing to networked destinations instead of disk. Since we're already in a Tokio task, there is no reason to have many levels of `spawn_blocking` involved.

This is a breaking change, but these APIs were previously unused.
🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
