### PR TITLE
minimal tokio version, document and check MSRV policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - "1.87" # Current MSRV due to extend_from_within
+          - "1.87.0" # Current MSRV due to extend_from_within
           - stable
           - nightly
         flags:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,36 @@ trusted publishing is unable to publish new crates. If you want to add a new cra
 
 Further publishing should happen via release-plz, without needing to manually work with tokens.
 
+## External version (MSRV, dependency) policy
+
+We reserve the right to increase the MSRV whenever new features make that useful or if
+testing the current MSRV ever becomes technically difficult. However, the MSRV should
+always at least be 8 weeks old.
+
+The MSRV of a crate should always be newer than the MSRV of all of its dependencies to avoid
+confusing Cargo's resolver. Currently for simplicity all metrique crates have the same MSRV,
+and this is tested by `cargo-toml-format.rs`.
+
+The code is tested by CI on the MSRV, on the current stable, and on the current nightly. In
+fact, the testing of compiler error messages is only at the MSRV, since otherwise the
+compiler message snapshots would have to be updated every 6 weeks.
+
+For `crates.io` versions, tests are run against both the "current" crates.io commit and against
+the lockfile checked into Github. The lockfile is normally updated on every release. Use with 
+older versions of crates.io dependencies is possible but may not be supported (if
+you encounter an issue that only happens with an old version of a dependency, our
+suggested solution will probably be to upgrade it).
+
+### Updating the MSRV
+
+The `cargo-toml-format` test should assert that the MSRV is updated in all the
+correct places, which are:
+
+1. The `cargo-toml-format` test
+2. The Cargo.toml of all packages
+3. The UI tests
+4. The test version in CI
+
 ## Code of Conduct
 
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ strum_macros = "0.27"
 syn = "2.0"
 synstructure = "0.13"
 tempfile = "3"
-tokio = { version = "1.47.0", default-features = false }
+tokio = { version = "1.38", default-features = false }
 tokio-util = "0.7.13"
 tracing = "0.1.41"
 tracing-appender = "0.2"

--- a/metrique-core/Cargo.toml
+++ b/metrique-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "metrique-core"
 version = "0.1.6"
 edition = "2024"
+rust-version = "1.87" # MSRV is 1.87 due to `extend_from_within` [and 1.86 due to trait upcasts]
 license = "Apache-2.0"
 description = "Library for working with unit of work metrics - core traits"
 repository = "https://github.com/awslabs/metrique"

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "metrique-macro"
 version = "0.1.5"
 edition = "2024"
+rust-version = "1.87" # MSRV is 1.87 due to `extend_from_within` [and 1.86 due to trait upcasts]
 license = "Apache-2.0"
 description = "Library for working with unit of work metrics - #[metrics] macro"
 repository = "https://github.com/awslabs/metrique"

--- a/metrique-timesource/Cargo.toml
+++ b/metrique-timesource/Cargo.toml
@@ -2,6 +2,7 @@
 name = "metrique-timesource"
 version = "0.1.4"
 edition = "2024"
+rust-version = "1.87" # MSRV is 1.87 due to `extend_from_within` [and 1.86 due to trait upcasts]
 license = "Apache-2.0"
 description = "Utilities for mocking Instant and SystemTime (part of metrique)"
 repository = "https://github.com/awslabs/metrique"

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 description = "Library for generating unit of work metrics"
 repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
+rust-version = "1.87" # MSRV is 1.87 due to `extend_from_within` [and 1.86 due to trait upcasts]
 
 [features]
 default = ["service-metrics"]

--- a/metrique/tests/cargo-toml-format.rs
+++ b/metrique/tests/cargo-toml-format.rs
@@ -2,6 +2,13 @@ use rstest::rstest;
 use std::fs;
 use std::path::PathBuf;
 
+const MSRV: &'static str = "1.87.0";
+
+// return just major and minor versions of msrv
+fn msrv_major_minor() -> String {
+    MSRV.split('.').take(2).collect::<Vec<_>>().join(".")
+}
+
 #[rstest]
 /// Test that the Cargo.tomls do not have issues that make `cargo publish` hard
 fn test_cargo_toml_format(
@@ -67,4 +74,73 @@ fn test_cargo_toml_format(
             }
         }
     }
+
+    // Check that there is a consistent package.rust-version amongst all packages since proper
+    // MSRV support requires it.
+    let package = toml.get("package").and_then(|p| p.as_table());
+    let workspace = toml.get("workspace").and_then(|p| p.as_table());
+
+    if package.is_none() && workspace.is_none() {
+        panic!(
+            "{} is neither a package nor a workspace?",
+            toml_path.display()
+        );
+    }
+
+    if let Some(package) = package {
+        let rust_version = package
+            .get("rust-version")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("Missing package.rust-version in {}", toml_path.display()));
+
+        assert_eq!(
+            rust_version,
+            msrv_major_minor(),
+            "package.rust-version in {} must equal MSRV ({})",
+            toml_path.display(),
+            msrv_major_minor()
+        );
+    }
+}
+
+#[rstest]
+/// Check that the UI tests run on the MSRV
+fn test_msrv_ui(
+    // .. since workspace root is parent of package root
+    #[files("../metrique/tests/ui.rs")] rs_path: PathBuf,
+) {
+    let msrv_string = format!("stable({MSRV})");
+    let file = std::fs::read_to_string(rs_path).unwrap();
+    assert!(
+        file.contains("rustversion"),
+        "ui.rs does not contain rustversion, this test needs to be updated to the new mechanism"
+    );
+    for line in file.lines() {
+        if line.contains("rustversion") {
+            assert!(
+                line.contains(&msrv_string),
+                "version {} does not contain msrv {}",
+                line,
+                msrv_string
+            );
+        }
+    }
+}
+
+#[rstest]
+/// Check that build yml tests on the MSRV
+fn test_build_yml(
+    // .. since workspace root is parent of package root
+    #[files("../Cargo.toml")] base_path: PathBuf,
+) {
+    let rs_path = base_path
+        .parent()
+        .unwrap()
+        .join(".github/workflows/build.yml");
+    let msrv_string = format!("- \"{MSRV}\" # Current MSRV");
+    let file = std::fs::read_to_string(rs_path).unwrap();
+    assert!(
+        file.contains(&msrv_string),
+        "build.yml must run at the msrv"
+    );
 }


### PR DESCRIPTION
📬 *Issue #, if available:*

Fixes #125 

✍️ *Description of changes:*

Declare support for Tokio 1.38. Also do MSRV policy correctly.

The MSRV policy should not matter now, but we might want to increase the MSRV some time in the future and it's good to be prepared.

Changed the CI to use the exact Rust version in rustup rather than the short one, since the UI test matches the exact version as well and I'll prefer no silent test breakage.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
