### PR TITLE
Improve robustness of #[aggregate] proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ name = "metrique-macro"
 version = "0.1.10"
 dependencies = [
  "Inflector",
+ "assert2",
  "darling",
  "insta",
  "metrique",

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -23,6 +23,7 @@ insta = { workspace = true }
 prettyplease = { workspace = true }
 metrique = { path = "../metrique", features = ["test-util"] }
 metrique-aggregation = { path = "../metrique-aggregation" }
+assert2 = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Improve the robustness of the `#[aggregate]` proc macro -- improve error messages on unknown fields, error out on duplicate fields, ensure it is generally robust

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
