### PR TITLE
Add support for prefixes to flattened fields

### DIFF
--- a/metrique-core/src/concat.rs
+++ b/metrique-core/src/concat.rs
@@ -1,0 +1,285 @@
+//! Utilities for concatenating strings
+
+use std::{borrow::Cow, marker::PhantomData};
+
+use self::private::SealedMaybeConstStr;
+
+/// A trait representing a constant string lifted to a constant
+pub trait ConstStr {
+    /// The constant string value
+    const VAL: &'static str;
+}
+
+/// An empty constant string
+pub struct EmptyConstStr;
+
+impl ConstStr for EmptyConstStr {
+    const VAL: &'static str = "";
+}
+
+impl<T: ConstStr> MaybeConstStr for T {
+    const MAYBE_VAL: &'static str = Self::VAL;
+    const LEN: usize = const { Self::VAL.len() };
+    const HAVE_VAL: bool = true;
+    fn extend(into: &mut String) {
+        into.push_str(Self::VAL);
+    }
+}
+
+impl<T: ConstStr> SealedMaybeConstStr for T {}
+
+/// A trait representing a string that is possibly a constant
+///
+/// The associated constants are implementation details and
+/// not to be used.
+pub trait MaybeConstStr: SealedMaybeConstStr {
+    #[doc(hidden)]
+    const MAYBE_VAL: &'static str;
+    #[doc(hidden)]
+    const LEN: usize = 0;
+    #[doc(hidden)]
+    const HAVE_VAL: bool;
+    /// Extend the value into a given string
+    fn extend(into: &mut String);
+}
+
+mod private {
+    pub trait SealedMaybeConstStr {}
+}
+
+/// The concatenation of 2 constant strings
+pub struct Concatenated<S, T>(S, T);
+
+const fn concatenate_strings<const N: usize>(x: &[u8], y: &[u8]) -> [u8; N] {
+    let mut buf = [0; N];
+    if N != x.len() + y.len() {
+        return buf;
+    }
+    let mut i = 0;
+    while i < x.len() {
+        buf[i] = x[i];
+        i += 1;
+    }
+    let mut i = 0;
+    while i < y.len() {
+        buf[x.len() + i] = y[i];
+        i += 1;
+    }
+    buf
+}
+
+struct ConcatenatedLen<X: MaybeConstStr, Y: MaybeConstStr, const N: usize>(
+    X,
+    Y,
+    PhantomData<[u8; N]>,
+);
+impl<S: MaybeConstStr, T: MaybeConstStr, const N: usize> MaybeConstStr
+    for ConcatenatedLen<S, T, N>
+{
+    const MAYBE_VAL: &str = const {
+        let buf =
+            const { &concatenate_strings::<N>(S::MAYBE_VAL.as_bytes(), T::MAYBE_VAL.as_bytes()) };
+        match std::str::from_utf8(buf) {
+            Ok(res) => res,
+            Err(_) => panic!(),
+        }
+    };
+    const HAVE_VAL: bool = S::HAVE_VAL && T::HAVE_VAL;
+    const LEN: usize = S::LEN + T::LEN;
+    fn extend(into: &mut String) {
+        S::extend(into);
+        T::extend(into);
+    }
+}
+impl<S: MaybeConstStr, T: MaybeConstStr, const N: usize> SealedMaybeConstStr
+    for ConcatenatedLen<S, T, N>
+{
+}
+
+impl<S: MaybeConstStr, T: MaybeConstStr> MaybeConstStr for Concatenated<S, T> {
+    const MAYBE_VAL: &str = match S::MAYBE_VAL.len() + T::MAYBE_VAL.len() {
+        0 => ConcatenatedLen::<S, T, 0>::MAYBE_VAL,
+        1 => ConcatenatedLen::<S, T, 1>::MAYBE_VAL,
+        2 => ConcatenatedLen::<S, T, 2>::MAYBE_VAL,
+        3 => ConcatenatedLen::<S, T, 3>::MAYBE_VAL,
+        4 => ConcatenatedLen::<S, T, 4>::MAYBE_VAL,
+        5 => ConcatenatedLen::<S, T, 5>::MAYBE_VAL,
+        6 => ConcatenatedLen::<S, T, 6>::MAYBE_VAL,
+        7 => ConcatenatedLen::<S, T, 7>::MAYBE_VAL,
+        8 => ConcatenatedLen::<S, T, 8>::MAYBE_VAL,
+        9 => ConcatenatedLen::<S, T, 9>::MAYBE_VAL,
+        10 => ConcatenatedLen::<S, T, 10>::MAYBE_VAL,
+        11 => ConcatenatedLen::<S, T, 11>::MAYBE_VAL,
+        12 => ConcatenatedLen::<S, T, 12>::MAYBE_VAL,
+        13 => ConcatenatedLen::<S, T, 13>::MAYBE_VAL,
+        14 => ConcatenatedLen::<S, T, 14>::MAYBE_VAL,
+        15 => ConcatenatedLen::<S, T, 15>::MAYBE_VAL,
+        16 => ConcatenatedLen::<S, T, 16>::MAYBE_VAL,
+        17 => ConcatenatedLen::<S, T, 17>::MAYBE_VAL,
+        18 => ConcatenatedLen::<S, T, 18>::MAYBE_VAL,
+        19 => ConcatenatedLen::<S, T, 19>::MAYBE_VAL,
+        20 => ConcatenatedLen::<S, T, 20>::MAYBE_VAL,
+        21 => ConcatenatedLen::<S, T, 21>::MAYBE_VAL,
+        22 => ConcatenatedLen::<S, T, 22>::MAYBE_VAL,
+        23 => ConcatenatedLen::<S, T, 23>::MAYBE_VAL,
+        24 => ConcatenatedLen::<S, T, 24>::MAYBE_VAL,
+        25 => ConcatenatedLen::<S, T, 25>::MAYBE_VAL,
+        26 => ConcatenatedLen::<S, T, 26>::MAYBE_VAL,
+        27 => ConcatenatedLen::<S, T, 27>::MAYBE_VAL,
+        28 => ConcatenatedLen::<S, T, 28>::MAYBE_VAL,
+        29 => ConcatenatedLen::<S, T, 29>::MAYBE_VAL,
+        30 => ConcatenatedLen::<S, T, 30>::MAYBE_VAL,
+        31 => ConcatenatedLen::<S, T, 31>::MAYBE_VAL,
+        32 => ConcatenatedLen::<S, T, 32>::MAYBE_VAL,
+        33 => ConcatenatedLen::<S, T, 33>::MAYBE_VAL,
+        34 => ConcatenatedLen::<S, T, 34>::MAYBE_VAL,
+        35 => ConcatenatedLen::<S, T, 35>::MAYBE_VAL,
+        36 => ConcatenatedLen::<S, T, 36>::MAYBE_VAL,
+        37 => ConcatenatedLen::<S, T, 37>::MAYBE_VAL,
+        38 => ConcatenatedLen::<S, T, 38>::MAYBE_VAL,
+        39 => ConcatenatedLen::<S, T, 39>::MAYBE_VAL,
+        40 => ConcatenatedLen::<S, T, 40>::MAYBE_VAL,
+        41 => ConcatenatedLen::<S, T, 41>::MAYBE_VAL,
+        42 => ConcatenatedLen::<S, T, 42>::MAYBE_VAL,
+        43 => ConcatenatedLen::<S, T, 43>::MAYBE_VAL,
+        44 => ConcatenatedLen::<S, T, 44>::MAYBE_VAL,
+        45 => ConcatenatedLen::<S, T, 45>::MAYBE_VAL,
+        46 => ConcatenatedLen::<S, T, 46>::MAYBE_VAL,
+        47 => ConcatenatedLen::<S, T, 47>::MAYBE_VAL,
+        48 => ConcatenatedLen::<S, T, 48>::MAYBE_VAL,
+        49 => ConcatenatedLen::<S, T, 49>::MAYBE_VAL,
+        50 => ConcatenatedLen::<S, T, 50>::MAYBE_VAL,
+        51 => ConcatenatedLen::<S, T, 51>::MAYBE_VAL,
+        52 => ConcatenatedLen::<S, T, 52>::MAYBE_VAL,
+        53 => ConcatenatedLen::<S, T, 53>::MAYBE_VAL,
+        54 => ConcatenatedLen::<S, T, 54>::MAYBE_VAL,
+        55 => ConcatenatedLen::<S, T, 55>::MAYBE_VAL,
+        56 => ConcatenatedLen::<S, T, 56>::MAYBE_VAL,
+        57 => ConcatenatedLen::<S, T, 57>::MAYBE_VAL,
+        58 => ConcatenatedLen::<S, T, 58>::MAYBE_VAL,
+        59 => ConcatenatedLen::<S, T, 59>::MAYBE_VAL,
+        60 => ConcatenatedLen::<S, T, 60>::MAYBE_VAL,
+        61 => ConcatenatedLen::<S, T, 61>::MAYBE_VAL,
+        62 => ConcatenatedLen::<S, T, 62>::MAYBE_VAL,
+        63 => ConcatenatedLen::<S, T, 63>::MAYBE_VAL,
+        64 => ConcatenatedLen::<S, T, 64>::MAYBE_VAL,
+        65 => ConcatenatedLen::<S, T, 65>::MAYBE_VAL,
+        66 => ConcatenatedLen::<S, T, 66>::MAYBE_VAL,
+        67 => ConcatenatedLen::<S, T, 67>::MAYBE_VAL,
+        68 => ConcatenatedLen::<S, T, 68>::MAYBE_VAL,
+        69 => ConcatenatedLen::<S, T, 69>::MAYBE_VAL,
+        70 => ConcatenatedLen::<S, T, 70>::MAYBE_VAL,
+        71 => ConcatenatedLen::<S, T, 71>::MAYBE_VAL,
+        72 => ConcatenatedLen::<S, T, 72>::MAYBE_VAL,
+        73 => ConcatenatedLen::<S, T, 73>::MAYBE_VAL,
+        74 => ConcatenatedLen::<S, T, 74>::MAYBE_VAL,
+        75 => ConcatenatedLen::<S, T, 75>::MAYBE_VAL,
+        76 => ConcatenatedLen::<S, T, 76>::MAYBE_VAL,
+        77 => ConcatenatedLen::<S, T, 77>::MAYBE_VAL,
+        78 => ConcatenatedLen::<S, T, 78>::MAYBE_VAL,
+        79 => ConcatenatedLen::<S, T, 79>::MAYBE_VAL,
+        80 => ConcatenatedLen::<S, T, 80>::MAYBE_VAL,
+        81 => ConcatenatedLen::<S, T, 81>::MAYBE_VAL,
+        82 => ConcatenatedLen::<S, T, 82>::MAYBE_VAL,
+        83 => ConcatenatedLen::<S, T, 83>::MAYBE_VAL,
+        84 => ConcatenatedLen::<S, T, 84>::MAYBE_VAL,
+        85 => ConcatenatedLen::<S, T, 85>::MAYBE_VAL,
+        86 => ConcatenatedLen::<S, T, 86>::MAYBE_VAL,
+        87 => ConcatenatedLen::<S, T, 87>::MAYBE_VAL,
+        88 => ConcatenatedLen::<S, T, 88>::MAYBE_VAL,
+        89 => ConcatenatedLen::<S, T, 89>::MAYBE_VAL,
+        90 => ConcatenatedLen::<S, T, 90>::MAYBE_VAL,
+        91 => ConcatenatedLen::<S, T, 91>::MAYBE_VAL,
+        92 => ConcatenatedLen::<S, T, 92>::MAYBE_VAL,
+        93 => ConcatenatedLen::<S, T, 93>::MAYBE_VAL,
+        94 => ConcatenatedLen::<S, T, 94>::MAYBE_VAL,
+        95 => ConcatenatedLen::<S, T, 95>::MAYBE_VAL,
+        96 => ConcatenatedLen::<S, T, 96>::MAYBE_VAL,
+        97 => ConcatenatedLen::<S, T, 97>::MAYBE_VAL,
+        98 => ConcatenatedLen::<S, T, 98>::MAYBE_VAL,
+        99 => ConcatenatedLen::<S, T, 99>::MAYBE_VAL,
+        100 => ConcatenatedLen::<S, T, 100>::MAYBE_VAL,
+        _ => "",
+    };
+    const HAVE_VAL: bool = S::HAVE_VAL && T::HAVE_VAL && (S::LEN + T::LEN) <= 100;
+    const LEN: usize = S::LEN + T::LEN;
+    fn extend(into: &mut String) {
+        S::extend(into);
+        T::extend(into);
+    }
+}
+impl<S: MaybeConstStr, T: MaybeConstStr> SealedMaybeConstStr for Concatenated<S, T> {}
+
+/// Return the value of a given [MaybeConstStr]. If possible, will return
+/// the value without allocating.
+pub fn const_str_value<S: MaybeConstStr>() -> Cow<'static, str> {
+    if S::HAVE_VAL {
+        Cow::Borrowed(S::MAYBE_VAL)
+    } else {
+        let mut buf = String::with_capacity(S::LEN);
+        S::extend(&mut buf);
+        Cow::Owned(buf)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::borrow::Cow;
+
+    use crate::concat::{Concatenated, ConstStr, const_str_value};
+
+    struct ConstFoo;
+    impl ConstStr for ConstFoo {
+        const VAL: &str = "Foo_";
+    }
+
+    struct ConstBar;
+    impl ConstStr for ConstBar {
+        const VAL: &str = "Bar";
+    }
+
+    struct ConstMinus;
+    impl ConstStr for ConstMinus {
+        const VAL: &str = "-";
+    }
+
+    type MinusConcated<U, V> = Concatenated<U, Concatenated<ConstMinus, V>>;
+    type VL1 = MinusConcated<ConstFoo, ConstBar>;
+    type VL2 = MinusConcated<VL1, VL1>;
+    type VL3 = MinusConcated<VL2, VL2>;
+    type VL4 = MinusConcated<VL3, VL3>;
+    type VL5 = MinusConcated<VL4, VL4>;
+    type VL6 = MinusConcated<VL5, VL5>;
+
+    #[test]
+    fn main() {
+        assert_eq!(
+            const_str_value::<Concatenated<ConstFoo, ConstBar>>(),
+            "Foo_Bar"
+        );
+        let vl6 = const_str_value::<VL6>();
+        match vl6 {
+            Cow::Owned(a) => assert_eq!(
+                a,
+                "Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar"
+            ),
+            _ => panic!(),
+        };
+        let vl5 = const_str_value::<VL5>();
+        match vl5 {
+            Cow::Owned(a) => assert_eq!(
+                a,
+                "Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar"
+            ),
+            _ => panic!(),
+        };
+        let vl4 = const_str_value::<VL4>();
+        match vl4 {
+            Cow::Borrowed(a) => assert_eq!(
+                a,
+                "Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar-Foo_-Bar"
+            ),
+            _ => panic!(),
+        };
+    }
+}

