### PR TITLE
MultiFlex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "rustversion",
  "ryu",
  "serde_json",
+ "smartstring",
  "tokio",
  "tokio-util",
  "toml",
@@ -1325,6 +1326,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1345,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_inflector"

--- a/metrique-core/src/lib.rs
+++ b/metrique-core/src/lib.rs
@@ -15,6 +15,7 @@ mod namestyle;
 
 pub use atomics::Counter;
 pub use namestyle::NameStyle;
+pub use namestyle::NoPrefix;
 
 /// Close a given value
 ///

--- a/metrique-core/src/namestyle.rs
+++ b/metrique-core/src/namestyle.rs
@@ -5,7 +5,10 @@
 
 use std::marker::PhantomData;
 
-use crate::concat::{Concatenated, EmptyConstStr, MaybeConstStr};
+use crate::{
+    concat::{Concatenated, EmptyConstStr, MaybeConstStr},
+    namestyle::private::NameStyleInternal,
+};
 
 pub(crate) mod private {
     /// Helper trait to make `NameStyle` sealed
@@ -37,6 +40,34 @@ pub trait NameStyle: private::NameStyleInternal {
     /// Inflect an affix (just inflect, without adding prefixes)
     #[doc(hidden)]
     type InflectAffix<ID: MaybeConstStr, PASCAL: MaybeConstStr, SNAKE: MaybeConstStr, KEBAB: MaybeConstStr>: MaybeConstStr;
+}
+
+/// docs
+pub struct NoPrefix<Ns>(PhantomData<Ns>);
+impl<Ns> NameStyleInternal for NoPrefix<Ns> {}
+
+impl<Ns: NameStyle> NameStyle for NoPrefix<Ns> {
+    type KebabCase = Ns::KebabCase;
+
+    type PascalCase = Ns::PascalCase;
+
+    type SnakeCase = Ns::SnakeCase;
+
+    type AppendPrefix<T: MaybeConstStr> = Identity<T>;
+
+    type Inflect<
+        ID: MaybeConstStr,
+        PASCAL: MaybeConstStr,
+        SNAKE: MaybeConstStr,
+        KEBAB: MaybeConstStr,
+    > = Ns::InflectAffix<ID, PASCAL, SNAKE, KEBAB>;
+
+    type InflectAffix<
+        ID: MaybeConstStr,
+        PASCAL: MaybeConstStr,
+        SNAKE: MaybeConstStr,
+        KEBAB: MaybeConstStr,
+    > = Ns::InflectAffix<ID, PASCAL, SNAKE, KEBAB>;
 }
 
 /// Inflects names to the identity case

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -36,6 +36,7 @@ metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.3" }
 tracing-appender = { workspace = true, optional = true }
 ryu = { workspace = true }
 itoa = { workspace = true }
+smartstring = "1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/metrique/examples/handlers.rs
+++ b/metrique/examples/handlers.rs
@@ -1,0 +1,87 @@
+use metrique::writer::Entry;
+use metrique::{CloseValue, RootEntry, unit_of_work::metrics};
+use metrique::{InflectableEntry, NameStyle, ServiceMetrics};
+use metrique_core::CloseEntry;
+use metrique_writer::{AttachGlobalEntrySinkExt, BoxEntry, FormatExt, GlobalEntrySink};
+use metrique_writer_format_emf::Emf;
+
+#[metrics(prefix = "handler_a_")]
+#[derive(Default)]
+struct HandlerAMetrics {
+    request_count: usize,
+}
+
+#[metrics(prefix = "hanlder_b_")]
+#[derive(Default)]
+struct HandlerBMetrics {
+    request_count: usize,
+    number_of_rs_in_strawberry: usize,
+}
+
+#[derive(Default)]
+struct MultiEntry {
+    entries: Vec<Box<dyn FnOnce() -> BoxEntry + Send + Sync>>,
+}
+
+struct ClosedMultiEntry {
+    entries: Vec<BoxEntry>,
+}
+
+impl<Ns: NameStyle> InflectableEntry<Ns> for ClosedMultiEntry {
+    fn write<'a>(&'a self, w: &mut impl metrique_writer::EntryWriter<'a>) {
+        for e in &self.entries {
+            e.write(w)
+        }
+    }
+}
+
+impl CloseValue for MultiEntry {
+    type Closed = ClosedMultiEntry;
+
+    fn close(self) -> Self::Closed {
+        ClosedMultiEntry {
+            entries: self.entries.into_iter().map(|f| f()).collect(),
+        }
+    }
+}
+
+#[metrics]
+struct RequestMetrics {
+    #[metrics(flatten)]
+    rows: MultiEntry,
+}
+
+impl MultiEntry {
+    fn insert<T: Send + 'static, E: CloseEntry<Closed = T> + Send + Sync + 'static>(
+        &mut self,
+        e: E,
+    ) {
+        let f = Box::new(move || BoxEntry::new(RootEntry::new(e.close())));
+        self.entries.push(f)
+    }
+}
+
+fn handler_a() -> HandlerAMetrics {
+    HandlerAMetrics { request_count: 1 }
+}
+
+fn handler_b() -> HandlerBMetrics {
+    HandlerBMetrics {
+        request_count: 4,
+        number_of_rs_in_strawberry: 65,
+    }
+}
+
+fn main() {
+    let _handle = ServiceMetrics::attach_to_stream(
+        Emf::all_validations("DynamicMetrics".to_string(), vec![vec![]])
+            .output_to_makewriter(std::io::stdout),
+    );
+    let mut main_entry = RequestMetrics {
+        rows: Default::default(),
+    }
+    .append_on_drop(ServiceMetrics::sink());
+    main_entry.rows.insert(handler_a());
+    main_entry.rows.insert(handler_b());
+    drop(main_entry)
+}

