### PR TITLE
Allow manual trigger of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ permissions:
   id-token: write     # Required for OIDC token exchange / trusted publishing
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Adds `workflow_dispatch` to the release workflow so it can be triggered manually from the Actions tab.