### PR TITLE
feat: generate docs for guard and handle types

### DIFF
--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -987,12 +987,16 @@ fn generate_on_drop_wrapper(
     target: &Ident,
     handle: &Ident,
 ) -> Ts2 {
+    let inner_str = inner.to_string();
+    let guard_str = guard.to_string();
     quote! {
+        #[doc = concat!("Metrics guard returned from [`", #inner_str, "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped.")]
         #vis type #guard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<#inner, Q>;
+        #[doc = concat!("Metrics handle returned from [`", #guard_str, "::handle`], similar to an `Arc<", #guard_str, ">`.")]
         #vis type #handle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<#inner, Q>;
 
         impl #inner {
-            #[doc = "Creates a AppendAndCloseOnDrop that will be automatically appended to `sink` on drop."]
+            #[doc = "Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop."]
             #vis fn append_on_drop<Q: ::metrique::writer::EntrySink<::metrique::RootEntry<#target>> + Send + Sync + 'static>(self, sink: Q) -> #guard<Q> {
                 ::metrique::append_and_close(self, sink)
             }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
@@ -112,16 +112,24 @@ impl metrique::CloseValue for RequestMetrics {
         }
     }
 }
+#[doc = concat!(
+    "Metrics guard returned from [`", "RequestMetrics",
+    "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
+)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
 >;
+#[doc = concat!(
+    "Metrics handle returned from [`", "RequestMetricsGuard",
+    "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
+)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
-    ///Creates a AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
@@ -86,16 +86,24 @@ impl metrique::CloseValue for RequestMetrics {
         }
     }
 }
+#[doc = concat!(
+    "Metrics guard returned from [`", "RequestMetrics",
+    "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
+)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
 >;
+#[doc = concat!(
+    "Metrics handle returned from [`", "RequestMetricsGuard",
+    "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
+)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
-    ///Creates a AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_prefix_warning_dot.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_prefix_warning_dot.snap
@@ -160,16 +160,24 @@ impl metrique::CloseValue for RequestMetrics {
         }
     }
 }
+#[doc = concat!(
+    "Metrics guard returned from [`", "RequestMetrics",
+    "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
+)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
 >;
+#[doc = concat!(
+    "Metrics handle returned from [`", "RequestMetricsGuard",
+    "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
+)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
-    ///Creates a AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__root_prefix_warning_dot.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__root_prefix_warning_dot.snap
@@ -78,16 +78,24 @@ impl metrique::CloseValue for RequestMetrics {
         }
     }
 }
+#[doc = concat!(
+    "Metrics guard returned from [`", "RequestMetrics",
+    "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
+)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
 >;
+#[doc = concat!(
+    "Metrics handle returned from [`", "RequestMetricsGuard",
+    "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
+)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
-    ///Creates a AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
@@ -146,16 +146,24 @@ impl metrique::CloseValue for RequestMetrics {
         }
     }
 }
+#[doc = concat!(
+    "Metrics guard returned from [`", "RequestMetrics",
+    "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
+)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
 >;
+#[doc = concat!(
+    "Metrics handle returned from [`", "RequestMetricsGuard",
+    "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
+)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
-    ///Creates a AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
@@ -112,16 +112,24 @@ impl metrique::CloseValue for RequestMetrics {
         }
     }
 }
+#[doc = concat!(
+    "Metrics guard returned from [`", "RequestMetrics",
+    "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
+)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
 >;
+#[doc = concat!(
+    "Metrics handle returned from [`", "RequestMetricsGuard",
+    "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
+)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
-    ///Creates a AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique/tests/deny-missing-docs.rs
+++ b/metrique/tests/deny-missing-docs.rs
@@ -1,0 +1,29 @@
+#![deny(missing_docs)]
+
+//! Crate docs
+
+// test that we don't break missing_docs
+
+use metrique::unit_of_work::metrics;
+
+#[metrics]
+/// Foo
+pub struct MyMetric {
+    #[metrics(sample_group)]
+    operation: Operation,
+}
+
+#[metrics(value, sample_group)]
+/// Bar
+pub struct Operation(OperationInner);
+
+#[metrics(value(string))]
+/// Baz
+pub enum OperationInner {
+    /// Foo
+    Foo,
+    /// Bar
+    Bar,
+}
+
+fn main() {}


### PR DESCRIPTION
looks nicer and avoids problems with `#[deny(missing_docs)]` in user code. Also, why not have documentation for guards since they appear in user's rustdocs.

📬 *Issue #, if available:*

✍️ *Description of changes:*

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
