### PR TITLE
chore(metrique): re-export CloseEntry

### DIFF
--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -45,7 +45,6 @@ pub mod timers;
 /// handle that work in the background.
 pub mod slot;
 
-use metrique_core::CloseEntry;
 use metrique_writer_core::Entry;
 use metrique_writer_core::EntryWriter;
 use metrique_writer_core::entry::SampleGroupElement;
@@ -61,7 +60,9 @@ use keep_alive::Parent;
 use metrique_writer_core::EntrySink;
 use std::sync::Arc;
 
-pub use metrique_core::{CloseValue, CloseValueRef, Counter, InflectableEntry, NameStyle};
+pub use metrique_core::{
+    CloseEntry, CloseValue, CloseValueRef, Counter, InflectableEntry, NameStyle,
+};
 
 /// Unit types and utilities for metrics.
 ///


### PR DESCRIPTION
📬 *Issue #, if available:*

n/a

✍️ *Description of changes:*

Minor paper cut fix. We have [CloseEntry](https://docs.rs/metrique-core/0.1.9/metrique_core/trait.CloseEntry.html) in core, which is a simple type alias. When hand-implementing `CloseValue` for an entry, that is generally what you want so that it reflects parent inflection. 

🔏 *By submitting this pull request*

- [x ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
