### PR TITLE
fix: fix metrique-writer-core doctests

### DIFF
--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -417,9 +417,9 @@ macro_rules! global_entry_sink {
                         /// # Example
                         /// ```rust
                         /// # use metrique_writer::sink::global_entry_sink;
-                        /// # use metrique_writer::test_util::test_entry_sink;
+                        /// # use metrique_writer::test_util::{test_entry_sink, TestEntrySink};
                         /// # global_entry_sink! { TestSink }
-                        /// let (inspector, sink) = test_entry_sink();
+                        /// let TestEntrySink { inspector, sink } = test_entry_sink();
                         /// let _guard = TestSink::set_test_sink(sink);
                         ///
                         /// // All appends now go to the thread-local test sink
@@ -443,7 +443,7 @@ macro_rules! global_entry_sink {
                         /// # use metrique_writer::sink::global_entry_sink;
                         /// # use metrique_writer::test_util::test_entry_sink;
                         /// # global_entry_sink! { TestSink }
-                        /// let (inspector, sink) = test_entry_sink();
+                        /// let TestEntrySink { inspector, sink } = test_entry_sink();
                         ///
                         /// let result = TestSink::with_test_sink(sink, || {
                         ///     // All appends in this closure go to the thread-local test sink


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

The doctests didn't compile, which broke anyone that is using the `global_entry_sink` macro and running doctests.

We need maketests here.

🔏 *By submitting this pull request*

- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
