### PR TITLE
feat!: Add MetricMap wrapper for better error messages in test_util

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,8 @@
+# Metrique Workspace Guidelines
+
+## Testing
+- Use `cargo nextest run` to run all tests in this workspace
+
 # Metrique Trait System
 
 ## Overview


### PR DESCRIPTION
## Better error messages on missing keys

Its pretty common to write a test, get the keys wrong, then need to debug the whole entry. This is _technically_ a breaking change, but hopefully doesn't actually break anyone in practice.

After this change, if a key is missing, you get an error like this:

```
   key 'SbeventStartTs' not found. Available keys: ["StartTsMillis", "CloseTs", "SubeventStartTs", "StartTsMicros", "SubeventEndTs", "StartTsSeconds"]
```