### PR TITLE
chore: remove vestigial test sink .as_u64() / add_f64() calls

### DIFF
--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -308,13 +308,13 @@ use crate::inflect::{name_contains_dot, name_contains_uninflectables, name_ends_
 /// let entry = metrique::test_util::test_metric(
 ///     Operation::Read(ReadMetrics { bytes_read: 1024 })
 /// );
-/// assert_eq!(entry.metrics["BytesRead"].as_u64(), 1024);
+/// assert_eq!(entry.metrics["BytesRead"], 1024);
 ///
 /// let entry = metrique::test_util::test_metric(
 ///     Operation::Write { latency: Duration::from_millis(5), bytes_written: 2048 }
 /// );
-/// assert_eq!(entry.metrics["Latency"].as_u64(), 5);
-/// assert_eq!(entry.metrics["BytesWritten"].as_u64(), 2048);
+/// assert_eq!(entry.metrics["Latency"], 5);
+/// assert_eq!(entry.metrics["BytesWritten"], 2048);
 /// ```
 ///
 /// ### Tag Field
@@ -340,7 +340,7 @@ use crate::inflect::{name_contains_dot, name_contains_uninflectables, name_ends_
 ///
 /// let entry = test_metric(Request::Read { bytes: 1024 });
 /// assert_eq!(entry.values["Operation"], "Read");  // Tag field with variant name
-/// assert_eq!(entry.metrics["Bytes"].as_u64(), 1024);
+/// assert_eq!(entry.metrics["Bytes"], 1024);
 /// ```
 ///
 /// The tag field name is specified explicitly and not affected by `prefix` or `rename_all`.

--- a/metrique-writer/src/test_util.rs
+++ b/metrique-writer/src/test_util.rs
@@ -378,7 +378,7 @@ pub struct TestEntrySink {
 ///
 ///     let entries = inspector.entries();
 ///     assert_eq!(entries[0].values["Operation"], "SayHello");
-///     assert_eq!(entries[0].metrics["NumberOfDucks"].as_u64(), 10);
+///     assert_eq!(entries[0].metrics["NumberOfDucks"], 10);
 /// }
 /// ```
 pub fn test_entry_sink() -> TestEntrySink {

--- a/metrique-writer/tests/test_test_util.rs
+++ b/metrique-writer/tests/test_test_util.rs
@@ -42,17 +42,15 @@ fn test_sink_records_entries() {
 
     assert_eq!(handle.entries().len(), 1);
     // check coercions & auto equality & auto ord
-    assert_eq!(handle.entries()[0].metrics["a"].as_u64(), 1);
+    assert_eq!(handle.entries()[0].metrics["a"], 1);
     assert_eq!(handle.entries()[0].metrics["a"].as_bool(), true);
     assert_eq!(handle.entries()[0].metrics["a"], true);
-    assert_eq!(handle.entries()[0].metrics["a"], 1);
     assert!(handle.entries()[0].metrics["a"] > 0);
 
-    assert_eq!(handle.entries()[0].metrics["a"].as_f64(), 1.0);
     assert_eq!(handle.entries()[0].metrics["a"], 1.0);
     assert!(handle.entries()[0].metrics["a"] > 0.0);
-    assert_eq!(handle.entries()[0].metrics["b"].as_f64(), 2.5);
-    assert_eq!(handle.entries()[0].metrics["b"].as_u64(), 2);
+    assert_eq!(handle.entries()[0].metrics["b"], 2.5);
+    assert_eq!(handle.entries()[0].metrics["b"], 2);
     assert_eq!(handle.entries()[0].values["c"], "label");
 }
 

--- a/metrique/examples/flex-dynamic-fields.rs
+++ b/metrique/examples/flex-dynamic-fields.rs
@@ -314,6 +314,6 @@ mod tests {
         // Check dynamic fields
         assert_eq!(entry.metrics["custom_metric"], 42);
         assert_eq!(entry.values["user_id"], "user123");
-        assert_eq!(entry.metrics["computed_value"].as_f64(), 3.14);
+        assert_eq!(entry.metrics["computed_value"], 3.14);
     }
 }

--- a/metrique/tests/timers.rs
+++ b/metrique/tests/timers.rs
@@ -138,7 +138,7 @@ async fn explicit_timer_stop() {
     // advance time 3 more seconds before dropping
     tokio::time::advance(Duration::from_secs(3)).await;
     drop(metric);
-    assert_eq!(inspector.entries()[0].metrics["Time"].as_f64(), 3.0);
+    assert_eq!(inspector.entries()[0].metrics["Time"], 3.0);
 }
 #[tokio::test]
 async fn subevents() {


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*
Cleaning up some lingering explicit `.as_u64()` / `.as_f64()` casts with the test sink.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
