### PR TITLE
fix: Use OrderedFloat for stable sorting in SortAndMerge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,7 @@ dependencies = [
  "metrique",
  "metrique-core",
  "metrique-writer",
+ "ordered-float",
  "rand",
  "rand_chacha",
  "rstest 0.23.0",

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -9,6 +9,7 @@ metrique-writer = { path = "../metrique-writer", version = "0.1.9"}
 metrique-core = { path = "../metrique-core", version = "0.1.9"}
 smallvec = "1.13"
 histogram.workspace = true
+ordered-float = "5"
 
 [dev-dependencies]
 metrique = { path = "../metrique", features = ["test-util"] }

--- a/metrique-aggregation/src/histogram.rs
+++ b/metrique-aggregation/src/histogram.rs
@@ -96,6 +96,7 @@
 use histogram::Config;
 use metrique_core::CloseValue;
 use metrique_writer::{MetricFlags, MetricValue, Observation, Value, ValueWriter};
+use ordered_float::OrderedFloat;
 use smallvec::SmallVec;
 use std::marker::PhantomData;
 
@@ -404,8 +405,7 @@ impl<const N: usize> AggregationStrategy for SortAndMerge<N> {
     }
 
     fn drain(&mut self) -> Vec<Observation> {
-        self.values
-            .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Greater));
+        self.values.sort_by_key(|v| OrderedFloat(*v));
         let mut observations = Vec::new();
         let mut iter = self.values.iter().copied().filter(|v| !v.is_nan());
 


### PR DESCRIPTION
fix https://github.com/awslabs/metrique/issues/145

The previous implementation used partial_cmp with unwrap_or(Greater) which
treats NaN as greater than all values, potentially causing sort instability
and panics. Now using OrderedFloat which provides total ordering for floats.

Changes:
- Added ordered-float dependency to metrique-aggregation
- Import OrderedFloat in histogram.rs
- Changed sort_by with partial_cmp to sort_by_key with OrderedFloat

Co-authored-by: Claude <claude@anthropic.com>