--- a/metrique-core/src/lib.rs
+++ b/metrique-core/src/lib.rs
@@ -9,6 +9,7 @@ use metrique_writer_core::{EntryWriter, entry::SampleGroupElement};
 
 mod atomics;
 mod close_value_impls;
+pub mod concat;
 mod inflectable_entry_impls;
 mod namestyle;
 

--- a/metrique-core/src/namestyle.rs
+++ b/metrique-core/src/namestyle.rs
@@ -3,7 +3,7 @@
 
 //! Contains various name styles
 
-use std::{borrow::Cow, marker::PhantomData};
+use std::marker::PhantomData;
 
 use crate::concat::{Concatenated, EmptyConstStr, MaybeConstStr};
 
@@ -37,16 +37,6 @@ pub trait NameStyle: private::NameStyleInternal {
     /// Inflect an affix (just inflect, without adding prefixes)
     #[doc(hidden)]
     type InflectAffix<ID: MaybeConstStr, PASCAL: MaybeConstStr, SNAKE: MaybeConstStr, KEBAB: MaybeConstStr>: MaybeConstStr;
-
-    /// In theory this function does not pose a back compat hazard, but it
-    /// is still better if people only call it via the macro
-    #[doc(hidden)]
-    fn inflect_name(
-        identity: &'static str,
-        pascal: &'static str,
-        snake: &'static str,
-        kebab: &'static str,
-    ) -> Cow<'static, str>;
 }
 
 /// Inflects names to the identity case
