### PR TITLE
fix: mark ThreadLocalTestSinkGuard as !Send + !Sync

### DIFF
--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -15,6 +15,8 @@
 //! ignoring the boxing performance issue.
 
 use std::any::Any;
+#[cfg(feature = "test-util")]
+use std::marker::PhantomData;
 
 use crate::{
     EntrySink,
@@ -192,6 +194,8 @@ pub struct ThreadLocalTestSinkGuard {
     // Function pointer to clear the guard when dropped
     // This is set by the macro-generated code
     clear_fn: fn(),
+    // ThreadLocalTestSinkGuard touches thread-local data and is therefore !Send/!Sync
+    _marker: PhantomData<*const ()>,
 }
 
 #[cfg(feature = "test-util")]
@@ -202,7 +206,10 @@ impl ThreadLocalTestSinkGuard {
     /// installing the thread-local sink override.
     #[doc(hidden)]
     pub fn new(clear_fn: fn()) -> Self {
-        Self { clear_fn }
+        Self {
+            clear_fn,
+            _marker: PhantomData,
+        }
     }
 }
 

--- a/metrique/tests/ui/fail/guard_not_send_sync.rs
+++ b/metrique/tests/ui/fail/guard_not_send_sync.rs
@@ -1,0 +1,15 @@
+use metrique_writer::sink::global_entry_sink;
+use metrique_writer::test_util::{test_entry_sink, TestEntrySink};
+global_entry_sink! { TestSink }
+
+fn assert_sync<S: Sync>(_s: &S) {}
+fn assert_send<S: Send>(_s: &S) {}
+
+// this is not a test of the macro, but we already have a cfail test
+fn main() {
+    let TestEntrySink { inspector: _, sink } = test_entry_sink();
+    let _guard = TestSink::set_test_sink(sink);
+    assert_sync(&_guard);
+    assert_send(&_guard);
+}
+

--- a/metrique/tests/ui/fail/guard_not_send_sync.stderr
+++ b/metrique/tests/ui/fail/guard_not_send_sync.stderr
@@ -1,0 +1,43 @@
+error[E0277]: `*const ()` cannot be shared between threads safely
+  --> tests/ui/fail/guard_not_send_sync.rs:12:17
+   |
+12 |     assert_sync(&_guard);
+   |     ----------- ^^^^^^^ `*const ()` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: within `ThreadLocalTestSinkGuard`, the trait `Sync` is not implemented for `*const ()`
+note: required because it appears within the type `PhantomData<*const ()>`
+  --> $RUST/core/src/marker.rs
+note: required because it appears within the type `ThreadLocalTestSinkGuard`
+  --> $WORKSPACE/metrique-writer-core/src/global.rs
+   |
+   | pub struct ThreadLocalTestSinkGuard {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `assert_sync`
+  --> tests/ui/fail/guard_not_send_sync.rs:5:19
+   |
+5  | fn assert_sync<S: Sync>(_s: &S) {}
+   |                   ^^^^ required by this bound in `assert_sync`
+
+error[E0277]: `*const ()` cannot be sent between threads safely
+  --> tests/ui/fail/guard_not_send_sync.rs:13:17
+   |
+13 |     assert_send(&_guard);
+   |     ----------- ^^^^^^^ `*const ()` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: within `ThreadLocalTestSinkGuard`, the trait `Send` is not implemented for `*const ()`
+note: required because it appears within the type `PhantomData<*const ()>`
+  --> $RUST/core/src/marker.rs
+note: required because it appears within the type `ThreadLocalTestSinkGuard`
+  --> $WORKSPACE/metrique-writer-core/src/global.rs
+   |
+   | pub struct ThreadLocalTestSinkGuard {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `assert_send`
+  --> tests/ui/fail/guard_not_send_sync.rs:6:19
+   |
+6  | fn assert_send<S: Send>(_s: &S) {}
+   |                   ^^^^ required by this bound in `assert_send`


### PR DESCRIPTION
this is a breaking change, but this is a bug

📬 *Issue #, if available:*

Fixes https://github.com/awslabs/metrique/issues/68

✍️ *Description of changes:*

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
