### PR TITLE
ci: skip docs.rs check on release-* branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
   docs-rs:
     name: Docs.rs Build Check
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-') }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
The docs.rs check will always fail on release PRs since the versions haven't been published yet. Skip this check for branches starting with 'release-'.