@@ -69,23 +59,6 @@ impl<PREFIX: MaybeConstStr> NameStyle for Identity<PREFIX> {
         SNAKE: MaybeConstStr,
         KEBAB: MaybeConstStr,
     > = ID;
-
-    #[inline]
-    fn inflect_name(
-        identity: &'static str,
-        _pascal: &'static str,
-        _snake: &'static str,
-        _kebab: &'static str,
-    ) -> Cow<'static, str> {
-        if PREFIX::LEN == 0 {
-            Cow::Borrowed(identity)
-        } else {
-            let mut result = String::with_capacity(PREFIX::LEN + identity.len());
-            PREFIX::extend(&mut result);
-            result.push_str(identity);
-            Cow::Owned(result)
-        }
-    }
 }
 
 /// inflects names to `PascalCase`
@@ -108,23 +81,6 @@ impl<PREFIX: MaybeConstStr> NameStyle for PascalCase<PREFIX> {
         SNAKE: MaybeConstStr,
         KEBAB: MaybeConstStr,
     > = PASCAL;
-
-    #[inline]
-    fn inflect_name(
-        _identity: &'static str,
-        pascal: &'static str,
-        _snake: &'static str,
-        _kebab: &'static str,
-    ) -> Cow<'static, str> {
-        if PREFIX::LEN == 0 {
-            Cow::Borrowed(pascal)
-        } else {
-            let mut result = String::with_capacity(PREFIX::LEN + pascal.len());
-            PREFIX::extend(&mut result);
-            result.push_str(pascal);
-            Cow::Owned(result)
-        }
-    }
 }
 
 /// Inflects names to `snake_case`
