### PR TITLE
chore: release 0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/awslabs/metrique/compare/metrique-v0.1.18...metrique-v0.1.19) - 2026-02-18
+
+### Added
+
+- Add runtime-wide time source override for tokio ([#206](https://github.com/awslabs/metrique/pull/206))
+
+- Histogram fields can now be aggregated across structs using `#[aggregate(strategy = Histogram<T>)]`. This enables merging latency distributions from multiple sources (e.g. fan-out shards) into a single combined distribution. ([#204](https://github.com/awslabs/metrique/pull/204))
+
 ## [0.1.18](https://github.com/awslabs/metrique/compare/metrique-v0.1.17...metrique-v0.1.18) - 2026-02-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "assert2",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-aggregation"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "assert2",
  "divan",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-macro"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "Inflector",
  "assert2",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-metricsrs"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "derive-where",
  "futures",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-timesource"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "metrique-timesource",
  "tokio",

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-aggregation"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 rust-version = "1.89" # build.yml
 license = "Apache-2.0"
@@ -12,13 +12,13 @@ readme = "README.md"
 metrique = { path = "../metrique", version = "0.1" }
 metrique-writer = { path = "../metrique-writer", version = "0.1.17" }
 metrique-core = { path = "../metrique-core", version = "0.1.15" }
-metrique-macro = { path = "../metrique-macro", version = "0.1.13" }
+metrique-macro = { path = "../metrique-macro", version = "0.1.14" }
 smallvec.workspace = true
 histogram.workspace = true
 ordered-float.workspace = true
 metrique-writer-core = { version = "0.1.12", path = "../metrique-writer-core" }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
-metrique-timesource = { version = "0.1.7", path = "../metrique-timesource", features = ["test-util"] }
+metrique-timesource = { version = "0.1.8", path = "../metrique-timesource", features = ["test-util"] }
 hashbrown.workspace = true
 
 [dev-dependencies]

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-macro"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-metricsrs/Cargo.toml
+++ b/metrique-metricsrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-metricsrs"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ metrics_024 = { workspace = true, optional = true }
 metrics-util_020 = { workspace = true, optional = true }
 metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.12", default-features = false }
 metrique-writer = { path = "../metrique-writer", version = "0.1.17", default-features = false }
-metrique-timesource = { path = "../metrique-timesource", version = "0.1.7" }
+metrique-timesource = { path = "../metrique-timesource", version = "0.1.8" }
 futures = { workspace = true, default-features = false, features = ["executor"] }
 tokio = { workspace = true, default-features = false, features = [
     "sync", "time"

--- a/metrique-timesource/Cargo.toml
+++ b/metrique-timesource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-timesource"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 license = "Apache-2.0"
 description = "Library for generating unit of work metrics"
@@ -26,12 +26,12 @@ metrics_rs_024 = ["metrics-rs-024"]
 [dependencies]
 tokio = { workspace = true, features = ["sync"] }
 metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.12" }
-metrique-macro = { path = "../metrique-macro", version = "0.1.13" }
+metrique-macro = { path = "../metrique-macro", version = "0.1.14" }
 metrique-core = { path = "../metrique-core", version = "0.1.15" }
 metrique-writer = { path = "../metrique-writer", version = "0.1.17" }
-metrique-metricsrs = { path = "../metrique-metricsrs", version = "0.1.17", optional = true }
+metrique-metricsrs = { path = "../metrique-metricsrs", version = "0.1.18", optional = true }
 metrique-service-metrics = { path = "../metrique-service-metrics", version = "0.1.16", optional = true }
-metrique-timesource = { path = "../metrique-timesource", version = "0.1.7" }
+metrique-timesource = { path = "../metrique-timesource", version = "0.1.8" }
 metrique-writer-format-emf = { path = "../metrique-writer-format-emf", version = "0.1.16", optional = true }
 metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.7" }
 tracing-appender = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
- Bump version to 0.1.19 (and dependent crates)
- Update CHANGELOG with changes from PRs #204 and #206

## Changes
- Add runtime-wide time source override for tokio (#206)
- Histogram fields can now be aggregated across structs using `#[aggregate(strategy = Histogram<T>)]` (#204)