### PR TITLE
chore: release 0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/awslabs/metrique/compare/metrique-v0.1.16...metrique-v0.1.17) - 2026-02-07
+
+### Fixed
+
+- Fix issues with `#[derive(Debug)]` on metrics entries ([#200](https://github.com/awslabs/metrique/pull/200))
+
 ## [0.1.16](https://github.com/awslabs/metrique/compare/metrique-v0.1.15...metrique-v0.1.16) - 2026-02-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "assert2",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-aggregation"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "assert2",
  "divan",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-core"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "itertools",
  "metrique",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-metricsrs"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "derive-where",
  "futures",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-service-metrics"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "metrique",
  "metrique-writer",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "ahash",
  "assert-json-diff",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "assert-json-diff",
  "derive-where",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-emf"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "assert-json-diff",
  "assert_approx_eq",

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-aggregation"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version = "1.89" # build.yml
 license = "Apache-2.0"
@@ -10,13 +10,13 @@ readme = "README.md"
 
 [dependencies]
 metrique = { path = "../metrique", version = "0.1" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.16" }
-metrique-core = { path = "../metrique-core", version = "0.1.14" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.17" }
+metrique-core = { path = "../metrique-core", version = "0.1.15" }
 metrique-macro = { path = "../metrique-macro", version = "0.1.13" }
 smallvec.workspace = true
 histogram.workspace = true
 ordered-float.workspace = true
-metrique-writer-core = { version = "0.1.11", path = "../metrique-writer-core" }
+metrique-writer-core = { version = "0.1.12", path = "../metrique-writer-core" }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 metrique-timesource = { version = "0.1.7", path = "../metrique-timesource", features = ["test-util"] }
 hashbrown.workspace = true

--- a/metrique-core/Cargo.toml
+++ b/metrique-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-core"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
 [dependencies]
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11" }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.12" }
 itertools = { workspace = true }
 
 [dev-dependencies]

--- a/metrique-metricsrs/Cargo.toml
+++ b/metrique-metricsrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-metricsrs"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -21,8 +21,8 @@ histogram = { workspace = true }
 pin-project = { workspace = true }
 metrics_024 = { workspace = true, optional = true }
 metrics-util_020 = { workspace = true, optional = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11", default-features = false }
-metrique-writer = { path = "../metrique-writer", version = "0.1.16", default-features = false }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.12", default-features = false }
+metrique-writer = { path = "../metrique-writer", version = "0.1.17", default-features = false }
 metrique-timesource = { path = "../metrique-timesource", version = "0.1.7" }
 futures = { workspace = true, default-features = false, features = ["executor"] }
 tokio = { workspace = true, default-features = false, features = [

--- a/metrique-service-metrics/Cargo.toml
+++ b/metrique-service-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-service-metrics"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
 [dependencies]
-metrique-writer = { path = "../metrique-writer", version = "0.1.16" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.17" }
 
 [dev-dependencies]
 

--- a/metrique-writer-core/Cargo.toml
+++ b/metrique-writer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-core"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-writer-format-emf/Cargo.toml
+++ b/metrique-writer-format-emf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-format-emf"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -19,8 +19,8 @@ rand = { workspace = true }
 hashbrown = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.16" }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.12" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.17" }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }

--- a/metrique-writer/Cargo.toml
+++ b/metrique-writer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -26,9 +26,9 @@ tokio = { workspace = true, optional = true, default-features = false, features 
 tracing = { workspace = true, optional = true }
 metrics_024 = { workspace = true, optional = true }
 metrics-util_020 = { workspace = true, optional = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11" }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.12" }
 metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.7" }
-metrique-core = { path = "../metrique-core", version = "0.1.14" }
+metrique-core = { path = "../metrique-core", version = "0.1.15" }
 ordered-float = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 license = "Apache-2.0"
 description = "Library for generating unit of work metrics"
@@ -25,14 +25,14 @@ metrics_rs_024 = ["metrics-rs-024"]
 
 [dependencies]
 tokio = { workspace = true, features = ["sync"] }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.11" }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.12" }
 metrique-macro = { path = "../metrique-macro", version = "0.1.13" }
-metrique-core = { path = "../metrique-core", version = "0.1.14" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.16" }
-metrique-metricsrs = { path = "../metrique-metricsrs", version = "0.1.16", optional = true }
-metrique-service-metrics = { path = "../metrique-service-metrics", version = "0.1.15", optional = true }
+metrique-core = { path = "../metrique-core", version = "0.1.15" }
+metrique-writer = { path = "../metrique-writer", version = "0.1.17" }
+metrique-metricsrs = { path = "../metrique-metricsrs", version = "0.1.17", optional = true }
+metrique-service-metrics = { path = "../metrique-service-metrics", version = "0.1.16", optional = true }
 metrique-timesource = { path = "../metrique-timesource", version = "0.1.7" }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf", version = "0.1.15", optional = true }
+metrique-writer-format-emf = { path = "../metrique-writer-format-emf", version = "0.1.16", optional = true }
 metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.7" }
 tracing-appender = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }


### PR DESCRIPTION
Release version 0.1.17

This PR updates versions and changelog for the 0.1.17 release.

## Changes
- metrique-writer-core: 0.1.11 -> 0.1.12 (✓ API compatible changes)
- metrique: 0.1.16 -> 0.1.17 (✓ API compatible changes)
- metrique-core: 0.1.14 -> 0.1.15
- metrique-writer: 0.1.16 -> 0.1.17
- metrique-metricsrs: 0.1.16 -> 0.1.17
- metrique-service-metrics: 0.1.15 -> 0.1.16
- metrique-writer-format-emf: 0.1.15 -> 0.1.16
- metrique-aggregation: 0.1.5 -> 0.1.6

## Changelog
- Add `#[derive(Debug)]` to TimestampValue (#200)