@@ -147,23 +103,6 @@ impl<PREFIX: MaybeConstStr> NameStyle for SnakeCase<PREFIX> {
         SNAKE: MaybeConstStr,
         KEBAB: MaybeConstStr,
     > = SNAKE;
-
-    #[inline]
-    fn inflect_name(
-        _identity: &'static str,
-        _pascal: &'static str,
-        snake: &'static str,
-        _kebab: &'static str,
-    ) -> Cow<'static, str> {
-        if PREFIX::LEN == 0 {
-            Cow::Borrowed(snake)
-        } else {
-            let mut result = String::with_capacity(PREFIX::LEN + snake.len());
-            PREFIX::extend(&mut result);
-            result.push_str(snake);
-            Cow::Owned(result)
-        }
-    }
 }
 
 /// Inflects names to `kebab-case`
@@ -186,21 +125,4 @@ impl<PREFIX: MaybeConstStr> NameStyle for KebabCase<PREFIX> {
         SNAKE: MaybeConstStr,
         KEBAB: MaybeConstStr,
     > = KEBAB;
-
-    #[inline]
-    fn inflect_name(
-        _identity: &'static str,
-        _pascal: &'static str,
-        _snake: &'static str,
-        kebab: &'static str,
-    ) -> Cow<'static, str> {
-        if PREFIX::LEN == 0 {
-            Cow::Borrowed(kebab)
-        } else {
-            let mut result = String::with_capacity(PREFIX::LEN + kebab.len());
-            PREFIX::extend(&mut result);
-            result.push_str(kebab);
-            Cow::Owned(result)
-        }
-    }
 }

