### PR TITLE
chore: release 0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/awslabs/metrique/compare/metrique-v0.1.17...metrique-v0.1.18) - 2026-02-14
+
+### Other
+
+- Add Debug derive to SetEntryDimensions ([#202](https://github.com/awslabs/metrique/pull/202))
+
 ## [0.1.17](https://github.com/awslabs/metrique/compare/metrique-v0.1.16...metrique-v0.1.17) - 2026-02-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "assert2",

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 license = "Apache-2.0"
 description = "Library for generating unit of work metrics"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.18
- Update CHANGELOG with changes from PR #202

## Changes
- Add Debug derive to SetEntryDimensions

This release follows the standard release process using release-plz.