--- a/metrique/examples/multi-flex.rs
+++ b/metrique/examples/multi-flex.rs
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This example demonstrates using MultiFlex to emit metrics for dynamic lists of items.
+//!
+//! MultiFlex is useful when you have a variable number of similar items to track metrics for,
+//! such as multiple database connections, API endpoints, or processing stages.
+
+use metrique::{
+    emf::Emf,
+    multi_flex::{FlexItem, MultiFlex},
+    unit_of_work::metrics,
+    writer::{AttachGlobalEntrySinkExt, FormatExt, GlobalEntrySink, sink::global_entry_sink},
+};
+use std::borrow::Cow;
+
+global_entry_sink! { ServiceMetrics }
+
+#[metrics]
+struct RequestMetrics {
+    request_id: String,
+    #[metrics(flatten, prefix = "endpoints")]
+    endpoints: MultiFlex<EndpointCall>,
+    total_calls: usize,
+}
+
+#[metrics]
+struct EndpointCall {
+    name: String,
+    response_time_ms: u64,
+    status_code: u16,
+}
+
+impl FlexItem for EndpointCall {
+    fn prefix_item(&self, idx: usize) -> Cow<'static, str> {
+        Cow::Owned(format!(".{idx}."))
+    }
+}
+
+fn main() {
+    // Initialize metrics sink
+    let _handle = ServiceMetrics::attach_to_stream(
+        Emf::builder("MultiFlexExample".to_string(), vec![vec!["request_id".to_string()]])
+            .build()
+            .output_to_makewriter(|| std::io::stdout().lock()),
+    );
+
+    // Create metrics for a request that calls multiple endpoints
+    let mut request_metrics = RequestMetrics {
+        request_id: "req-12345".to_string(),
+        endpoints: MultiFlex::default(),
+        total_calls: 0,
+    };
+
+    // Add metrics for each endpoint call
+    request_metrics.endpoints.push(EndpointCall {
+        name: "user-service".to_string(),
+        response_time_ms: 45,
+        status_code: 200,
+    });
+
+    request_metrics.endpoints.push(EndpointCall {
+        name: "auth-service".to_string(),
+        response_time_ms: 12,
+        status_code: 200,
+    });
+
+    request_metrics.endpoints.push(EndpointCall {
+        name: "billing-service".to_string(),
+        response_time_ms: 89,
+        status_code: 503,
+    });
+
+    request_metrics.total_calls = 3;
+
+    // Emit the metrics - this will create metrics like:
+    // endpoints.0.response_time_ms: 45
+    // endpoints.1.response_time_ms: 12  
+    // endpoints.2.response_time_ms: 89
+    drop(request_metrics.append_on_drop(ServiceMetrics::sink()));
+
+    println!("Metrics emitted for request with {} endpoint calls", 3);
+}

