### PR TITLE
chore: Enable rustdoc-scrape-examples for docs.rs

### DIFF
--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -33,6 +33,11 @@ uuid = { version = "1", features = ["v4"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
+# We need to name one example so that our examples that use dev-dependencies get scraped
+[[example]]
+name = "embedded"
+doc-scrape-examples = true
+
 [[bench]]
 name = "aggregation"
 harness = false

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -66,7 +66,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 rstest = { workspace = true }
 
+# We need to name one example so that our examples that use dev-dependencies get scraped
+[[example]]
+name = "unit-of-work-simple"
+doc-scrape-examples = true
+
 [package.metadata.docs.rs]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+echo "=== Running Local CI Checks ==="
+
+# Format check
+echo "→ Checking formatting..."
+cargo +nightly fmt --all -- --check || { echo "FAILED: cargo +nightly fmt --all -- --check"; exit 1; }
+
+# Clippy
+echo "→ Running clippy..."
+cargo clippy --workspace --all-features -- -D warnings || { echo "FAILED: cargo clippy --workspace --all-features -- -D warnings"; exit 1; }
+
+# Security audit
+echo "→ Running security audit..."
+cargo audit || { echo "FAILED: cargo audit"; exit 1; }
+
+# Build and test matrix
+for toolchain in 1.89.0 stable nightly; do
+    for flags in "--all-features" "--no-default-features"; do
+        echo "→ Building with $toolchain $flags..."
+        
+        if [ "$toolchain" != "stable" ]; then
+            rm -fv Cargo.lock
+        fi
+        
+        cargo +$toolchain build --quiet $flags || { echo "FAILED: cargo +$toolchain build --quiet $flags"; exit 1; }
+        cargo +$toolchain test --quiet $flags || { echo "FAILED: cargo +$toolchain test --quiet $flags"; exit 1; }
+        
+        if [ "$toolchain" == "nightly" ] && [ "$flags" == "--all-features" ]; then
+            echo "→ Building docs with nightly..."
+            RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +$toolchain doc --quiet --no-deps $flags -Zunstable-options -Zrustdoc-scrape-examples || { echo "FAILED: doc build"; exit 1; }
+        fi
+    done
+done
+
+echo "✓ All CI checks passed!"

--- a/scripts/open-docs.sh
+++ b/scripts/open-docs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps --all-features -Zunstable-options -Zrustdoc-scrape-examples --open


### PR DESCRIPTION
✍️ *Description of changes:*

Added cargo-args with -Zrustdoc-scrape-examples to package.metadata.docs.rs so that docs.rs will show example code snippets inline with API documentation.

This should help a little bit on example-discoverability. I also added a couple of QOL scripts

<img width="1050" height="329" alt="Screenshot 2026-01-14 at 10 43 50 AM" src="https://github.com/user-attachments/assets/6b2898ec-4223-42e7-b8dd-0c434af78668" />


🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
