### PR TITLE
chore(docs): clarify that you can also bring your own format with the Format trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A set of crates for collecting and exporting metrics, especially unit-of-work metrics.
 
 This currently supports exporting metrics in [Amazon EMF] format to CloudWatch.
-More formats might be supported in future versions.
-
+More formats might be supported in future versions. You can also configure a custom
+format using the [`Format`] trait.
 
 ## Getting Started
 
@@ -77,7 +77,8 @@ fn initialize_metrics(service_log_dir: PathBuf) -> AttachHandle {
 
 > See [`metrique-writer`](metrique-writer) for more information about queues and destinations.
 
-You can either attach it to a global destination or thread the queue to the location you construct your metrics object directly. Currently, only formatters for [Amazon EMF] are provided, but more may be added in the future.
+You can either attach it to a global destination or thread the queue to the location you construct your metrics object directly. Currently, only formatters for [Amazon EMF] are provided, but more may be added in the future. You can also configure a custom
+format using the [`Format`] trait.
 
 ## Glossary
 
@@ -125,7 +126,7 @@ You can either attach it to a global destination or thread the queue to the loca
 [`Entry`]: https://docs.rs/metrique-writer/0.1/metrique_writer/trait.Entry.html
 [`EntryIoStream`]: https://docs.rs/metrique-writer/0.1/metrique_writer/trait.EntryIoStream.html
 [`EntrySink`]: https://docs.rs/metrique-writer/0.1/metrique_writer/trait.EntrySink.html
-[`Format`]: https://docs.rs/metrique-writer/0.1/metrique_writer/format/trait.Format.html
+[`Format`]: https://docs.rs/metrique/0.1/metrique/writer/format/trait.Format.html
 [`FlushGuard`]: https://docs.rs/metrique/0.1/metrique/slot/struct.FlushGuard.html
 [`FlushImmediately`]: https://docs.rs/metrique-writer/0.1/metrique_writer/sink/struct.FlushImmediately.html
 [`InflectableEntry`]: https://docs.rs/metrique/0.1/metrique/trait.InflectableEntry.html

--- a/metrique-writer/README.md
+++ b/metrique-writer/README.md
@@ -57,7 +57,8 @@ It is also possible to implement `Entry` manually (see the docs for [`Entry`]).
 
 This library currently only comes with `metrique-writer-format-emf`,
 which formats to [Amazon CloudWatch Embedded Metric Format (EMF)][emf-docs],
-but more formatters might be added in the future.
+but more formatters might be added in the future. You can also configure a custom
+format using the [`Format`] trait.
 
 Entries are sent to an [`EntrySink`] in order to be written to a destination.
 
@@ -229,4 +230,4 @@ queue.append_any(metric);
 ```
 
 [emf-docs]: htps://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
-[`Format`]: https://docs.rs/metrique-writer/0.1/metrique_writer/format/trait.Format.html
+[`Format`]: https://docs.rs/metrique/0.1/metrique/writer/format/trait.Format.html


### PR DESCRIPTION

📬 *Issue #, if available:*

✍️ *Description of changes:*

Currently our docs read like the library only offers EMF, or else you're out of luck until new formats are added. In fact you can bring your own format if you implement the `Format` trait. It's not trivial work, and this PR doesn't add a full-form guide, but users can at least reference the Emf implementation of `Format`.

For now, I just added that breadcrumb to places where we say 'only emf is supported for now, but more formats might be supported in the future'. I also tweaked our link to point to our `metrique`-re-export of the metrique-writer types since that keeps people from needing to jump around as much (they probably DO want to immediately go to the EMF implementation).

Context: I was having a conversation with a prospective user that was interested in bringing their own minimalist, non-standard format. If they are willing to do the legwork to implement the `Format` trait, `metrique` would support that just fine.


🔏 *By submitting this pull request*

- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
