### PR TITLE
feat: Add Distribution wrapper type to metrique_aggregation

### DIFF
--- a/metrique-aggregation/examples/embedded.rs
+++ b/metrique-aggregation/examples/embedded.rs
@@ -25,6 +25,7 @@ struct BackendCall {
     #[aggregate(strategy = Sum)]
     requests_made: usize,
 
+    // To preserve all values precisely, use `value::Distribution`
     #[aggregate(strategy = Histogram<Duration>)]
     #[metrics(unit = Millisecond)]
     latency: Duration,

--- a/metrique-aggregation/src/histogram.rs
+++ b/metrique-aggregation/src/histogram.rs
@@ -146,6 +146,9 @@ pub trait SharedAggregationStrategy {
 /// Use this when you have many observations of the same metric within a single unit of work.
 /// The histogram aggregates values in memory and emits them as a single metric entry.
 ///
+/// If you want to preserve all values instead of bucketing them, use `Histogram<T, SortAndMerge>` as
+/// the strategy.
+///
 /// Requires `&mut self` to add values. For thread-safe access, use [`SharedHistogram`].
 pub struct Histogram<T, S = ExponentialAggregationStrategy> {
     strategy: S,

--- a/metrique-aggregation/src/value.rs
+++ b/metrique-aggregation/src/value.rs
@@ -1,6 +1,11 @@
 //! Strategies for aggregating values
 
-use crate::traits::AggregateValue;
+use metrique_writer::MetricValue;
+
+use crate::{
+    histogram::{Histogram, SortAndMerge},
+    traits::AggregateValue,
+};
 use std::{marker::PhantomData, ops::AddAssign};
 
 /// Sums values when aggregating
@@ -79,6 +84,19 @@ where
 
     fn insert(accum: &mut Self::Aggregated, value: T) {
         T::merge(accum, value);
+    }
+}
+
+/// Distribution preserves all values while compressing duplicates
+///
+/// This is effectively a type alias for `Histogram<T, SortAndMerge>`, however,
+/// when used as an aggregate strategy, it avoids the needs to name `T`.
+pub struct Distribution;
+impl<T: MetricValue> AggregateValue<T> for Distribution {
+    type Aggregated = Histogram<T, SortAndMerge>;
+
+    fn insert(accum: &mut Self::Aggregated, value: T) {
+        accum.add_value(value);
     }
 }
 

--- a/metrique-writer/src/value/distribution.rs
+++ b/metrique-writer/src/value/distribution.rs
@@ -17,6 +17,12 @@ use metrique_writer_core::value::MetricFlags;
 
 /// Collects a distribution of [`Value`]s that will be recorded individually under a single name.
 ///
+/// <div class="warning">
+///    This type is generally intended for internal use. If you want to record multiple values
+///    with duplicates merged use <code>metrique_aggregation::value::Distribution</code>
+///    or <code>metrique_aggregation::histogram::Histogram&lt;T, SortAndMerge&gt;</code>
+/// </div>
+///
 /// For example,
 /*
 /// ```


### PR DESCRIPTION
✍️ *Description of changes:* Adds `Distribution` as an alias for `Histogram<T, SortAndMerge>`

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
