### PR TITLE
chore: release 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/awslabs/metrique/compare/metrique-v0.1.15...metrique-v0.1.16) - 2026-02-01
+
+### Added
+
+- impl Debug for Slot, SlotGuard, and AppendAndCloseOnDrop ([#194](https://github.com/awslabs/metrique/pull/194))
+
+- Add `set_test_sink_on_current_tokio_runtime` to simplify testing with Tokio ([#193](https://github.com/awslabs/metrique/pull/193))
+
+### Other
+
 ## [0.1.15](https://github.com/awslabs/metrique/compare/metrique-v0.1.14...metrique-v0.1.15) - 2026-01-16
 
 ### Fixes 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "assert2",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-aggregation"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "assert2",
  "divan",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-core"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "itertools",
  "metrique",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-macro"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "Inflector",
  "assert2",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-metricsrs"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "derive-where",
  "futures",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-service-metrics"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "metrique",
  "metrique-writer",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "ahash",
  "assert-json-diff",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "assert-json-diff",
  "derive-where",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-emf"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "assert-json-diff",
  "assert_approx_eq",

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-aggregation"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.89" # build.yml
 license = "Apache-2.0"
@@ -10,13 +10,13 @@ readme = "README.md"
 
 [dependencies]
 metrique = { path = "../metrique", version = "0.1" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.15" }
-metrique-core = { path = "../metrique-core", version = "0.1.13" }
-metrique-macro = { path = "../metrique-macro", version = "0.1.12" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.16" }
+metrique-core = { path = "../metrique-core", version = "0.1.14" }
+metrique-macro = { path = "../metrique-macro", version = "0.1.13" }
 smallvec.workspace = true
 histogram.workspace = true
 ordered-float.workspace = true
-metrique-writer-core = { version = "0.1.10", path = "../metrique-writer-core" }
+metrique-writer-core = { version = "0.1.11", path = "../metrique-writer-core" }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 metrique-timesource = { version = "0.1.7", path = "../metrique-timesource", features = ["test-util"] }
 hashbrown.workspace = true

--- a/metrique-core/Cargo.toml
+++ b/metrique-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-core"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
 [dependencies]
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.10" }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11" }
 itertools = { workspace = true }
 
 [dev-dependencies]

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-macro"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-metricsrs/Cargo.toml
+++ b/metrique-metricsrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-metricsrs"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -21,8 +21,8 @@ histogram = { workspace = true }
 pin-project = { workspace = true }
 metrics_024 = { workspace = true, optional = true }
 metrics-util_020 = { workspace = true, optional = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.10", default-features = false }
-metrique-writer = { path = "../metrique-writer", version = "0.1.15", default-features = false }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11", default-features = false }
+metrique-writer = { path = "../metrique-writer", version = "0.1.16", default-features = false }
 metrique-timesource = { path = "../metrique-timesource", version = "0.1.7" }
 futures = { workspace = true, default-features = false, features = ["executor"] }
 tokio = { workspace = true, default-features = false, features = [

--- a/metrique-service-metrics/Cargo.toml
+++ b/metrique-service-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-service-metrics"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
 [dependencies]
-metrique-writer = { path = "../metrique-writer", version = "0.1.15" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.16" }
 
 [dev-dependencies]
 

--- a/metrique-writer-core/Cargo.toml
+++ b/metrique-writer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-core"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-writer-format-emf/Cargo.toml
+++ b/metrique-writer-format-emf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-format-emf"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -19,8 +19,8 @@ rand = { workspace = true }
 hashbrown = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.10" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.15" }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.16" }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }

--- a/metrique-writer/Cargo.toml
+++ b/metrique-writer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -26,9 +26,9 @@ tokio = { workspace = true, optional = true, default-features = false, features 
 tracing = { workspace = true, optional = true }
 metrics_024 = { workspace = true, optional = true }
 metrics-util_020 = { workspace = true, optional = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.10" }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11" }
 metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.7" }
-metrique-core = { path = "../metrique-core", version = "0.1.13" }
+metrique-core = { path = "../metrique-core", version = "0.1.14" }
 ordered-float = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 license = "Apache-2.0"
 description = "Library for generating unit of work metrics"
@@ -25,14 +25,14 @@ metrics_rs_024 = ["metrics-rs-024"]
 
 [dependencies]
 tokio = { workspace = true, features = ["sync"] }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.10" }
-metrique-macro = { path = "../metrique-macro", version = "0.1.12" }
-metrique-core = { path = "../metrique-core", version = "0.1.13" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.15" }
-metrique-metricsrs = { path = "../metrique-metricsrs", version = "0.1.15", optional = true }
-metrique-service-metrics = { path = "../metrique-service-metrics", version = "0.1.14", optional = true }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11" }
+metrique-macro = { path = "../metrique-macro", version = "0.1.13" }
+metrique-core = { path = "../metrique-core", version = "0.1.14" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.16" }
+metrique-metricsrs = { path = "../metrique-metricsrs", version = "0.1.16", optional = true }
+metrique-service-metrics = { path = "../metrique-service-metrics", version = "0.1.15", optional = true }
 metrique-timesource = { path = "../metrique-timesource", version = "0.1.7" }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf", version = "0.1.14", optional = true }
+metrique-writer-format-emf = { path = "../metrique-writer-format-emf", version = "0.1.15", optional = true }
 metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.7" }
 tracing-appender = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }


### PR DESCRIPTION
Release PR for version 0.1.16

Updates:
- metrique-writer-core: 0.1.10 -> 0.1.11
- metrique-macro: 0.1.12 -> 0.1.13
- metrique-writer: 0.1.15 -> 0.1.16
- metrique-writer-format-emf: 0.1.14 -> 0.1.15
- metrique: 0.1.15 -> 0.1.16
- metrique-core: 0.1.13 -> 0.1.14
- metrique-metricsrs: 0.1.15 -> 0.1.16
- metrique-service-metrics: 0.1.14 -> 0.1.15
- metrique-aggregation: 0.1.4 -> 0.1.5