### PR TITLE
feat: add LocalFormat for human-readable local development metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Metrique Workspace Guidelines
 
+## Public API Surface
+- Enums and enum variants should be `#[non_exhaustive]` so new fields/variants can be added without breaking changes.
+- Prefer constructor methods over exposing enum variant fields directly. For example, use `LocalFormat::json()` and `LocalFormat::compact_json()` instead of requiring users to write `OutputStyle::Json { compact: true }`. This allows adding new settings to variants in the future without breaking callers.
+
 ## Testing
 - Use `cargo +1.89 nextest run` to run all tests in this workspace
 - To run the full suite of tests CI will run, see `scripts/ci-local.sh`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819b44bc7c87d9117eb522f14d46e918add69ff12713c475946b0a29363ed1c2"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470252db18ecc35fd766c0891b1e3ec6cbbcd62507e85276c01bf75d8e94d4a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +757,7 @@ dependencies = [
  "assert2",
  "chrono",
  "itoa",
+ "jiff",
  "metrique",
  "metrique-core",
  "metrique-macro",
@@ -747,6 +789,7 @@ dependencies = [
  "divan",
  "hashbrown",
  "histogram",
+ "insta",
  "metrique",
  "metrique-core",
  "metrique-macro",
@@ -758,6 +801,7 @@ dependencies = [
  "rand_chacha",
  "rstest",
  "rustversion",
+ "serde_json",
  "smallvec",
  "tokio",
  "tracing",
@@ -1044,6 +1088,15 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ Inflector = "0.11.4"
 insta = "1.36"
 itertools = { version = "0.14", default-features = false }
 itoa = "1.0.15"
+jiff = "0.2"
 metrics_024 = { package = "metrics", version = "0.24" }
 metrics-util_020 = { package = "metrics-util", version = "0.20" }
 ordered-float = "5.1.0"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ fn initialize_metrics(service_log_dir: PathBuf) -> AttachHandle {
 
 You can either attach it to a global destination or thread the queue to the location you construct your metrics object directly. Currently, only formatters for [Amazon EMF] are provided, but more may be added in the future.
 
+For local development, [`metrique::local::LocalFormat`] provides human-readable output (pretty-printed key-value pairs, JSON, or markdown tables) with automatic histogram percentile computation. See the [module docs](https://docs.rs/metrique/latest/metrique/local/index.html) for a guide on implementing your own custom format.
+
 You can also implement a custom format using the [`Format`] trait.
 If you do, you can optionally implement a custom [`EntrySink`] if you need flush
 functionality beyond writing bytes to an arbitrary I/O destination.

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -22,8 +22,10 @@ metrique-timesource = { version = "0.1.8", path = "../metrique-timesource", feat
 hashbrown.workspace = true
 
 [dev-dependencies]
-metrique = { path = "../metrique", features = ["test-util", "emf"] }
+metrique = { path = "../metrique", features = ["test-util", "emf", "local-format"] }
 divan = "0.1"
+insta = { workspace = true }
+serde_json = { workspace = true }
 rand.workspace = true
 rand_chacha.workspace = true
 assert2.workspace = true
@@ -44,6 +46,10 @@ __build_examples_for_rustdoc = ["metrique/emf", "metrique/test-util"]
 name = "embedded"
 doc-scrape-examples = true
 requires_features = ["__build_examples_for_rustdoc"]
+
+[[example]]
+name = "local-webserver"
+doc-scrape-examples = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/metrique-aggregation/examples/local-webserver.rs
+++ b/metrique-aggregation/examples/local-webserver.rs
@@ -1,0 +1,112 @@
+//! Example: Local Development Metrics with KeyedAggregator
+//!
+//! This demonstrates using `LocalFormat` with `KeyedAggregator` to produce
+//! human-readable aggregated metrics for two different API operations.
+//!
+//! Run with: `cargo run -p metrique-aggregation --example local-webserver`
+//!
+//! Try different output styles via the FORMAT env var:
+//!   FORMAT=pretty   (default) — YAML-esque key-value pairs
+//!   FORMAT=json     — pretty-printed JSON
+//!   FORMAT=compact-json — single-line JSON
+//!   FORMAT=markdown — markdown table
+
+use metrique::ServiceMetrics;
+use metrique::local::{LocalFormat, OutputStyle};
+use metrique::unit::Millisecond;
+use metrique::unit_of_work::metrics;
+use metrique::writer::value::ToString;
+use metrique::writer::{AttachGlobalEntrySinkExt, FormatExt, GlobalEntrySink};
+use metrique_aggregation::histogram::Histogram;
+use metrique_aggregation::value::Sum;
+use metrique_aggregation::{aggregate, aggregator::KeyedAggregator, sink::WorkerSink};
+use std::time::Duration;
+
+/// Metrics for each API request, aggregated by operation and status.
+///
+/// Fields marked `#[aggregate(key)]` become the grouping key — requests with the
+/// same (operation, status) pair are merged together. The remaining fields use
+/// aggregation strategies: `Sum` for counters, `Histogram` for latency distributions.
+#[aggregate]
+#[metrics(rename_all = "PascalCase")]
+struct RequestMetrics {
+    #[aggregate(key)]
+    operation: String,
+
+    #[aggregate(key)]
+    #[metrics(format = ToString)]
+    status: u16,
+
+    #[aggregate(strategy = Sum)]
+    request_count: u64,
+
+    #[aggregate(strategy = Histogram<Duration>)]
+    #[metrics(unit = Millisecond)]
+    latency: Duration,
+
+    #[aggregate(strategy = Sum)]
+    error_count: u64,
+}
+
+/// Simulate handling a request with some latency.
+async fn handle_request(operation: &str, status: u16, latency_ms: u64) -> RequestMetrics {
+    tokio::time::sleep(Duration::from_millis(latency_ms)).await;
+    RequestMetrics {
+        operation: operation.to_string(),
+        status,
+        request_count: 1,
+        latency: Duration::from_millis(latency_ms),
+        error_count: if status >= 400 { 1 } else { 0 },
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // Set up LocalFormat writing to stderr.
+    // Control output style via FORMAT env var: pretty (default), json, compact-json, markdown
+    let style = match std::env::var("FORMAT").as_deref() {
+        Ok("json") => OutputStyle::json(),
+        Ok("compact-json") => OutputStyle::compact_json(),
+        Ok("markdown") => OutputStyle::markdown_table(),
+        _ => OutputStyle::pretty(),
+    };
+    let _handle = ServiceMetrics::attach_to_stream(
+        LocalFormat::new(style).output_to_makewriter(|| std::io::stderr().lock()),
+    );
+
+    // KeyedAggregator groups entries by their `#[aggregate(key)]` fields and merges
+    // the rest. WorkerSink runs the aggregator on a background thread and flushes
+    // periodically (here every 500ms).
+    let aggregator = KeyedAggregator::<RequestMetrics>::new(ServiceMetrics::sink());
+    let sink = WorkerSink::new(aggregator, Duration::from_millis(500));
+
+    eprintln!("Simulating requests...\n");
+
+    // Simulate a burst of requests to two operations
+    let requests = vec![
+        ("GetUser", 200u16, 12u64),
+        ("GetUser", 200, 15),
+        ("GetUser", 200, 8),
+        ("GetUser", 200, 45),
+        ("GetUser", 500, 120),
+        ("ListUsers", 200, 50),
+        ("ListUsers", 200, 65),
+        ("ListUsers", 200, 55),
+        ("ListUsers", 200, 70),
+        ("ListUsers", 400, 30),
+    ];
+
+    for (op, status, latency_ms) in requests {
+        let metrics = handle_request(op, status, latency_ms).await;
+        // close_and_merge: closes the metrics struct (resolving timers etc.),
+        // then sends it to the aggregator to be merged with other entries
+        // sharing the same key.
+        metrics.close_and_merge(sink.clone());
+    }
+
+    // Flush forces the aggregator to emit all accumulated data now.
+    sink.flush().await;
+
+    // Give the background queue a moment to format and write.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}

--- a/metrique-aggregation/src/histogram.rs
+++ b/metrique-aggregation/src/histogram.rs
@@ -97,7 +97,7 @@
 
 use histogram::Config;
 use metrique_core::CloseValue;
-use metrique_writer::{MetricFlags, MetricValue, Observation, Value, ValueWriter};
+use metrique_writer::{Distribution, MetricFlags, MetricValue, Observation, Value, ValueWriter};
 use ordered_float::OrderedFloat;
 use smallvec::SmallVec;
 use std::{borrow::Borrow, marker::PhantomData};
@@ -318,7 +318,7 @@ where
             self.observations.iter().copied(),
             T::Unit::UNIT,
             [],
-            MetricFlags::empty(),
+            MetricFlags::upcast(&Distribution),
         )
     }
 }

--- a/metrique-aggregation/tests/local_format.rs
+++ b/metrique-aggregation/tests/local_format.rs
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for LocalFormat output with real Histogram types.
+//!
+//! These tests verify that:
+//! 1. HistogramClosed sets the Distribution flag so formatters always show percentiles
+//! 2. LocalFormat output is stable across all three styles
+
+use metrique::RootEntry;
+use metrique::local::{LocalFormat, OutputStyle};
+use metrique::unit_of_work::metrics;
+use metrique_aggregation::histogram::{ExponentialAggregationStrategy, Histogram};
+use metrique_core::CloseValue;
+use metrique_writer::format::Format;
+use metrique_writer::unit::Millisecond;
+use std::time::Duration;
+
+#[metrics(rename_all = "PascalCase")]
+struct RequestMetrics {
+    operation: &'static str,
+    #[metrics(unit = Millisecond)]
+    latency: Histogram<Duration, ExponentialAggregationStrategy>,
+    request_count: u64,
+}
+
+/// Format a metrics struct through LocalFormat, stripping the timestamp line for determinism.
+fn format_entry(style: OutputStyle, metrics: RequestMetrics) -> String {
+    let closed = metrics.close();
+    let entry = RootEntry::new(closed);
+    let mut buf = Vec::new();
+    LocalFormat::new(style).format(&entry, &mut buf).unwrap();
+    let output = String::from_utf8(buf).unwrap();
+    // Strip timestamp lines for deterministic snapshots
+    output
+        .lines()
+        .filter(|line| !line.contains("timestamp"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn sample_metrics() -> RequestMetrics {
+    let mut m = RequestMetrics {
+        operation: "GetUser",
+        latency: Histogram::default(),
+        request_count: 42,
+    };
+    m.latency.add_value(Duration::from_millis(5));
+    m.latency.add_value(Duration::from_millis(12));
+    m.latency.add_value(Duration::from_millis(25));
+    m.latency.add_value(Duration::from_millis(100));
+    m
+}
+
+/// A histogram with a single observation must still render as a distribution
+/// (with percentiles), not as a single inline value. This proves HistogramClosed
+/// sets the Distribution flag.
+#[test]
+fn histogram_single_value_shows_as_distribution() {
+    let mut m = RequestMetrics {
+        operation: "PutItem",
+        latency: Histogram::default(),
+        request_count: 1,
+    };
+    m.latency.add_value(Duration::from_millis(42));
+
+    let output = format_entry(OutputStyle::json(), m);
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    // With the Distribution flag, even a single observation should produce
+    // a percentile object, not a bare number.
+    let latency = &parsed["Latency"];
+    assert!(
+        latency.is_object(),
+        "single-observation histogram should render as object with percentiles, got: {latency}"
+    );
+    assert!(latency["count"].is_number());
+    assert!(latency["min"].is_number());
+    assert!(latency["max"].is_number());
+}
+
+#[test]
+fn snapshot_pretty() {
+    let output = format_entry(OutputStyle::pretty(), sample_metrics());
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_json() {
+    let output = format_entry(OutputStyle::json(), sample_metrics());
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_compact_json() {
+    let output = format_entry(OutputStyle::compact_json(), sample_metrics());
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_markdown() {
+    let output = format_entry(OutputStyle::markdown_table(), sample_metrics());
+    insta::assert_snapshot!(output);
+}

--- a/metrique-aggregation/tests/snapshots/local_format__snapshot_compact_json.snap
+++ b/metrique-aggregation/tests/snapshots/local_format__snapshot_compact_json.snap
@@ -1,0 +1,5 @@
+---
+source: metrique-aggregation/tests/local_format.rs
+expression: output
+---
+{"Latency":{"count":4,"max":101.9990234375,"min":5.1240234375,"p50":12.2490234375,"p99":101.9990234375,"p99.9":101.9990234375},"Latency_unit":"Milliseconds","Operation":"GetUser","RequestCount":42}

--- a/metrique-aggregation/tests/snapshots/local_format__snapshot_json.snap
+++ b/metrique-aggregation/tests/snapshots/local_format__snapshot_json.snap
@@ -1,0 +1,17 @@
+---
+source: metrique-aggregation/tests/local_format.rs
+expression: output
+---
+{
+  "Latency": {
+    "count": 4,
+    "max": 101.9990234375,
+    "min": 5.1240234375,
+    "p50": 12.2490234375,
+    "p99": 101.9990234375,
+    "p99.9": 101.9990234375
+  },
+  "Latency_unit": "Milliseconds",
+  "Operation": "GetUser",
+  "RequestCount": 42
+}

--- a/metrique-aggregation/tests/snapshots/local_format__snapshot_markdown.snap
+++ b/metrique-aggregation/tests/snapshots/local_format__snapshot_markdown.snap
@@ -1,0 +1,14 @@
+---
+source: metrique-aggregation/tests/local_format.rs
+expression: output
+---
+| Name          | Value     |
+| ------------- | --------- |
+| Operation     | GetUser   |
+| Latency.min   | 5.124ms   |
+| Latency.p50   | 12.249ms  |
+| Latency.p99   | 101.999ms |
+| Latency.p99.9 | 101.999ms |
+| Latency.max   | 101.999ms |
+| Latency.count | 4         |
+| RequestCount  | 42        |

--- a/metrique-aggregation/tests/snapshots/local_format__snapshot_pretty.snap
+++ b/metrique-aggregation/tests/snapshots/local_format__snapshot_pretty.snap
@@ -1,0 +1,13 @@
+---
+source: metrique-aggregation/tests/local_format.rs
+expression: output
+---
+---
+  Operation: GetUser
+  Latency (4 samples):
+    min: 5.124ms
+    p50: 12.249ms
+    p99: 101.999ms
+    p99.9: 101.999ms
+    max: 101.999ms
+  RequestCount: 42

--- a/metrique-writer-core/src/lib.rs
+++ b/metrique-writer-core/src/lib.rs
@@ -12,7 +12,7 @@ pub use crate::sink::{AnyEntrySink, BoxEntrySink, EntrySink};
 pub use crate::stream::{EntryIoStream, IoStreamError};
 pub use crate::unit::{Convert, Unit};
 pub use crate::validate::{ValidationError, ValidationErrorBuilder};
-pub use crate::value::{MetricFlags, MetricValue, Observation, Value, ValueWriter};
+pub use crate::value::{Distribution, MetricFlags, MetricValue, Observation, Value, ValueWriter};
 
 pub(crate) type CowStr = std::borrow::Cow<'static, str>;
 

--- a/metrique-writer-core/src/value/flags.rs
+++ b/metrique-writer-core/src/value/flags.rs
@@ -18,6 +18,14 @@ pub trait MetricOptions: Any + Debug {
     }
 }
 
+/// A flag indicating that this metric represents a distribution (histogram).
+///
+/// Formatters can use this to always display percentiles, even when there is
+/// only a single observation in the current batch.
+#[derive(Debug)]
+pub struct Distribution;
+impl MetricOptions for Distribution {}
+
 /// Contains a set of options that describe the implementation of a metric
 ///
 /// This is a "semi-opaque" struct. The idea is that code that just uses `fn metric`

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -17,7 +17,7 @@ pub use force::{FlagConstructor, ForceFlag};
 pub use formatter::{FormattedValue, Lifted, NotLifted, ToString, ValueFormatter};
 use std::{borrow::Cow, sync::Arc};
 
-pub use flags::{MetricFlags, MetricOptions};
+pub use flags::{Distribution, MetricFlags, MetricOptions};
 
 use crate::{
     CowStr, Unit, ValidationError,

--- a/metrique-writer/src/lib.rs
+++ b/metrique-writer/src/lib.rs
@@ -10,7 +10,9 @@ pub use metrique_writer_core::global::GlobalEntrySink;
 pub use metrique_writer_core::sink::{AnyEntrySink, BoxEntrySink, EntrySink};
 pub use metrique_writer_core::stream::{EntryIoStream, IoStreamError};
 pub use metrique_writer_core::unit::{Convert, Unit};
-pub use metrique_writer_core::value::{MetricFlags, MetricValue, Observation, Value, ValueWriter};
+pub use metrique_writer_core::value::{
+    Distribution, MetricFlags, MetricValue, Observation, Value, ValueWriter,
+};
 pub use metrique_writer_core::{ValidationError, ValidationErrorBuilder};
 pub use metrique_writer_macro::Entry;
 

--- a/metrique-writer/src/value/distribution.rs
+++ b/metrique-writer/src/value/distribution.rs
@@ -61,6 +61,7 @@ pub struct Distribution<V, const N: usize = 0> {
 /// Always records observations on the heap.
 pub type VecDistribution<V> = Distribution<V, 0>;
 
+#[diagnostic::do_not_recommend]
 impl<V: MetricValue, const N: usize> Value for Distribution<V, N> {
     fn write(&self, writer: impl ValueWriter) {
         if self.values.is_empty() {

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -12,6 +12,8 @@ rust-version = "1.89" # See build.yml for why this MSRV
 default = ["service-metrics"]
 # re-exports metrique-writer-format-emf as metrique::emf
 emf = ["dep:metrique-writer-format-emf"]
+# Human-readable local development format (pretty, JSON, markdown table)
+local-format = ["dep:serde_json", "dep:jiff"]
 # utilities for tests
 test-util = ["metrique-writer/test-util", "metrique-writer-core/test-util", "metrique-metricsrs/test-util"]
 # Private utilities for testing the formatter crates. 100% unstable, do not use outside of this workspace
@@ -38,6 +40,8 @@ tracing-appender = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 ryu = { workspace = true }
 itoa = { workspace = true }
+serde_json = { workspace = true, optional = true }
+jiff = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert2 = { workspace = true }
@@ -59,7 +63,7 @@ tracing = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }
 trybuild = { workspace = true }
 rustversion = { workspace = true }
-metrique = { path = ".", features = ["emf", "test-util"] }
+metrique = { path = ".", features = ["emf", "test-util", "local-format"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -11,6 +11,8 @@ pub mod emf;
 pub mod flex;
 pub mod instrument;
 mod keep_alive;
+#[cfg(feature = "local-format")]
+pub mod local;
 
 /// Provides timing utilities for metrics, including timestamps and duration measurements.
 ///

--- a/metrique/src/local.rs
+++ b/metrique/src/local.rs
@@ -1,0 +1,865 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A human-readable metrics format for local development and debugging.
+//!
+//! This module provides [`LocalFormat`], a [`Format`] implementation designed for local
+//! development rather than production metric backends. It produces readable output to
+//! stdout or any `io::Write` destination.
+//!
+//! # Output Styles
+//!
+//! - [`OutputStyle::Pretty`]: YAML-esque key-value pairs with smart unit display
+//! - [`OutputStyle::Json`]: JSON objects with unit annotations
+//! - [`OutputStyle::MarkdownTable`]: Markdown table for pasting into docs/issues
+//!
+//! # Histogram Analysis
+//!
+//! When a metric contains multiple observations (e.g. from aggregation), the format
+//! automatically computes percentiles (min, p50, p99, p99.9, max).
+//!
+//! # How This Format Works (Guide to Implementing a Custom Format)
+//!
+//! Metrique uses a visitor/double-dispatch pattern to decouple metric data from formatting:
+//!
+//! 1. The [`Format::format`] method receives an [`Entry`] and an `io::Write` output.
+//! 2. The format creates an [`EntryWriter`] — a collector that the entry will write into.
+//! 3. It calls `entry.write(&mut writer)`, which triggers the entry to call back into
+//!    the writer's methods: `timestamp()`, `value(name, value)`, and `config()`.
+//! 4. For each `value()` call, the writer creates a [`ValueWriter`] — a one-shot handler
+//!    for a single metric value. The value then calls one of three methods on it:
+//!    - `string()` for string properties (dimensions, operation names)
+//!    - `metric()` for numeric observations with units and dimensions
+//!    - `error()` for validation errors
+//! 5. After the entry has written all its fields, the format serializes the collected
+//!    data to the output.
+//!
+//! This two-level visitor pattern (EntryWriter → ValueWriter) allows formats to handle
+//! both string properties and numeric metrics uniformly, while giving each value type
+//! control over how it presents itself.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use metrique::local::{LocalFormat, OutputStyle};
+//! use metrique::writer::format::FormatExt;
+//! use metrique::writer::{AttachGlobalEntrySinkExt, GlobalEntrySink};
+//! use metrique::ServiceMetrics;
+//!
+//! let _handle = ServiceMetrics::attach_to_stream(
+//!     LocalFormat::new(OutputStyle::Pretty)
+//!         .output_to_makewriter(|| std::io::stderr().lock()),
+//! );
+//! ```
+
+use std::{borrow::Cow, io, time::SystemTime};
+
+use metrique_writer_core::{
+    Distribution, Entry, EntryWriter, MetricFlags, Observation, Unit, ValidationError, Value,
+    ValueWriter, format::Format, stream::IoStreamError,
+};
+
+/// The output style for [`LocalFormat`].
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub enum OutputStyle {
+    /// YAML-esque key-value pairs with smart unit display.
+    /// Time values are shown in human-friendly units (e.g. "42.3ms" instead of "0.0423").
+    #[default]
+    Pretty,
+    /// JSON objects. Units are included as a `_unit` suffix field.
+    /// Pretty-printed by default; use [`LocalFormat::compact_json`] for single-line output.
+    #[non_exhaustive]
+    Json {
+        /// If true, output compact single-line JSON. Defaults to false (pretty-printed).
+        compact: bool,
+    },
+    /// Markdown table suitable for pasting into GitHub issues or docs.
+    MarkdownTable,
+}
+
+impl OutputStyle {
+    /// Pretty-printed key-value pairs.
+    pub fn pretty() -> Self {
+        Self::Pretty
+    }
+
+    /// Pretty-printed JSON output.
+    pub fn json() -> Self {
+        Self::Json { compact: false }
+    }
+
+    /// Compact single-line JSON output.
+    pub fn compact_json() -> Self {
+        Self::Json { compact: true }
+    }
+
+    /// Markdown table output.
+    pub fn markdown_table() -> Self {
+        Self::MarkdownTable
+    }
+}
+
+/// A named percentile to compute from histogram data.
+#[derive(Debug, Clone)]
+pub struct Percentile {
+    label: String,
+    fraction: f64,
+}
+
+impl Percentile {
+    /// Create a percentile from a fraction in `[0.0, 1.0]`.
+    ///
+    /// The display label is generated automatically: 0.0 → "min", 1.0 → "max",
+    /// 0.5 → "p50", 0.99 → "p99", 0.999 → "p99.9", etc.
+    pub fn new(fraction: f64) -> Self {
+        let fraction = fraction.clamp(0.0, 1.0);
+        let label = if fraction == 0.0 {
+            "min".to_owned()
+        } else if fraction == 1.0 {
+            "max".to_owned()
+        } else {
+            let pct = fraction * 100.0;
+            if pct == pct.floor() {
+                format!("p{}", pct as u64)
+            } else {
+                format!("p{pct}")
+            }
+        };
+        Self { label, fraction }
+    }
+}
+
+/// Default percentiles: min, p50, p99, p99.9, max
+fn default_percentiles() -> Vec<Percentile> {
+    vec![
+        Percentile::new(0.0),
+        Percentile::new(0.5),
+        Percentile::new(0.99),
+        Percentile::new(0.999),
+        Percentile::new(1.0),
+    ]
+}
+
+/// A human-readable metrics format for local development.
+///
+/// See the [module-level docs](self) for details.
+#[derive(Debug, Clone)]
+pub struct LocalFormat {
+    style: OutputStyle,
+    percentiles: Vec<Percentile>,
+}
+
+impl LocalFormat {
+    /// Create a new `LocalFormat` with the given output style.
+    pub fn new(style: OutputStyle) -> Self {
+        Self {
+            style,
+            percentiles: default_percentiles(),
+        }
+    }
+
+    /// Create a `LocalFormat` with pretty-printed JSON output.
+    pub fn json() -> Self {
+        Self::new(OutputStyle::json())
+    }
+
+    /// Create a `LocalFormat` with compact (single-line) JSON output.
+    pub fn compact_json() -> Self {
+        Self::new(OutputStyle::compact_json())
+    }
+
+    /// Override which percentiles are computed for histogram data.
+    ///
+    /// ```
+    /// # use metrique::local::{LocalFormat, Percentile};
+    /// let format = LocalFormat::json()
+    ///     .percentiles(vec![Percentile::new(0.0), Percentile::new(0.5), Percentile::new(1.0)]);
+    /// ```
+    pub fn percentiles(mut self, percentiles: Vec<Percentile>) -> Self {
+        self.percentiles = percentiles;
+        self
+    }
+}
+
+// ── Format implementation ──────────────────────────────────────────────
+//
+// `Format` is the core trait that all metrique formatters implement. It receives an
+// opaque `Entry` and must serialize it to an `io::Write` output. Since entries are
+// opaque, we use the visitor pattern: create an `EntryWriter` that collects data,
+// let the entry write into it, then serialize the collected data.
+
+impl Format for LocalFormat {
+    fn format(
+        &mut self,
+        entry: &impl Entry,
+        output: &mut impl io::Write,
+    ) -> Result<(), IoStreamError> {
+        // Step 1: Create our collector. This implements `EntryWriter` so the entry
+        // can write its fields into it.
+        let mut collector = Collector::default();
+
+        // Step 2: Let the entry write all its fields into our collector.
+        // This triggers callbacks to `collector.timestamp()`, `collector.value()`, etc.
+        entry.write(&mut collector);
+
+        // Step 3: Serialize the collected data in the chosen style.
+        match self.style {
+            OutputStyle::Pretty => write_pretty(output, &collector, &self.percentiles)?,
+            OutputStyle::Json { compact } => {
+                write_json(output, &collector, &self.percentiles, compact)?
+            }
+            OutputStyle::MarkdownTable => {
+                write_markdown_table(output, &collector, &self.percentiles)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ── Data collection ────────────────────────────────────────────────────
+//
+// The collector implements `EntryWriter` to gather all fields from an entry.
+// For each field, it creates a `FieldValueWriter` (implementing `ValueWriter`)
+// that captures whether the field is a string property or a numeric metric.
+
+/// Collected representation of a single entry's data.
+#[derive(Default)]
+struct Collector {
+    timestamp: Option<SystemTime>,
+    fields: Vec<Field>,
+}
+
+/// A single field collected from an entry.
+struct Field {
+    name: String,
+    data: FieldData,
+}
+
+/// The data for a field — either a string property or a numeric metric.
+enum FieldData {
+    String(String),
+    Metric {
+        observations: Vec<WeightedObservation>,
+        unit: Unit,
+        dimensions: Vec<(String, String)>,
+        is_distribution: bool,
+    },
+}
+
+/// An observation with an associated weight for percentile computation.
+#[derive(Debug, Clone, Copy)]
+struct WeightedObservation {
+    value: f64,
+    weight: u64,
+}
+
+// `EntryWriter` is the first level of the visitor pattern. The format provides this
+// to the entry, and the entry calls `timestamp()`, `value()`, and `config()` on it.
+impl<'a> EntryWriter<'a> for Collector {
+    fn timestamp(&mut self, timestamp: SystemTime) {
+        self.timestamp = Some(timestamp);
+    }
+
+    // For each field, we create a `FieldValueWriter` that will capture the value.
+    // The entry calls `value.write(writer)` which dispatches to either `string()`,
+    // `metric()`, or `error()` on our writer.
+    fn value(&mut self, name: impl Into<Cow<'a, str>>, value: &(impl Value + ?Sized)) {
+        let name = name.into().into_owned();
+        let mut data = None;
+        value.write(FieldValueWriter(&mut data));
+        if let Some(data) = data {
+            self.fields.push(Field { name, data });
+        }
+        // If data is None, the value wrote nothing (e.g. Option::None) — skip it.
+    }
+
+    fn config(&mut self, _config: &'a dyn metrique_writer_core::EntryConfig) {
+        // LocalFormat ignores format-specific config (like EMF dimension sets).
+    }
+}
+
+/// `ValueWriter` is the second level of the visitor pattern. It's created per-field
+/// and consumed when the value writes to it. The `Sized` bound on `self` means each
+/// ValueWriter is used exactly once.
+struct FieldValueWriter<'a>(&'a mut Option<FieldData>);
+
+impl ValueWriter for FieldValueWriter<'_> {
+    fn string(self, value: &str) {
+        *self.0 = Some(FieldData::String(value.to_owned()));
+    }
+
+    fn metric<'a>(
+        self,
+        distribution: impl IntoIterator<Item = Observation>,
+        unit: Unit,
+        dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
+        _flags: MetricFlags<'_>,
+    ) {
+        let is_distribution = _flags.downcast::<Distribution>().is_some();
+        let mut observations = Vec::new();
+        for obs in distribution {
+            match obs {
+                Observation::Unsigned(v) => observations.push(WeightedObservation {
+                    value: v as f64,
+                    weight: 1,
+                }),
+                Observation::Floating(v) => observations.push(WeightedObservation {
+                    value: v,
+                    weight: 1,
+                }),
+                Observation::Repeated { total, occurrences } => {
+                    if occurrences > 0 {
+                        // Repeated observations represent `occurrences` samples that sum
+                        // to `total`. We store the average with the full weight so
+                        // percentile computation accounts for the count without
+                        // allocating one entry per occurrence.
+                        observations.push(WeightedObservation {
+                            value: total / occurrences as f64,
+                            weight: occurrences,
+                        });
+                    }
+                }
+                // Observation is #[non_exhaustive]; unknown variants are intentionally
+                // skipped — this is a best-effort debug format, not a lossless serializer.
+                _ => {}
+            }
+        }
+        let dimensions = dimensions
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v.to_owned()))
+            .collect();
+        *self.0 = Some(FieldData::Metric {
+            observations,
+            unit,
+            dimensions,
+            is_distribution,
+        });
+    }
+
+    fn error(self, error: ValidationError) {
+        *self.0 = Some(FieldData::String(format!("ERROR: {error}")));
+    }
+}
+
+// ── Percentile computation ─────────────────────────────────────────────
+
+fn compute_percentiles<'a>(
+    observations: &[WeightedObservation],
+    percentiles: &'a [Percentile],
+) -> Vec<(&'a str, f64)> {
+    if observations.is_empty() {
+        return Vec::new();
+    }
+    let mut sorted: Vec<WeightedObservation> = observations.to_vec();
+    sorted.sort_by(|a, b| {
+        a.value
+            .partial_cmp(&b.value)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let total_weight: u64 = sorted.iter().map(|o| o.weight).sum();
+    percentiles
+        .iter()
+        .map(|p| {
+            let target = if p.fraction <= 0.0 {
+                0
+            } else if p.fraction >= 1.0 {
+                total_weight
+            } else {
+                (total_weight as f64 * p.fraction).ceil() as u64
+            };
+            let mut cumulative = 0u64;
+            let mut value = sorted[0].value;
+            for obs in &sorted {
+                cumulative += obs.weight;
+                value = obs.value;
+                if cumulative >= target {
+                    break;
+                }
+            }
+            (p.label.as_str(), value)
+        })
+        .collect()
+}
+
+/// Total number of observations (accounting for weights).
+fn total_count(observations: &[WeightedObservation]) -> u64 {
+    observations.iter().map(|o| o.weight).sum()
+}
+
+// ── Smart unit display ─────────────────────────────────────────────────
+//
+// In Pretty mode, we display values in the most readable unit. For example,
+// a metric in Microseconds with value 1_500_000 is shown as "1.5s" rather than
+// "1500000μs".
+
+/// Format a value with smart unit scaling for Pretty mode.
+fn format_pretty_value(value: f64, unit: Unit) -> String {
+    match unit {
+        Unit::Second(scale) => {
+            // Convert to seconds: value is in the scaled unit (e.g. milliseconds),
+            // so divide by the reduction factor to get seconds.
+            let seconds = value / scale.reduction_factor() as f64;
+            format_duration_smart(seconds)
+        }
+        Unit::Byte(scale) => {
+            // Convert to bytes: value is in the scaled unit (e.g. megabytes),
+            // so multiply by the expansion factor to get bytes.
+            let bytes = value * scale.expansion_factor() as f64;
+            format_bytes_smart(bytes)
+        }
+        Unit::Percent => format!("{value:.1}%"),
+        Unit::Count => {
+            if value == value.floor() {
+                format!("{}", value as i64)
+            } else {
+                format!("{value:.2}")
+            }
+        }
+        Unit::None => {
+            if value == value.floor() && value.abs() < i64::MAX as f64 {
+                format!("{}", value as i64)
+            } else {
+                format!("{value:.3}")
+            }
+        }
+        _ => format!("{value:.3} {unit}"),
+    }
+}
+
+fn format_duration_smart(seconds: f64) -> String {
+    if seconds == 0.0 {
+        return "0s".to_owned();
+    }
+    let abs = seconds.abs();
+    if abs >= 1.0 {
+        format!("{seconds:.3}s")
+    } else if abs >= 0.001 {
+        format!("{:.3}ms", seconds * 1_000.0)
+    } else {
+        format!("{:.3}μs", seconds * 1_000_000.0)
+    }
+}
+
+fn format_bytes_smart(bytes: f64) -> String {
+    if bytes == 0.0 {
+        return "0B".to_owned();
+    }
+    let abs = bytes.abs();
+    if abs >= 1_000_000_000.0 {
+        format!("{:.2}GB", bytes / 1_000_000_000.0)
+    } else if abs >= 1_000_000.0 {
+        format!("{:.2}MB", bytes / 1_000_000.0)
+    } else if abs >= 1_000.0 {
+        format!("{:.2}KB", bytes / 1_000.0)
+    } else {
+        format!("{bytes:.0}B")
+    }
+}
+
+/// Format a value for JSON mode — keep the raw number, unit goes in a separate field.
+fn format_json_value(value: f64) -> serde_json::Value {
+    if value == value.floor() && value.abs() < i64::MAX as f64 {
+        serde_json::Value::Number(serde_json::Number::from(value as i64))
+    } else {
+        serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null)
+    }
+}
+
+// ── Pretty output ──────────────────────────────────────────────────────
+
+/// Format a SystemTime as an ISO 8601 string using jiff.
+fn format_timestamp(ts: SystemTime) -> String {
+    jiff::Timestamp::try_from(ts)
+        .map(|t| t.to_string())
+        .unwrap_or_else(|_| format!("{ts:?}"))
+}
+
+fn write_pretty(
+    output: &mut impl io::Write,
+    collector: &Collector,
+    percentiles: &[Percentile],
+) -> io::Result<()> {
+    writeln!(output, "---")?;
+    if let Some(ts) = collector.timestamp {
+        writeln!(output, "  timestamp: {}", format_timestamp(ts))?;
+    }
+    for field in &collector.fields {
+        match &field.data {
+            FieldData::String(s) => {
+                writeln!(output, "  {}: {s}", field.name)?;
+            }
+            FieldData::Metric {
+                observations,
+                unit,
+                dimensions,
+                is_distribution,
+            } => {
+                if !dimensions.is_empty() {
+                    let dims: Vec<String> =
+                        dimensions.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                    writeln!(output, "  {} [{}]:", field.name, dims.join(", "))?;
+                }
+                let show_histogram = *is_distribution || total_count(observations) > 1;
+                if !show_histogram {
+                    // Single value — show inline
+                    let val = observations.first().map(|o| o.value).unwrap_or(0.0);
+                    if dimensions.is_empty() {
+                        writeln!(
+                            output,
+                            "  {}: {}",
+                            field.name,
+                            format_pretty_value(val, *unit)
+                        )?;
+                    } else {
+                        writeln!(output, "    {}", format_pretty_value(val, *unit))?;
+                    }
+                } else {
+                    // Multiple observations — show percentiles
+                    let count = total_count(observations);
+                    if dimensions.is_empty() {
+                        writeln!(output, "  {} ({count} samples):", field.name)?;
+                    } else {
+                        writeln!(output, "    ({count} samples):")?;
+                    }
+                    for (label, val) in compute_percentiles(observations, percentiles) {
+                        writeln!(output, "    {label}: {}", format_pretty_value(val, *unit))?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ── JSON output ────────────────────────────────────────────────────────
+
+fn write_json(
+    output: &mut impl io::Write,
+    collector: &Collector,
+    percentiles: &[Percentile],
+    compact: bool,
+) -> io::Result<()> {
+    let mut map = serde_json::Map::new();
+
+    if let Some(ts) = collector.timestamp {
+        if let Ok(dur) = ts.duration_since(SystemTime::UNIX_EPOCH) {
+            map.insert("timestamp".to_owned(), format_json_value(dur.as_secs_f64()));
+            map.insert(
+                "timestamp_iso".to_owned(),
+                serde_json::Value::String(format_timestamp(ts)),
+            );
+        }
+    }
+
+    for field in &collector.fields {
+        match &field.data {
+            FieldData::String(s) => {
+                map.insert(field.name.clone(), serde_json::Value::String(s.clone()));
+            }
+            FieldData::Metric {
+                observations,
+                unit,
+                dimensions,
+                is_distribution,
+            } => {
+                let show_histogram = *is_distribution || total_count(observations) > 1;
+                if !show_histogram {
+                    let val = observations.first().map(|o| o.value).unwrap_or(0.0);
+                    map.insert(field.name.clone(), format_json_value(val));
+                } else {
+                    let pcts = compute_percentiles(observations, percentiles);
+                    let count = total_count(observations);
+                    let mut pct_map = serde_json::Map::new();
+                    pct_map.insert("count".to_owned(), serde_json::Value::Number(count.into()));
+                    for (label, val) in pcts {
+                        pct_map.insert(label.to_owned(), format_json_value(val));
+                    }
+                    map.insert(field.name.clone(), serde_json::Value::Object(pct_map));
+                }
+                // Unit annotation: include as a sibling field when not None
+                if *unit != Unit::None {
+                    map.insert(
+                        format!("{}_unit", field.name),
+                        serde_json::Value::String(unit.to_string()),
+                    );
+                }
+                if !dimensions.is_empty() {
+                    let dim_map: serde_json::Map<String, serde_json::Value> = dimensions
+                        .iter()
+                        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                        .collect();
+                    map.insert(
+                        format!("{}_dimensions", field.name),
+                        serde_json::Value::Object(dim_map),
+                    );
+                }
+            }
+        }
+    }
+
+    let obj = serde_json::Value::Object(map);
+    let json = if compact {
+        serde_json::to_string(&obj)
+    } else {
+        serde_json::to_string_pretty(&obj)
+    }
+    .map_err(io::Error::other)?;
+    writeln!(output, "{json}")?;
+    Ok(())
+}
+
+// ── Markdown table output ──────────────────────────────────────────────
+
+fn write_markdown_table(
+    output: &mut impl io::Write,
+    collector: &Collector,
+    percentiles: &[Percentile],
+) -> io::Result<()> {
+    // Collect rows: (name, value_string)
+    let mut rows: Vec<(String, String)> = Vec::new();
+
+    if let Some(ts) = collector.timestamp {
+        rows.push(("timestamp".to_owned(), format_timestamp(ts)));
+    }
+
+    for field in &collector.fields {
+        match &field.data {
+            FieldData::String(s) => {
+                rows.push((field.name.clone(), s.clone()));
+            }
+            FieldData::Metric {
+                observations,
+                unit,
+                dimensions,
+                is_distribution,
+            } => {
+                for (k, v) in dimensions {
+                    rows.push((format!("{}.{k}", field.name), v.clone()));
+                }
+                let show_histogram = *is_distribution || total_count(observations) > 1;
+                if !show_histogram {
+                    let val = observations.first().map(|o| o.value).unwrap_or(0.0);
+                    rows.push((field.name.clone(), format_pretty_value(val, *unit)));
+                } else {
+                    for (label, val) in compute_percentiles(observations, percentiles) {
+                        rows.push((
+                            format!("{}.{label}", field.name),
+                            format_pretty_value(val, *unit),
+                        ));
+                    }
+                    rows.push((
+                        format!("{}.count", field.name),
+                        total_count(observations).to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Compute column widths
+    let name_width = rows.iter().map(|(n, _)| n.len()).max().unwrap_or(4).max(4);
+    let value_width = rows.iter().map(|(_, v)| v.len()).max().unwrap_or(5).max(5);
+
+    writeln!(
+        output,
+        "| {:<name_width$} | {:<value_width$} |",
+        "Name", "Value"
+    )?;
+    writeln!(output, "| {:-<name_width$} | {:-<value_width$} |", "", "")?;
+    for (name, value) in &rows {
+        writeln!(
+            output,
+            "| {:<name_width$} | {:<value_width$} |",
+            name, value
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrique_writer_core::unit::{self, NegativeScale, UnitTag};
+
+    #[test]
+    fn test_pretty_single_value() {
+        let mut format = LocalFormat::new(OutputStyle::Pretty);
+        let entry = SimpleEntry {
+            name: "GetUser",
+            latency_ms: 42.5,
+        };
+        let mut buf = Vec::new();
+        format.format(&entry, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("operation: GetUser"));
+        assert!(output.contains("latency: 42.500ms"));
+    }
+
+    #[test]
+    fn test_json_output() {
+        let mut format = LocalFormat::json();
+        let entry = SimpleEntry {
+            name: "GetUser",
+            latency_ms: 42.5,
+        };
+        let mut buf = Vec::new();
+        format.format(&entry, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(parsed["operation"], "GetUser");
+        assert_eq!(parsed["latency_unit"], "Milliseconds");
+    }
+
+    #[test]
+    fn test_markdown_table() {
+        let mut format = LocalFormat::new(OutputStyle::MarkdownTable);
+        let entry = SimpleEntry {
+            name: "GetUser",
+            latency_ms: 42.5,
+        };
+        let mut buf = Vec::new();
+        format.format(&entry, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("| Name"));
+        assert!(output.contains("operation"));
+    }
+
+    #[test]
+    fn test_histogram_percentiles() {
+        let mut format = LocalFormat::new(OutputStyle::Pretty);
+        let entry = HistogramEntry {
+            values: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+        };
+        let mut buf = Vec::new();
+        format.format(&entry, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("10 samples"));
+        assert!(output.contains("min:"));
+        assert!(output.contains("max:"));
+        assert!(output.contains("p50:"));
+        assert!(output.contains("p99:"));
+    }
+
+    #[test]
+    fn test_smart_duration_display() {
+        assert_eq!(format_duration_smart(0.0), "0s");
+        assert_eq!(format_duration_smart(1.5), "1.500s");
+        assert_eq!(format_duration_smart(0.042), "42.000ms");
+        assert_eq!(format_duration_smart(0.000_042), "42.000μs");
+    }
+
+    #[test]
+    fn test_smart_bytes_display() {
+        assert_eq!(format_bytes_smart(0.0), "0B");
+        assert_eq!(format_bytes_smart(512.0), "512B");
+        assert_eq!(format_bytes_smart(1_500.0), "1.50KB");
+        assert_eq!(format_bytes_smart(2_500_000.0), "2.50MB");
+        assert_eq!(format_bytes_smart(3_000_000_000.0), "3.00GB");
+    }
+
+    #[test]
+    fn test_percentile_computation() {
+        let data: Vec<WeightedObservation> = (1..=100)
+            .map(|i| WeightedObservation {
+                value: i as f64,
+                weight: 1,
+            })
+            .collect();
+        let percentiles = default_percentiles();
+        let pcts = compute_percentiles(&data, &percentiles);
+        assert_eq!(pcts[0], ("min", 1.0));
+        assert_eq!(pcts[4], ("max", 100.0));
+        // p50 should be around 50
+        assert!((pcts[1].1 - 50.0).abs() <= 1.0);
+    }
+
+    // ── Test helpers: manual Entry impls ───────────────────────────────
+
+    struct SimpleEntry {
+        name: &'static str,
+        latency_ms: f64,
+    }
+
+    impl Entry for SimpleEntry {
+        fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+            writer.value("operation", self.name);
+            writer.value("latency", &MillisValue(self.latency_ms));
+        }
+    }
+
+    struct MillisValue(f64);
+    impl Value for MillisValue {
+        fn write(&self, writer: impl ValueWriter) {
+            writer.metric(
+                [Observation::Floating(self.0)],
+                Unit::Second(NegativeScale::Milli),
+                [],
+                MetricFlags::empty(),
+            );
+        }
+    }
+
+    struct HistogramEntry {
+        values: Vec<f64>,
+    }
+
+    impl Entry for HistogramEntry {
+        fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+            writer.value("latency", &HistogramValue(&self.values));
+        }
+    }
+
+    struct HistogramValue<'a>(&'a [f64]);
+    impl Value for HistogramValue<'_> {
+        fn write(&self, writer: impl ValueWriter) {
+            writer.metric(
+                self.0.iter().copied().map(Observation::Floating),
+                unit::None::UNIT,
+                [],
+                MetricFlags::empty(),
+            );
+        }
+    }
+
+    /// A single Repeated observation with the Distribution flag — this is what
+    /// HistogramClosed emits when all samples collapse into one bucket.
+    #[test]
+    fn distribution_flag_forces_histogram_display() {
+        let mut format = LocalFormat::new(OutputStyle::Pretty);
+        let entry = SingleRepeatedDistribution;
+        let mut buf = Vec::new();
+        format.format(&entry, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        // Even though there's only one observation entry, the Distribution flag
+        // should cause it to render as a histogram with percentiles.
+        assert!(output.contains("1000 samples"), "output was: {output}");
+        assert!(output.contains("min:"));
+        assert!(output.contains("max:"));
+    }
+
+    struct SingleRepeatedDistribution;
+    impl Entry for SingleRepeatedDistribution {
+        fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+            writer.value("latency", &RepeatedDistributionValue);
+        }
+    }
+
+    struct RepeatedDistributionValue;
+    impl Value for RepeatedDistributionValue {
+        fn write(&self, writer: impl ValueWriter) {
+            writer.metric(
+                [Observation::Repeated {
+                    total: 5000.0,
+                    occurrences: 1000,
+                }],
+                unit::None::UNIT,
+                [],
+                MetricFlags::upcast(&Distribution),
+            );
+        }
+    }
+}

--- a/metrique/tests/ui/fail/bad_metrics_value.stderr
+++ b/metrique/tests/ui/fail/bad_metrics_value.stderr
@@ -126,8 +126,8 @@ error[E0277]: `FormattedValue<'_, u32, Foo, _>` is not a metric value
              Baz3Value
              Box<T>
              Cow<'_, T>
-             Distribution<V, N>
              Duration
+             ForceFlag<T, FLAGS>
            and $N others
 
 error[E0277]: CloseValue is not implemented for &String

--- a/metrique/tests/ui/fail/missing_flatten_attribute.stderr
+++ b/metrique/tests/ui/fail/missing_flatten_attribute.stderr
@@ -13,10 +13,10 @@ error[E0277]: `ChildMetricsEntry` is not a metric value
              Arc<T>
              Box<T>
              Cow<'_, T>
-             Distribution<V, N>
              Duration
              ForceFlag<T, FLAGS>
              Mean<U>
+             Observation
            and $N others
    = note: required for `Option<ChildMetricsEntry>` to implement `Value`
 note: required by a bound in `value`

--- a/scripts/check-docsrs.sh
+++ b/scripts/check-docsrs.sh
@@ -9,19 +9,36 @@ set -e
 # Determine the target to use based on installed nightly targets
 TARGET=$(rustup target list --installed --toolchain nightly | head -1)
 
+# Build [patch.crates-io] entries so the packaged crate resolves workspace
+# siblings from the local checkout instead of crates.io. Without this, any
+# new public API added in a workspace crate that hasn't been published yet
+# will fail to resolve.
+generate_patch_entries() {
+    local pkg_name=$1
+    echo '[patch.crates-io]'
+    cargo metadata --no-deps --format-version 1 | \
+        jq -r --arg skip "$pkg_name" \
+        '.packages[] | select(.name != $skip) | "\(.name) = { path = \"\(.manifest_path | rtrimstr("/Cargo.toml"))\" }"'
+}
+
 check_package() {
     local pkg_name=$1
     local pkg_version=$2
+    local pkg_dir="target/package/$pkg_name-$pkg_version"
 
     echo "→ Checking docs.rs build for $pkg_name..."
 
-    # Because of workspace unification, we need to actually package the individual packages,
-    # then attempt to document the package itself to detect failure in the presence of
-    # of some bugs.
-    cargo package -p "$pkg_name" --allow-dirty
+    # Package without verification — we need to patch Cargo.toml before building.
+    cargo package -p "$pkg_name" --allow-dirty --no-verify
 
-    (cd "target/package/$pkg_name-$pkg_version" && \
-        cargo +nightly docs-rs --target "$TARGET")
+    # Extract the .crate tarball (cargo package --no-verify doesn't extract)
+    rm -rf "$pkg_dir"
+    tar xzf "target/package/$pkg_name-$pkg_version.crate" -C target/package/
+
+    # Patch the extracted Cargo.toml so workspace siblings resolve locally.
+    generate_patch_entries "$pkg_name" >> "$pkg_dir/Cargo.toml"
+
+    (cd "$pkg_dir" && cargo +nightly docs-rs --target "$TARGET")
 }
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Summary

Add a `local-format` feature providing `LocalFormat`, a `Format` implementation for local development and debugging. Supports pretty, JSON, compact JSON, and markdown table output styles.

## Key design decisions

- **Feature-gated** behind `local-format` (`serde_json` + `jiff` are optional deps — zero cost for production builds)
- **`Distribution` MetricFlag** in `metrique-writer-core` so histograms always render as distributions regardless of observation count
- **Weighted percentile computation** — no unbounded expansion of `Repeated` observations
- **ISO 8601 timestamps** via `jiff`
- **`OutputStyle` constructors** for all variants (`#[non_exhaustive]`-friendly)
- **`Percentile::new(fraction)`** auto-generates labels (0.99 → "p99", 0.0 → "min", etc.)

## Output styles

```
# Pretty (default)
---
  Operation: GetUser
  Latency (4 samples):
    min: 8.000ms
    p50: 12.000ms
    p99: 45.000ms
    max: 45.000ms

# JSON
{"Latency":{"count":4,"min":8,"p50":12,"p99":45,"max":45},"Latency_unit":"Milliseconds",...}

# Markdown
| Name        | Value    |
| ----------- | -------- |
| Latency.min | 8.000ms  |
| Latency.p50 | 12.000ms |
```

## Testing

- Unit tests in `metrique/src/local.rs`
- Integration tests + insta snapshots in `metrique-aggregation/tests/local_format.rs`
- Stress tested with `cargo nextest --stress-duration 10s` (421 iterations, 0 failures)

## Example

```bash
# Try different formats via FORMAT env var
cargo run -p metrique-aggregation --example local-webserver
FORMAT=json cargo run -p metrique-aggregation --example local-webserver
FORMAT=markdown cargo run -p metrique-aggregation --example local-webserver
```