### PR TITLE
Make metrique-writer enable metrique-writer-core test-util

### DIFF
--- a/metrique-writer/Cargo.toml
+++ b/metrique-writer/Cargo.toml
@@ -59,7 +59,7 @@ default = [
     "metrics_rs_024",
     "metrics_rs_bridge",
 ]
-test-util = []
+test-util = ["metrique-writer-core/test-util"]
 # Private utilities for testing the formatter crates. 100% unstable, do not use outside of this workspace
 # dep:tracing-appender is for rustdoc
 private-test-util = ["dep:tracing-appender"]


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:* The `set_test_sink` code is gated behind a `test-util` in metrique-writer core, however, we want to avoid people needing to depend on that directly. This enables that feature as a consequence of enabling test-util in metrique-writer.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
