### PR TITLE
fix(docs): properly set global dimension in emf module docs

### DIFF
--- a/metrique/docs/emf.md
+++ b/metrique/docs/emf.md
@@ -50,7 +50,7 @@ There are two ways you define dimensions with `metrique`:
    };
 
    let _handle = ServiceMetrics::attach_to_stream(
-       Emf::builder("Ns".to_string(), vec![vec![]])
+       Emf::builder("Ns".to_string(), vec![vec!["region".to_string()]])
            .build()
            .output_to_makewriter(|| std::io::stdout().lock())
            // All entries will contain `region: us-east-1` as a dimension


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

The existing docs imply that setting `merge_globals()` automatically sets dimensions for all globals. This isn't true, it is only the case that the [merge_global_dimensionsets()](https://docs.rs/metrique/latest/metrique/writer/trait.FormatExt.html#method.merge_global_dimensions) API does something like this.

Updating the example to match what the description says it does.

I spot checked and saw that we defined things right in the other places. It might be a bit confusing that our full form examples mostly show globals being set without associated dimensions. I didn't care to change them to eg use 
```
vec![
  vec![],
  vec!["region".to_string()],
  vec!["service".to_string()],
  vec!["region".to_string(), "service".to_string()]
]
```
but that's probably the most realistic default.

Up to the reviewer if they think that is worth doing. It might be nice to have a 'cartesian join all globals please' as a first-class API since you can see that that's a heap of boilerplate when there are 2+ dimensions.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
