### PR TITLE
Fix failing test from new histogram release

### DIFF
--- a/metrique-metricsrs/src/metrics_histogram.rs
+++ b/metrique-metricsrs/src/metrics_histogram.rs
@@ -230,7 +230,7 @@ mod tests {
         assert_eq!(
             h.drain(),
             vec![Bucket {
-                value: 4227858432,
+                value: 4227858431,
                 count: 1
             }]
         );


### PR DESCRIPTION
https://github.com/pelikan-io/rustcommon/pull/143/files changed the buckets to be one less than previously.


- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
