### PR TITLE
Add AggregateValue<HistogramClosed<T>> impl and histogram aggregation example

### DIFF
--- a/metrique-aggregation/examples/histogram_aggregation.rs
+++ b/metrique-aggregation/examples/histogram_aggregation.rs
@@ -1,0 +1,74 @@
+//! Example: Aggregating Histograms within Aggregated Structs
+//!
+//! This example demonstrates aggregating entries where the source type already
+//! contains a `Histogram` field. This is useful when sub-operations themselves
+//! collect distributions that you want to merge into a single aggregated entry.
+//!
+//! For example, each backend shard might return latency distributions from its
+//! internal processing, and you want to merge all those distributions together.
+
+use metrique::emf::Emf;
+use metrique::unit::Millisecond;
+use metrique::unit_of_work::metrics;
+use metrique::writer::{FormatExt, sink::FlushImmediatelyBuilder};
+use metrique_aggregation::aggregate;
+use metrique_aggregation::aggregator::Aggregate;
+use metrique_aggregation::histogram::Histogram;
+use metrique_aggregation::value::Sum;
+use std::time::Duration;
+
+/// Metrics from a single backend shard, which itself contains a histogram
+/// of internal processing latencies observed during that shard's work.
+#[aggregate]
+#[metrics]
+struct ShardResult {
+    #[aggregate(strategy = Sum)]
+    rows_scanned: usize,
+
+    /// Each shard reports a distribution of per-row processing latencies.
+    /// When aggregated, these histograms are merged together.
+    #[aggregate(strategy = Histogram<Duration>)]
+    #[metrics(unit = Millisecond)]
+    per_row_latency: Histogram<Duration>,
+}
+
+/// Top-level query metrics that aggregate results from all shards.
+#[metrics(rename_all = "PascalCase")]
+struct QueryMetrics {
+    query_id: &'static str,
+    #[metrics(flatten)]
+    shard_results: Aggregate<ShardResult>,
+}
+
+fn main() {
+    let emf_sink = Emf::builder("HistogramAggregation".to_string(), vec![vec![]])
+        .build()
+        .output_to_makewriter(|| std::io::stdout().lock());
+    let sink = FlushImmediatelyBuilder::new().build_boxed(emf_sink);
+
+    let mut query = QueryMetrics {
+        query_id: "q-12345",
+        shard_results: Aggregate::default(),
+    };
+
+    // Simulate 3 shards, each returning their own latency distribution
+    for shard_idx in 0..3 {
+        let mut shard = ShardResult {
+            rows_scanned: 100,
+            per_row_latency: Histogram::default(),
+        };
+        // Each shard observed some per-row latencies
+        for row in 0..10 {
+            let latency = Duration::from_micros(200 + (shard_idx * 50) + (row * 10));
+            shard.per_row_latency.add_value(latency);
+        }
+        query.shard_results.insert(shard);
+    }
+
+    // Emit — the per_row_latency histograms from all shards are merged
+    drop(query.append_on_drop(sink));
+
+    // Output will contain a single entry with:
+    // - RowsScanned: 300 (summed across 3 shards)
+    // - PerRowLatency: merged distribution of all 30 observations
+}

--- a/metrique-macro/src/aggregate.rs
+++ b/metrique-macro/src/aggregate.rs
@@ -232,9 +232,9 @@ pub(crate) fn generate_aggregate_strategy_impl(
         .and_then(|attrs| attrs.unit)
         .is_some();
 
-        // In entry mode with unit, need to dereference WithUnit wrapper
+        // In entry mode with unit, need to unwrap WithUnit wrapper
         let entry_value = if has_unit {
-            quote! { *input.#name }
+            quote! { input.#name.into_inner() }
         } else {
             quote! { input.#name }
         };

--- a/metrique-macro/src/snapshots/metrique_macro__aggregate__tests__aggregate_entry_mode.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__aggregate__tests__aggregate_entry_mode.snap
@@ -28,7 +28,7 @@ for <ApiCall as metrique::CloseValue>::Closed {
             SortAndMerge,
         > as ::metrique_aggregation::__macro_plumbing::AggregateValue<
             <Timer as metrique::CloseValue>::Closed,
-        >>::insert(&mut accum.latency, *input.latency);
+        >>::insert(&mut accum.latency, input.latency.into_inner());
     }
 }
 impl ::metrique_aggregation::__macro_plumbing::AggregateStrategy for ApiCall {


### PR DESCRIPTION
## Summary

Enables aggregating structs that contain `Histogram` fields via the `#[aggregate]` macro.

### Changes

1. **`AggregateValue<HistogramClosed<T>>` for `Histogram<T, S>`** — When the `#[aggregate]` macro closes a source type, `Histogram<T>` fields become `HistogramClosed<T>`. This new impl replays those closed observations into the accumulator histogram, enabling histogram-in-histogram aggregation.

2. **Macro fix: `into_inner()` instead of deref** — The aggregate macro previously used `*input.field` to unwrap `WithUnit` wrappers, which fails for non-`Copy` closed types like `HistogramClosed`. Changed to `input.field.into_inner()`.

3. **New example: `histogram_aggregation`** — Demonstrates aggregating structs where each entry already contains a `Histogram` field (e.g., each backend shard reports its own latency distribution, and they get merged together).

### Testing

All 341 tests pass. One insta snapshot updated to reflect the macro change.