--- a/metrique-macro/src/inflect.rs
+++ b/metrique-macro/src/inflect.rs
@@ -25,6 +25,37 @@ impl NameStyle {
             NameStyle::KebabCase => name.to_kebab_case(),
         }
     }
+
+    pub(crate) fn apply_prefix(self, name: &str) -> String {
+        use inflector::Inflector;
+        match self {
+            NameStyle::PascalCase => name.to_pascal_case(),
+            NameStyle::SnakeCase => {
+                let mut res = name.to_snake_case();
+                if !res.ends_with("_") {
+                    res.push('_');
+                }
+                res
+            }
+            NameStyle::Preserve => name.to_string(),
+            NameStyle::KebabCase => {
+                let mut res = name.to_kebab_case();
+                if !res.ends_with("-") {
+                    res.push('-');
+                }
+                res
+            }
+        }
+    }
+
+    pub(crate) fn to_word(self) -> &'static str {
+        match self {
+            NameStyle::PascalCase => "Pascal",
+            NameStyle::SnakeCase => "Snake",
+            NameStyle::Preserve => "Preserve",
+            NameStyle::KebabCase => "Kebab",
+        }
+    }
 }
 
 pub fn metric_name(
@@ -72,5 +103,32 @@ impl HasInflectableName for MetricsVariant {
 
     fn name(&self) -> String {
         self.ident.to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::NameStyle;
+
+    #[test]
+    fn test_inflect_prefix() {
+        let kebab = NameStyle::KebabCase;
+        let snake = NameStyle::SnakeCase;
+        let pascal = NameStyle::PascalCase;
+
+        assert_eq!(kebab.apply_prefix("Foo"), "foo-");
+        assert_eq!(kebab.apply_prefix("foo"), "foo-");
+        assert_eq!(kebab.apply_prefix("foo_"), "foo-");
+        assert_eq!(kebab.apply_prefix("foo-"), "foo-");
+
+        assert_eq!(snake.apply_prefix("Foo"), "foo_");
+        assert_eq!(snake.apply_prefix("foo"), "foo_");
+        assert_eq!(snake.apply_prefix("foo_"), "foo_");
+        assert_eq!(snake.apply_prefix("foo-"), "foo_");
+
+        assert_eq!(pascal.apply_prefix("Foo"), "Foo");
+        assert_eq!(pascal.apply_prefix("foo"), "Foo");
+        assert_eq!(pascal.apply_prefix("foo_"), "Foo");
+        assert_eq!(pascal.apply_prefix("foo-"), "Foo");
     }
 }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
@@ -26,22 +26,70 @@ const _: () = {
         fn write<'a>(&'a self, writer: &mut impl ::metrique::__writer::EntryWriter<'a>) {
             ::metrique::__writer::EntryWriter::value(
                 writer,
-                <NS as ::metrique::NameStyle>::inflect_name(
-                    "operation",
-                    "Operation",
-                    "operation",
-                    "operation",
-                ),
+                {
+                    #[allow(non_camel_case_types)]
+                    struct operationPreserve;
+                    impl ::metrique::concat::ConstStr for operationPreserve {
+                        const VAL: &'static str = "operation";
+                    }
+                    #[allow(non_camel_case_types)]
+                    struct operationKebab;
+                    impl ::metrique::concat::ConstStr for operationKebab {
+                        const VAL: &'static str = "operation";
+                    }
+                    #[allow(non_camel_case_types)]
+                    struct operationPascal;
+                    impl ::metrique::concat::ConstStr for operationPascal {
+                        const VAL: &'static str = "Operation";
+                    }
+                    #[allow(non_camel_case_types)]
+                    struct operationSnake;
+                    impl ::metrique::concat::ConstStr for operationSnake {
+                        const VAL: &'static str = "operation";
+                    }
+                    ::metrique::concat::const_str_value::<
+                        <NS as ::metrique::NameStyle>::Inflect<
+                            operationPreserve,
+                            operationPascal,
+                            operationSnake,
+                            operationKebab,
+                        >,
+                    >()
+                },
                 &self.operation,
             );
             ::metrique::__writer::EntryWriter::value(
                 writer,
-                <NS as ::metrique::NameStyle>::inflect_name(
-                    "number_of_ducks",
-                    "NumberOfDucks",
-                    "number_of_ducks",
-                    "number-of-ducks",
-                ),
+                {
+                    #[allow(non_camel_case_types)]
+                    struct number_of_ducksPreserve;
+                    impl ::metrique::concat::ConstStr for number_of_ducksPreserve {
+                        const VAL: &'static str = "number_of_ducks";
+                    }
+                    #[allow(non_camel_case_types)]
+                    struct number_of_ducksKebab;
+                    impl ::metrique::concat::ConstStr for number_of_ducksKebab {
+                        const VAL: &'static str = "number-of-ducks";
+                    }
+                    #[allow(non_camel_case_types)]
+                    struct number_of_ducksPascal;
+                    impl ::metrique::concat::ConstStr for number_of_ducksPascal {
+                        const VAL: &'static str = "NumberOfDucks";
+                    }
+                    #[allow(non_camel_case_types)]
+                    struct number_of_ducksSnake;
+                    impl ::metrique::concat::ConstStr for number_of_ducksSnake {
+                        const VAL: &'static str = "number_of_ducks";
+                    }
+                    ::metrique::concat::const_str_value::<
+                        <NS as ::metrique::NameStyle>::Inflect<
+                            number_of_ducksPreserve,
+                            number_of_ducksPascal,
+                            number_of_ducksSnake,
+                            number_of_ducksKebab,
+                        >,
+                    >()
+                },
                 &self.number_of_ducks,
             );
         }

--- a/metrique/README.md
+++ b/metrique/README.md
@@ -465,7 +465,7 @@ Supported case styles include: `"PascalCase"`, `"camelCase"`, `"snake_case"`.
 
 #### Add a prefix to all fields
 
-Use the `prefix` attribute to add a consistent prefix to all fields:
+Use the `prefix` attribute on structs to add a consistent prefix to all fields:
 
 ```rust
 use metrique::unit_of_work::metrics;
@@ -477,6 +477,30 @@ struct ApiMetrics {
     latency: usize,
     // Will appear as "ApiErrors" in metrics output
     errors: usize
+}
+```
+
+#### Add a prefix to all metrics in a subfield
+
+Use the `prefix` attribute on `flatten` to add a consistent prefix to fields of the
+included struct:
+
+```rust
+use metrique::unit_of_work::metrics;
+
+#[metrics(subfield)]
+struct DownstreamMetrics {
+    // our downstream calls their metric just "success", so we don't know who succeedded
+    success: bool,
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct MyMetrics {
+    // This is our success field, will appear as "Success" in metrics output
+    success: bool,
+    // Their success field will appear as "DownstreamSuccess" in metrics output
+    #[metrics(flatten, prefix="Downstream")]
+    downstream: DownstreamMetrics,
 }
 ```
 
@@ -514,16 +538,16 @@ struct Metrics {
     overridden_field: &'static str,
 
     // Nested metrics can have their own renaming rules
-    #[metrics(flatten)]
+    #[metrics(flatten, prefix="his-")]
     nested: PrefixedMetrics,
 }
 
 #[metrics(rename_all = "PascalCase", prefix = "api_")]
 struct PrefixedMetrics {
-    // Will appear as "ApiLatency" in metrics output (explicit rename_all overrides the parent)
+    // Will appear as "his-ApiLatency" in metrics output (explicit rename_all overrides the parent)
     latency: usize,
 
-    // Will appear as "exact_name" in metrics output (overrides both prefix and case)
+    // Will appear as "his-exact_name" in metrics output (overrides both struct prefix and case, but not external prefix)
     #[metrics(name = "exact_name")]
     response_time: usize,
 }

--- a/metrique/README.md
+++ b/metrique/README.md
@@ -439,7 +439,13 @@ struct RequestMetrics {
     request_size: usize
 }
 ```
+
 ### Renaming metric fields
+
+> the complex interaction between naming, prefixing, and inflection is deterministic, but sometimes might
+> not do what you expect. It is critical that you add [tests](#testing-emitted-metrics) that validate that
+> the keys being produced match your expectations
+
 You can customize how metric field names appear in the output using several approaches:
 
 #### Rename all fields with a consistent case style
@@ -488,9 +494,24 @@ included struct:
 ```rust
 use metrique::unit_of_work::metrics;
 
+use std::collections::HashMap;
+
 #[metrics(subfield)]
 struct DownstreamMetrics {
     // our downstream calls their metric just "success", so we don't know who succeedded
+    success: bool,
+}
+
+// using `subfield_owned` to allow closing over the `HashMap`
+#[metrics(subfield_owned)]
+struct OtherDownstreamMetrics {
+    // the prefix will be *SKIPPED* within this field, since it is included using `flatten_entry`
+    //
+    // the prefix is skipped since prepending a prefix would require allocating a new String,
+    // and metrique will rather not have code that does that.
+    #[metrics(flatten_entry, no_close)]
+    prefix_skipped: HashMap<String, u32>,
+    // another downstream that calls their metric just "success", so we don't know who succeedded
     success: bool,
 }
 
@@ -501,8 +522,18 @@ struct MyMetrics {
     // Their success field will appear as "DownstreamSuccess" in metrics output
     #[metrics(flatten, prefix="Downstream")]
     downstream: DownstreamMetrics,
+    #[metrics(flatten, prefix="OtherDownstream")]
+    other_downstream: OtherDownstreamMetrics,
 }
 ```
+
+Prefixes will be inflected to the case metrics are emitted in, so if you let `rename_all`
+vary, the inner metric name will be:
+
+ 1. in `rename_all = "Preserve"`, `Downstreamsuccess` / `OtherDownstreamsuccess`
+ 2. in `rename_all = "PascalCase"`, `DownstreamSuccess` / `OtherDownstreamSuccess`
+ 3. in `rename_all = "kebab-case"`, `downstream-success` / `other-downstream-success`
+ 4. in `rename_all = "snake_case"`, `downstream_success` / `other_downstream_success`
 
 #### Rename individual fields
 

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -403,3 +403,5 @@ impl<M: InflectableEntry> Entry for RootEntry<M> {
 
 #[cfg(feature = "service-metrics")]
 pub use metrique_service_metrics::ServiceMetrics;
+
+pub use metrique_core::concat;

--- a/metrique/tests/ui/fail/bad_field_attrs.rs
+++ b/metrique/tests/ui/fail/bad_field_attrs.rs
@@ -31,6 +31,9 @@ struct MetricsWithInvalidUnit {
 
     #[metrics(ignore, no_close)]
     ignore_no_close: usize,
+
+    #[metrics(prefix = "foo")]
+    prefix_no_flatten: usize,
 }
 
 #[metrics(rename_all = "snake_case")]

--- a/metrique/tests/ui/fail/bad_field_attrs.stderr
+++ b/metrique/tests/ui/fail/bad_field_attrs.stderr
@@ -57,3 +57,9 @@ error: Cannot combine ignore with no_close
    |
 32 |     #[metrics(ignore, no_close)]
    |               ^^^^^^
+
+error: prefix can only be used with flatten
+  --> tests/ui/fail/bad_field_attrs.rs:35:15
+   |
+35 |     #[metrics(prefix = "foo")]
+   |               ^^^^^^


### PR DESCRIPTION
📬 *Issue #, if available:*

#39 

✍️ *Description of changes:*


Use the `prefix` attribute on `flatten` to add a consistent prefix to fields of the
included struct:

```rust
use metrique::unit_of_work::metrics;

#[metrics(subfield)]
struct DownstreamMetrics {
    // our downstream calls their metric just "success", so we don't know who succeedded
    success: bool,
}

#[metrics(rename_all = "PascalCase")]
struct MyMetrics {
    // This is our success field, will appear as "Success" in metrics output
    success: bool,
    // Their success field will appear as "DownstreamSuccess" in metrics output
    #[metrics(flatten, prefix="Downstream")]
    downstream: DownstreamMetrics,
}
```

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
