### PR TITLE
feat(test-util): derive Clone and Debug for TestEntrySink

### DIFF
--- a/metrique-writer/src/test_util.rs
+++ b/metrique-writer/src/test_util.rs
@@ -266,6 +266,7 @@ pub fn to_test_entry(e: impl Entry) -> TestEntry {
 /// to the sink.
 ///
 /// This requires that the `test-util` feature be enabled.
+#[derive(Clone, Debug)]
 pub struct TestEntrySink {
     /// The inspector for examining captured metric entries.
     pub inspector: Inspector,


### PR DESCRIPTION
📬 *Issue #, if available:*

n/a

✍️ *Description of changes:*

The two inner fields for `TestEntrySink` are both wrapping `Arcs` and have `Debug` implemented. It's a minor paper cut to not be able to easily clone `TestEntrySink`. This came up while I was working on a test harness that needed to clone and send a particular queue inside a call that might happen multiple times.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
