### PR TITLE
feat: add metrique-writer-format-json to release-plz config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,12 +93,8 @@ trusted publishing is unable to publish new crates. If you want to add a new cra
 
 1. create a branch that contains the crate you are publishing (it should
    be in the root `Cargo.toml`'s `workspace.members`, and in a publishable state).
-2. add an entry to `release-plz.toml` of the form
-   ```
-   [[package]]
-   name = "<package>"
-   changelog_path = "CHANGELOG.md"
-   ```
+2. add the package name to the `changelog_include` list in the `[[package]] name = "metrique"`
+   entry in `release-plz.toml`.
 3. run `cargo publish -p <package> --dry-run`
 4. get a temporary crates.io token just for the publishing
 5. run `cargo login` with that token

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,7 @@ changelog_include = [
     "metrique-writer",
     "metrique-writer-core",
     "metrique-writer-format-emf",
+    "metrique-writer-format-json",
     "metrique-writer-macro",
     "metrique-aggregation"
 ]


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

I'll get `metrique-writer-format-json` published initially via crates.io API key and then connected to trusted publishing.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