--- a/metrique/examples/multi-flex.rs
+++ b/metrique/examples/multi-flex.rs
@@ -17,6 +17,7 @@ use std::borrow::Cow;
 global_entry_sink! { ServiceMetrics }
 
 #[metrics]
+#[derive(Clone, Debug)]
 struct RequestMetrics {
     request_id: String,
     #[metrics(flatten, prefix = "endpoints")]
@@ -25,6 +26,19 @@ struct RequestMetrics {
 }
 
 #[metrics]
+struct MultiRequest {
+    #[metrics(flatten)]
+    requests: MultiFlex<RequestMetrics>,
+}
+
+impl FlexItem for RequestMetrics {
+    fn prefix_item(&self, _idx: usize) -> Cow<'static, str> {
+        Cow::Owned(format!("{}.", self.request_id))
+    }
+}
+
+#[metrics]
+#[derive(Debug, Clone)]
 struct EndpointCall {
     name: String,
     response_time_ms: u64,
@@ -39,10 +53,15 @@ impl FlexItem for EndpointCall {
 
 fn main() {
     // Initialize metrics sink
+    tracing_subscriber::fmt::init();
     let _handle = ServiceMetrics::attach_to_stream(
-        Emf::builder("MultiFlexExample".to_string(), vec![vec!["request_id".to_string()]])
-            .build()
-            .output_to_makewriter(|| std::io::stdout().lock()),
+        Emf::builder(
+            "MultiFlexExample".to_string(),
+            vec![vec!["request_id".to_string()]],
+        )
+        .skip_all_validations(true)
+        .build()
+        .output_to_makewriter(|| std::io::stdout().lock()),
     );
 
     // Create metrics for a request that calls multiple endpoints
@@ -73,11 +92,19 @@ fn main() {
 
     request_metrics.total_calls = 3;
 
+    let mut multi_requset = MultiRequest {
+        requests: Default::default(),
+    };
+    multi_requset.requests.push(request_metrics.clone());
+    let mut other_request = request_metrics.clone();
+    other_request.request_id = "request-2".to_string();
+    multi_requset.requests.push(other_request);
+
     // Emit the metrics - this will create metrics like:
     // endpoints.0.response_time_ms: 45
-    // endpoints.1.response_time_ms: 12  
+    // endpoints.1.response_time_ms: 12
     // endpoints.2.response_time_ms: 89
-    drop(request_metrics.append_on_drop(ServiceMetrics::sink()));
+    multi_requset.append_on_drop(ServiceMetrics::sink());
 
     println!("Metrics emitted for request with {} endpoint calls", 3);
 }

--- a/metrique/src/flex.rs
+++ b/metrique/src/flex.rs
@@ -21,7 +21,7 @@
 //!     #[metrics(timestamp)]
 //!     timestamp: SystemTime,
 //!     operation: &'static str,
-//!     
+//!
 //!     // Dynamic field - key name determined at runtime
 //!     #[metrics(flatten)]
 //!     dynamic_count: Flex<usize>,

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -45,6 +45,9 @@ pub mod timers;
 /// handle that work in the background.
 pub mod slot;
 
+/// [`MultiFlex`][multi_flex::MultiFlex] allows you to have multiple entries each with their own deterministic prefix
+pub mod multi_flex;
+
 use metrique_core::CloseEntry;
 use metrique_writer_core::Entry;
 use metrique_writer_core::EntryWriter;

--- a/metrique/src/multi_flex.rs
+++ b/metrique/src/multi_flex.rs
@@ -1,0 +1,155 @@
+use std::borrow::Cow;
+
+use metrique_core::{
+    CloseValue, InflectableEntry, NameStyle, NoPrefix,
+    concat::{ConstStr, MaybeConstStr},
+};
+use metrique_writer::{EntryWriter, Value};
+use metrique_writer_core::entry::SampleGroupElement;
+
+/// Trait for items that can be used in a [`MultiFlex`] collection.
+///
+/// Items must be able to generate a prefix for their metrics based on their position
+/// in the collection. This prefix is used to namespace the metrics for each item.
+pub trait FlexItem {
+    /// Generate a prefix for this item's metrics based on its index in the collection.
+    ///
+    /// The prefix should include separators (like `.0.`, `.1.`) to properly namespace
+    /// the metrics. For example, returning `.{idx}.` will create metrics like
+    /// `devices.0.size`, `devices.1.size`, etc.
+    ///
+    /// # Arguments
+    /// * `idx` - The zero-based index of this item in the MultiFlex collection
+    ///
+    /// # Returns
+    /// A string that will be used as a prefix for all metrics from this item
+    fn prefix_item(&self, idx: usize) -> Cow<'static, str>;
+}
+
+/// A collection type for emitting metrics from a dynamic list of items.
+///
+/// `MultiFlex<T>` allows you to collect metrics from a variable number of similar items,
+/// where each item's metrics are prefixed with its index in the collection. This is useful
+/// for scenarios like:
+/// - Multiple database connections with per-connection metrics
+/// - API calls to different endpoints
+/// - Processing stages with per-stage timing
+/// - Device metrics from multiple devices
+///
+/// # Example
+/// ```rust
+/// use metrique::{multi_flex::{FlexItem, MultiFlex}, unit_of_work::metrics};
+/// use std::borrow::Cow;
+///
+/// #[metrics]
+/// struct MyMetrics {
+///     #[metrics(flatten, prefix = "devices")]
+///     devices: MultiFlex<Device>,
+/// }
+///
+/// #[metrics]
+/// struct Device {
+///     id: String,
+///     size: usize,
+/// }
+///
+/// impl FlexItem for Device {
+///     fn prefix_item(&self, idx: usize) -> Cow<'static, str> {
+///         Cow::Owned(format!(".{idx}."))
+///     }
+/// }
+/// ```
+///
+/// This will emit metrics like `devices.0.size`, `devices.1.size`, etc.
+pub struct MultiFlex<T>(Vec<T>);
+
+impl<T> Default for MultiFlex<T> {
+    fn default() -> Self {
+        Self(vec![])
+    }
+}
+
+impl<T> MultiFlex<T> {
+    /// Add an item to the MultiFlex collection.
+    ///
+    /// The item will be assigned the next available index and its metrics will be
+    /// prefixed accordingly when the collection is emitted.
+    ///
+    /// # Arguments
+    /// * `item` - The item to add to the collection
+    pub fn push(&mut self, item: T) {
+        self.0.push(item);
+    }
+}
+
+/// The closed form of a [`MultiFlex`] collection, containing the processed entries
+/// ready for metric emission.
+///
+/// This struct is created when a `MultiFlex<T>` is closed and contains each item
+/// paired with its computed prefix. You typically don't interact with this type
+/// directly - it's used internally by the metrics system.
+pub struct MultiFlexEntry<T> {
+    entries: Vec<(Cow<'static, str>, T)>,
+}
+
+impl<T: CloseValue + FlexItem> CloseValue for MultiFlex<T> {
+    type Closed = MultiFlexEntry<T::Closed>;
+
+    fn close(self) -> Self::Closed {
+        MultiFlexEntry {
+            entries: self
+                .0
+                .into_iter()
+                .enumerate()
+                .map(|(idx, entry)| (entry.prefix_item(idx), entry.close()))
+                .collect(),
+        }
+    }
+}
+
+struct EmptyString;
+impl ConstStr for EmptyString {
+    const VAL: &'static str = "";
+}
+
+impl<T: InflectableEntry<NoPrefix<NS>>, NS: NameStyle> InflectableEntry<NS> for MultiFlexEntry<T> {
+    fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+        //writer.value(Cow::Borrowed(self.key.as_ref()), &self.value);
+        for (prefix, item) in &self.entries {
+            let external_prefix = <NS::Inflect<EmptyString, EmptyString, EmptyString, EmptyString> as MaybeConstStr>::MAYBE_VAL;
+            let prefix = format!("{external_prefix}{prefix}");
+
+            let prefix = Cow::Owned(prefix);
+            let mut prefixer = DynPrefix { prefix, writer };
+            InflectableEntry::<NoPrefix<NS>>::write(item, &mut prefixer);
+            item.write(&mut prefixer);
+        }
+    }
+
+    fn sample_group(&self) -> impl Iterator<Item = SampleGroupElement> {
+        // sample groups are ignored inside of multi-groups
+        vec![].into_iter()
+    }
+}
+
+struct DynPrefix<'b, T> {
+    prefix: Cow<'static, str>,
+    writer: &'b mut T,
+}
+
+impl<'a, 'b, T: EntryWriter<'a>> EntryWriter<'a> for DynPrefix<'b, T> {
+    fn timestamp(&mut self, timestamp: std::time::SystemTime) {
+        self.writer.timestamp(timestamp);
+    }
+
+    fn value(&mut self, name: impl Into<Cow<'a, str>>, value: &(impl Value + ?Sized)) {
+        let prefix = &self.prefix;
+        let name = name.into();
+        let name = format!("{prefix}{name}");
+        self.writer.value(name, value);
+    }
+
+    fn config(&mut self, config: &'a dyn metrique_writer::EntryConfig) {
+        self.writer.config(config);
+    }
+}

--- a/metrique/src/multi_flex.rs
+++ b/metrique/src/multi_flex.rs
@@ -61,6 +61,7 @@ pub trait FlexItem {
 /// ```
 ///
 /// This will emit metrics like `devices.0.size`, `devices.1.size`, etc.
+#[derive(Clone, Debug)]
 pub struct MultiFlex<T>(Vec<T>);
 
 impl<T> Default for MultiFlex<T> {
@@ -122,7 +123,6 @@ impl<T: InflectableEntry<NoPrefix<NS>>, NS: NameStyle> InflectableEntry<NS> for 
             let prefix = Cow::Owned(prefix);
             let mut prefixer = DynPrefix { prefix, writer };
             InflectableEntry::<NoPrefix<NS>>::write(item, &mut prefixer);
-            item.write(&mut prefixer);
         }
     }
 

--- a/metrique/tests/multi-flex.rs
+++ b/metrique/tests/multi-flex.rs
@@ -1,0 +1,51 @@
+use metrique::{
+    multi_flex::{FlexItem, MultiFlex},
+    test_util::{TestEntrySink, test_entry_sink},
+    unit_of_work::metrics,
+};
+use std::borrow::Cow;
+
+#[metrics]
+struct MyDevices {
+    // devices.0.size etc.
+    #[metrics(flatten, prefix = "devices")]
+    devices: MultiFlex<Device>,
+    top_level: usize,
+}
+
+#[metrics]
+struct Device {
+    id: String,
+    size: usize,
+}
+
+impl FlexItem for Device {
+    fn prefix_item(&self, idx: usize) -> std::borrow::Cow<'static, str> {
+        return Cow::Owned(format!(".{idx}."));
+    }
+}
+
+#[test]
+fn basic_test() {
+    let mut devices = MyDevices {
+        devices: Default::default(),
+        top_level: 5,
+    };
+
+    devices.devices.push(Device {
+        id: "hello".into(),
+        size: 10,
+    });
+    devices.devices.push(Device {
+        id: "also hello".into(),
+        size: 10000,
+    });
+    let TestEntrySink { sink, inspector } = test_entry_sink();
+    drop(devices.append_on_drop(sink));
+    let metrics = inspector.entries();
+    assert_eq!(metrics[0].metrics["devices.0.size"], 10);
+    assert_eq!(metrics[0].metrics["devices.1.size"], 10000);
+    assert_eq!(metrics[0].values["devices.0.id"], "hello");
+    assert_eq!(metrics[0].values["devices.1.id"], "also hello");
+    assert_eq!(metrics[0].metrics["top_level"], 5);
+}


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*
Produces `devices.0.size` etc.
```rust
#[metrics]
struct MyDevices {
    // devices.0.size etc.
    #[metrics(flatten, prefix = "devices")]
    devices: MultiFlex<Device>,
}

#[metrics]
struct Device {
    id: String,
    size: usize,
}

impl FlexItem for Device {
    fn prefix_item(&self, idx: usize) -> std::borrow::Cow<'static, str> {
        return Cow::Owned(format!(".{idx}."));
    }
}
```

The implementation does way more allocations than should be needed, but I didn't find any super easy ways to fix them with the current lifetime issues.

🔏 *By submitting this pull request*

- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
