### PR TITLE
feat: Add tokio-metrics runtime metrics integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,7 @@ dependencies = [
  "metrique-util",
  "metrique-writer",
  "metrique-writer-core",
+ "rstest",
  "tokio",
  "tokio-metrics",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,7 @@ name = "metrique-util"
 version = "0.1.2"
 dependencies = [
  "arc-swap",
+ "assert2",
  "metrique",
  "metrique-core",
  "metrique-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,10 +1703,10 @@ dependencies = [
 [[package]]
 name = "tokio-metrics"
 version = "0.4.9"
-source = "git+https://github.com/yulnr/tokio-metrics?branch=metrique-entry-support#fbcb7a1d666e95427e018ac8151f9981dfc3e286"
+source = "git+https://github.com/yulnr/tokio-metrics?branch=metrique-entry-support#bd771327c4718e9ef2cc3c4578d57f53c9dc3e40"
 dependencies = [
  "futures-util",
- "metrique-writer",
+ "metrique",
  "pin-project-lite",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "tokio-metrics"
 version = "0.4.9"
-source = "git+https://github.com/yulnr/tokio-metrics?branch=metrique-entry-support#f49c083ff7ded81b96fe458fe71b4cf13ea1a79a"
+source = "git+https://github.com/yulnr/tokio-metrics?branch=metrique-entry-support#5cc2ca6421dceab990108f7c52882a936bac4081"
 dependencies = [
  "futures-util",
  "metrique",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,8 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.4.9"
-source = "git+https://github.com/yulnr/tokio-metrics?branch=metrique-entry-support#5cc2ca6421dceab990108f7c52882a936bac4081"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e81d53caf955549b1dec7af4ac2149e94cc25ed97b4a545151140281e2f528"
 dependencies = [
  "futures-util",
  "metrique",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,8 @@ dependencies = [
  "metrique-writer",
  "metrique-writer-core",
  "tokio",
+ "tokio-metrics",
+ "tracing",
 ]
 
 [[package]]
@@ -1696,6 +1698,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.4.9"
+source = "git+https://github.com/yulnr/tokio-metrics?branch=metrique-entry-support#fbcb7a1d666e95427e018ac8151f9981dfc3e286"
+dependencies = [
+ "futures-util",
+ "metrique-writer",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "tokio-metrics"
 version = "0.4.9"
-source = "git+https://github.com/yulnr/tokio-metrics?branch=metrique-entry-support#bd771327c4718e9ef2cc3c4578d57f53c9dc3e40"
+source = "git+https://github.com/yulnr/tokio-metrics?branch=metrique-entry-support#f49c083ff7ded81b96fe458fe71b4cf13ea1a79a"
 dependencies = [
  "futures-util",
  "metrique",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ trybuild = "1.0"
 toml = "0.9"
 walkdir = "2"
 
+# External crates that depend on metrique pull it from crates.io, while workspace
+# members use local paths. Without these patches, Cargo treats them as separate
+# crates, causing duplicate type errors. Only affects workspace builds.
 [patch.crates-io]
 metrique = { path = "metrique" }
 metrique-core = { path = "metrique-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,13 +68,11 @@ trybuild = "1.0"
 toml = "0.9"
 walkdir = "2"
 
-# TODO: Remove before merge — tokio-metrics depends on metrique from
-# crates.io; patch to local to avoid duplicate crate errors.
 [patch.crates-io]
 metrique = { path = "metrique" }
 metrique-core = { path = "metrique-core" }
-metrique-writer-core = { path = "metrique-writer-core" }
-metrique-writer = { path = "metrique-writer" }
 metrique-macro = { path = "metrique-macro" }
 metrique-timesource = { path = "metrique-timesource" }
+metrique-writer = { path = "metrique-writer" }
+metrique-writer-core = { path = "metrique-writer-core" }
 metrique-writer-macro = { path = "metrique-writer-macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ toml = "0.9"
 walkdir = "2"
 
 # TODO: Remove before merge — tokio-metrics depends on metrique from
-# awslabs git; patch to local to avoid duplicate crate errors.
-[patch."https://github.com/awslabs/metrique"]
+# crates.io; patch to local to avoid duplicate crate errors.
+[patch.crates-io]
 metrique = { path = "metrique" }
 metrique-core = { path = "metrique-core" }
 metrique-writer-core = { path = "metrique-writer-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,13 @@ trybuild = "1.0"
 toml = "0.9"
 walkdir = "2"
 
-# TODO: Remove before merge — temporary overrides so that tokio-metrics'
-# transitive metrique-writer dep resolves to the local workspace versions,
-# avoiding duplicate-crate errors.
-[patch.crates-io]
+# TODO: Remove before merge — tokio-metrics depends on metrique from
+# awslabs git; patch to local to avoid duplicate crate errors.
+[patch."https://github.com/awslabs/metrique"]
+metrique = { path = "metrique" }
 metrique-core = { path = "metrique-core" }
 metrique-writer-core = { path = "metrique-writer-core" }
 metrique-writer = { path = "metrique-writer" }
+metrique-macro = { path = "metrique-macro" }
+metrique-timesource = { path = "metrique-timesource" }
+metrique-writer-macro = { path = "metrique-writer-macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,11 @@ tracing-subscriber = "0.3.20"
 trybuild = "1.0"
 toml = "0.9"
 walkdir = "2"
+
+# TODO: Remove before merge — temporary overrides so that tokio-metrics'
+# transitive metrique-writer dep resolves to the local workspace versions,
+# avoiding duplicate-crate errors.
+[patch.crates-io]
+metrique-core = { path = "metrique-core" }
+metrique-writer-core = { path = "metrique-writer-core" }
+metrique-writer = { path = "metrique-writer" }

--- a/metrique-core/src/lib.rs
+++ b/metrique-core/src/lib.rs
@@ -14,7 +14,7 @@ mod inflectable_entry_impls;
 mod namestyle;
 
 pub use atomics::{Counter, CounterGuard, OwnedCounterGuard};
-pub use namestyle::NameStyle;
+pub use namestyle::{DynamicNameStyle, Identity, KebabCase, NameStyle, PascalCase, SnakeCase};
 
 /// Close a given value
 ///

--- a/metrique-core/src/namestyle.rs
+++ b/metrique-core/src/namestyle.rs
@@ -126,3 +126,21 @@ impl<PREFIX: MaybeConstStr> NameStyle for KebabCase<PREFIX> {
         KEBAB: MaybeConstStr,
     > = KEBAB;
 }
+
+/// Runtime-selectable name style for metric field names.
+///
+/// This mirrors the compile-time [`NameStyle`] types (`Identity`, `PascalCase`,
+/// etc.) as enum variants for use in runtime configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum DynamicNameStyle {
+    /// Keep original field names.
+    #[default]
+    Identity,
+    /// Convert to PascalCase (e.g. `WorkersCount`).
+    PascalCase,
+    /// Convert to snake_case (e.g. `workers_count`).
+    SnakeCase,
+    /// Convert to kebab-case (e.g. `workers-count`).
+    KebabCase,
+}

--- a/metrique-util/Cargo.toml
+++ b/metrique-util/Cargo.toml
@@ -30,6 +30,7 @@ tokio-metrics = { version = "0.5.0", optional = true, features = ["rt", "metriqu
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
+assert2 = { workspace = true }
 metrique = { path = "../metrique", features = ["emf", "test-util"] }
 metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
 metrique-writer-core = { path = "../metrique-writer-core", features = ["test-util"] }

--- a/metrique-util/Cargo.toml
+++ b/metrique-util/Cargo.toml
@@ -34,6 +34,7 @@ metrique = { path = "../metrique", features = ["emf", "test-util"] }
 metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
 metrique-writer-core = { path = "../metrique-writer-core", features = ["test-util"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
+rstest = { workspace = true }
 metrique-util = { path = ".", features = ["state"] }
 
 [package.metadata.docs.rs]

--- a/metrique-util/Cargo.toml
+++ b/metrique-util/Cargo.toml
@@ -8,13 +8,27 @@ description = "Additional utilities for metrique"
 repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+
 [features]
 default = []
 state = ["dep:arc-swap"]
+tokio-metrics-bridge = [
+    "dep:metrique-writer-core",
+    "dep:tokio",
+    "dep:tokio-metrics",
+    "dep:tracing",
+]
 
 [dependencies]
 metrique-core = { path = "../metrique-core", version = "0.1.18" }
 arc-swap = { version = "1", optional = true }
+metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.13", optional = true }
+tokio = { workspace = true, optional = true, features = ["time", "rt"] }
+# TODO: Update before merge, should point to tokio-metrics on crates.io
+tokio-metrics = { git = "https://github.com/yulnr/tokio-metrics", branch = "metrique-entry-support", optional = true, features = ["rt", "metrique-integration"] }
+tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 metrique = { path = "../metrique", features = ["emf", "test-util"] }

--- a/metrique-util/Cargo.toml
+++ b/metrique-util/Cargo.toml
@@ -15,7 +15,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 default = []
 state = ["dep:arc-swap"]
 tokio-metrics-bridge = [
-    "dep:metrique-writer-core",
+    "dep:metrique",
     "dep:tokio",
     "dep:tokio-metrics",
     "dep:tracing",
@@ -23,11 +23,10 @@ tokio-metrics-bridge = [
 
 [dependencies]
 metrique-core = { path = "../metrique-core", version = "0.1.18" }
+metrique = { path = "../metrique", version = "0.1.23", optional = true, default-features = false }
 arc-swap = { version = "1", optional = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.13", optional = true }
 tokio = { workspace = true, optional = true, features = ["time", "rt"] }
-# TODO: Update before merge, should point to tokio-metrics on crates.io
-tokio-metrics = { git = "https://github.com/yulnr/tokio-metrics", branch = "metrique-entry-support", optional = true, features = ["rt", "metrique-integration"] }
+tokio-metrics = { version = "0.5.0", optional = true, features = ["rt", "metrique-integration"] }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/metrique-util/README.md
+++ b/metrique-util/README.md
@@ -5,7 +5,9 @@ Additional utilities for [metrique].
 ## Features
 
 - `state`: Provides [`State<T>`], an atomically swappable shared value with snapshot-on-first-read semantics. Useful for shared runtime state (feature flags, config reloads, routing tables) that should appear on every metric record.
-- `tokio-metrics-bridge`: Subscribes [tokio-metrics](https://crates.io/crates/tokio-metrics) runtime snapshots to a global entry sink. The reporter task is automatically aborted when the `AttachHandle` is dropped.
+- `tokio-metrics-bridge`: Subscribes [tokio-metrics] runtime snapshots to a global entry sink. The reporter task is automatically aborted when the `AttachHandle` is dropped.
+
+[tokio-metrics]: https://crates.io/crates/tokio-metrics
 
 ## Usage
 

--- a/metrique-util/README.md
+++ b/metrique-util/README.md
@@ -5,6 +5,7 @@ Additional utilities for [metrique].
 ## Features
 
 - `state`: Provides [`State<T>`], an atomically swappable shared value with snapshot-on-first-read semantics. Useful for shared runtime state (feature flags, config reloads, routing tables) that should appear on every metric record.
+- `tokio-metrics-bridge`: Subscribes [tokio-metrics](https://crates.io/crates/tokio-metrics) runtime snapshots to a global entry sink. The reporter task is automatically aborted when the `AttachHandle` is dropped.
 
 ## Usage
 

--- a/metrique-util/src/dynamic_inflection.rs
+++ b/metrique-util/src/dynamic_inflection.rs
@@ -48,10 +48,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use assert2::check;
     use metrique::CloseValue;
     use metrique::unit_of_work::metrics;
     use metrique_core::DynamicNameStyle;
-    use assert2::check;
     use metrique_writer::test_util::to_test_entry;
     use rstest::rstest;
 

--- a/metrique-util/src/dynamic_inflection.rs
+++ b/metrique-util/src/dynamic_inflection.rs
@@ -51,6 +51,7 @@ mod tests {
     use metrique::CloseValue;
     use metrique::unit_of_work::metrics;
     use metrique_core::DynamicNameStyle;
+    use assert2::check;
     use metrique_writer::test_util::to_test_entry;
     use rstest::rstest;
 
@@ -89,8 +90,8 @@ mod tests {
             name_style: style,
         };
         let t = to_test_entry(entry);
-        assert_eq!(t.metrics[expected_prefixed], 42);
-        assert_eq!(t.metrics[expected_plain], 7);
+        check!(t.metrics[expected_prefixed] == 42);
+        check!(t.metrics[expected_plain] == 7);
     }
 
     #[metrics]
@@ -128,8 +129,8 @@ mod tests {
             name_style: style,
         };
         let t = to_test_entry(entry);
-        assert_eq!(t.metrics[request_key], 5);
-        assert_eq!(t.metrics[workers_key], 0);
-        t.metrics[park_key].as_u64();
+        check!(t.metrics[request_key] == 5);
+        check!(t.metrics[workers_key] == 0);
+        check!(t.metrics[park_key].as_u64() == 0);
     }
 }

--- a/metrique-util/src/dynamic_inflection.rs
+++ b/metrique-util/src/dynamic_inflection.rs
@@ -45,3 +45,91 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use metrique::CloseValue;
+    use metrique::unit_of_work::metrics;
+    use metrique_core::DynamicNameStyle;
+    use metrique_writer::test_util::to_test_entry;
+    use rstest::rstest;
+
+    use super::DynamicInflectionEntry;
+
+    #[metrics(subfield_owned)]
+    #[derive(Default)]
+    struct Inner {
+        count: u64,
+    }
+
+    #[metrics]
+    #[derive(Default)]
+    struct Outer {
+        #[metrics(flatten, prefix = "pfx_")]
+        inner: Inner,
+        other: u64,
+    }
+
+    #[rstest]
+    #[case::identity(DynamicNameStyle::Identity, "pfx_count", "other")]
+    #[case::pascal_case(DynamicNameStyle::PascalCase, "PfxCount", "Other")]
+    #[case::snake_case(DynamicNameStyle::SnakeCase, "pfx_count", "other")]
+    #[case::kebab_case(DynamicNameStyle::KebabCase, "pfx-count", "other")]
+    fn prefix_inflection(
+        #[case] style: DynamicNameStyle,
+        #[case] expected_prefixed: &str,
+        #[case] expected_plain: &str,
+    ) {
+        let entry = DynamicInflectionEntry {
+            entry: Outer {
+                inner: Inner { count: 42 },
+                other: 7,
+            }
+            .close(),
+            name_style: style,
+        };
+        let t = to_test_entry(entry);
+        assert_eq!(t.metrics[expected_prefixed], 42);
+        assert_eq!(t.metrics[expected_plain], 7);
+    }
+
+    #[metrics]
+    struct WithRuntimeMetrics {
+        #[metrics(flatten, prefix = "rt_")]
+        runtime: tokio_metrics::RuntimeMetrics,
+        request_count: u64,
+    }
+
+    #[rstest]
+    #[case::identity(
+        DynamicNameStyle::Identity,
+        "request_count",
+        "rt_workers_count",
+        "rt_total_park_count"
+    )]
+    #[case::pascal_case(
+        DynamicNameStyle::PascalCase,
+        "RequestCount",
+        "RtWorkersCount",
+        "RtTotalParkCount"
+    )]
+    fn runtime_metrics_with_prefix(
+        #[case] style: DynamicNameStyle,
+        #[case] request_key: &str,
+        #[case] workers_key: &str,
+        #[case] park_key: &str,
+    ) {
+        let entry = DynamicInflectionEntry {
+            entry: WithRuntimeMetrics {
+                runtime: tokio_metrics::RuntimeMetrics::default(),
+                request_count: 5,
+            }
+            .close(),
+            name_style: style,
+        };
+        let t = to_test_entry(entry);
+        assert_eq!(t.metrics[request_key], 5);
+        assert_eq!(t.metrics[workers_key], 0);
+        t.metrics[park_key].as_u64();
+    }
+}

--- a/metrique-util/src/dynamic_inflection.rs
+++ b/metrique-util/src/dynamic_inflection.rs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use metrique::InflectableEntry;
+use metrique::writer::{Entry, EntryWriter};
+use metrique_core::{DynamicNameStyle, Identity, KebabCase, PascalCase, SnakeCase};
+
+use crate::MetricNameStyle;
+
+/// Adapter that bridges [`InflectableEntry`] to [`Entry`] by selecting the
+/// field name inflection ([`MetricNameStyle`]) at runtime.
+///
+/// Use this when the name style is determined by configuration rather than
+/// at compile time.
+pub(crate) struct DynamicInflectionEntry<M> {
+    pub(crate) entry: M,
+    pub(crate) name_style: MetricNameStyle,
+}
+
+impl<M> Entry for DynamicInflectionEntry<M>
+where
+    M: InflectableEntry<Identity>
+        + InflectableEntry<PascalCase>
+        + InflectableEntry<SnakeCase>
+        + InflectableEntry<KebabCase>,
+{
+    fn write<'a>(&'a self, w: &mut impl EntryWriter<'a>) {
+        match self.name_style {
+            DynamicNameStyle::Identity => InflectableEntry::<Identity>::write(&self.entry, w),
+            DynamicNameStyle::PascalCase => InflectableEntry::<PascalCase>::write(&self.entry, w),
+            DynamicNameStyle::SnakeCase => InflectableEntry::<SnakeCase>::write(&self.entry, w),
+            DynamicNameStyle::KebabCase => InflectableEntry::<KebabCase>::write(&self.entry, w),
+            _ => {
+                static WARNED_UNKNOWN_NAME_STYLE: AtomicBool = AtomicBool::new(false);
+                if !WARNED_UNKNOWN_NAME_STYLE.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        ?self.name_style,
+                        "unknown MetricNameStyle variant; falling back to Identity"
+                    );
+                }
+                InflectableEntry::<Identity>::write(&self.entry, w)
+            }
+        }
+    }
+}

--- a/metrique-util/src/lib.rs
+++ b/metrique-util/src/lib.rs
@@ -11,6 +11,8 @@ mod state;
 pub use state::{LatestRef, State};
 
 #[cfg(feature = "tokio-metrics-bridge")]
+mod dynamic_inflection;
+#[cfg(feature = "tokio-metrics-bridge")]
 mod tokio_metrics_reporter;
 #[cfg(feature = "tokio-metrics-bridge")]
 pub use tokio_metrics_reporter::{

--- a/metrique-util/src/lib.rs
+++ b/metrique-util/src/lib.rs
@@ -9,3 +9,8 @@
 mod state;
 #[cfg(feature = "state")]
 pub use state::{LatestRef, State};
+
+#[cfg(feature = "tokio-metrics-bridge")]
+mod tokio_metrics_reporter;
+#[cfg(feature = "tokio-metrics-bridge")]
+pub use tokio_metrics_reporter::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};

--- a/metrique-util/src/lib.rs
+++ b/metrique-util/src/lib.rs
@@ -3,16 +3,14 @@
 
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "state")]
 mod state;
 #[cfg(feature = "state")]
-#[cfg_attr(docsrs, doc(cfg(feature = "state")))]
 pub use state::{LatestRef, State};
 
 #[cfg(feature = "tokio-metrics-bridge")]
 mod tokio_metrics_reporter;
 #[cfg(feature = "tokio-metrics-bridge")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio-metrics-bridge")))]
 pub use tokio_metrics_reporter::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};

--- a/metrique-util/src/lib.rs
+++ b/metrique-util/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "state")]
 mod state;

--- a/metrique-util/src/lib.rs
+++ b/metrique-util/src/lib.rs
@@ -8,9 +8,11 @@
 #[cfg(feature = "state")]
 mod state;
 #[cfg(feature = "state")]
+#[cfg_attr(docsrs, doc(cfg(feature = "state")))]
 pub use state::{LatestRef, State};
 
 #[cfg(feature = "tokio-metrics-bridge")]
 mod tokio_metrics_reporter;
 #[cfg(feature = "tokio-metrics-bridge")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio-metrics-bridge")))]
 pub use tokio_metrics_reporter::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};

--- a/metrique-util/src/lib.rs
+++ b/metrique-util/src/lib.rs
@@ -13,4 +13,6 @@ pub use state::{LatestRef, State};
 #[cfg(feature = "tokio-metrics-bridge")]
 mod tokio_metrics_reporter;
 #[cfg(feature = "tokio-metrics-bridge")]
-pub use tokio_metrics_reporter::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};
+pub use tokio_metrics_reporter::{
+    AttachGlobalEntrySinkTokioMetricsExt, MetricNameStyle, TokioRuntimeMetricsConfig,
+};

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -14,6 +14,7 @@ const DEFAULT_METRIC_SAMPLING_INTERVAL: Duration = Duration::from_secs(30);
 /// Configuration for Tokio runtime metrics bridge subscriptions.
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
+#[must_use]
 pub struct TokioRuntimeMetricsConfig {
     /// Sampling interval used by the reporter loop.
     interval: Duration,

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -170,20 +170,12 @@ mod tests {
         assert!(!entries.is_empty(), "expected entries");
 
         let entry = &entries[0];
-        assert!(
-            entry.metrics.contains_key("workers_count"),
-            "expected snake_case field names with Identity style, got keys: {:?}",
-            entry.metrics.keys().collect::<Vec<_>>()
-        );
-        assert!(entry.metrics.contains_key("total_park_count"));
-        assert!(entry.metrics.contains_key("elapsed"));
+        assert_eq!(entry.metrics["workers_count"], 1);
+        entry.metrics["total_park_count"].as_u64();
+        assert!(entry.metrics["elapsed"] > 0.0);
 
         #[cfg(tokio_unstable)]
-        assert!(
-            entry.metrics.contains_key("poll_time_histogram"),
-            "expected poll_time_histogram under tokio_unstable, got keys: {:?}",
-            entry.metrics.keys().collect::<Vec<_>>()
-        );
+        assert!(entry.metrics["poll_time_histogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -204,20 +196,12 @@ mod tests {
         assert!(!entries.is_empty(), "expected entries");
 
         let entry = &entries[0];
-        assert!(
-            entry.metrics.contains_key("WorkersCount"),
-            "expected PascalCase field names, got keys: {:?}",
-            entry.metrics.keys().collect::<Vec<_>>()
-        );
-        assert!(entry.metrics.contains_key("TotalParkCount"));
-        assert!(entry.metrics.contains_key("Elapsed"));
+        assert_eq!(entry.metrics["WorkersCount"], 1);
+        entry.metrics["TotalParkCount"].as_u64();
+        assert!(entry.metrics["Elapsed"] > 0.0);
 
         #[cfg(tokio_unstable)]
-        assert!(
-            entry.metrics.contains_key("PollTimeHistogram"),
-            "expected PollTimeHistogram under tokio_unstable, got keys: {:?}",
-            entry.metrics.keys().collect::<Vec<_>>()
-        );
+        assert!(entry.metrics["PollTimeHistogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -238,20 +222,12 @@ mod tests {
         assert!(!entries.is_empty(), "expected entries");
 
         let entry = &entries[0];
-        assert!(
-            entry.metrics.contains_key("workers_count"),
-            "expected snake_case field names, got keys: {:?}",
-            entry.metrics.keys().collect::<Vec<_>>()
-        );
-        assert!(entry.metrics.contains_key("total_park_count"));
-        assert!(entry.metrics.contains_key("elapsed"));
+        assert_eq!(entry.metrics["workers_count"], 1);
+        entry.metrics["total_park_count"].as_u64();
+        assert!(entry.metrics["elapsed"] > 0.0);
 
         #[cfg(tokio_unstable)]
-        assert!(
-            entry.metrics.contains_key("poll_time_histogram"),
-            "expected poll_time_histogram under tokio_unstable, got keys: {:?}",
-            entry.metrics.keys().collect::<Vec<_>>()
-        );
+        assert!(entry.metrics["poll_time_histogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -272,20 +248,12 @@ mod tests {
         assert!(!entries.is_empty(), "expected entries");
 
         let entry = &entries[0];
-        assert!(
-            entry.metrics.contains_key("workers-count"),
-            "expected kebab-case field names, got keys: {:?}",
-            entry.metrics.keys().collect::<Vec<_>>()
-        );
-        assert!(entry.metrics.contains_key("total-park-count"));
-        assert!(entry.metrics.contains_key("elapsed"));
+        assert_eq!(entry.metrics["workers-count"], 1);
+        entry.metrics["total-park-count"].as_u64();
+        assert!(entry.metrics["elapsed"] > 0.0);
 
         #[cfg(tokio_unstable)]
-        assert!(
-            entry.metrics.contains_key("poll-time-histogram"),
-            "expected poll-time-histogram under tokio_unstable, got keys: {:?}",
-            entry.metrics.keys().collect::<Vec<_>>()
-        );
+        assert!(entry.metrics["poll-time-histogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -74,9 +74,10 @@ pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEn
     /// [`AttachHandle`]: metrique_writer_core::global::AttachHandle
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
         let sink = Self::sink();
-        let task = spawn_tokio_runtime_metrics_task(sink, config);
+        let (worker_abort, monitor) = spawn_tokio_runtime_metrics_task(sink, config);
         Self::register_shutdown_fn(Box::new(move || {
-            task.abort();
+            worker_abort.abort();
+            monitor.abort();
         }));
     }
 }
@@ -86,9 +87,9 @@ impl<T: AttachGlobalEntrySink + GlobalEntrySink> AttachGlobalEntrySinkTokioMetri
 fn spawn_tokio_runtime_metrics_task(
     sink: BoxEntrySink,
     config: TokioRuntimeMetricsConfig,
-) -> JoinHandle<()> {
+) -> (tokio::task::AbortHandle, JoinHandle<()>) {
     let interval = config.interval;
-    tokio::spawn(async move {
+    let worker = tokio::spawn(async move {
         tracing::debug!("tokio runtime metrics reporter started");
         let handle = Handle::current();
         let monitor = RuntimeMonitor::new(&handle);
@@ -107,7 +108,20 @@ fn spawn_tokio_runtime_metrics_task(
             tokio::time::sleep(interval).await;
         }
         tracing::debug!("tokio runtime metrics reporter stopped");
-    })
+    });
+    let worker_abort = worker.abort_handle();
+    let monitor = tokio::spawn(async move {
+        match worker.await {
+            Ok(()) => {}
+            Err(err) if err.is_cancelled() => {
+                tracing::debug!("tokio runtime metrics reporter cancelled");
+            }
+            Err(err) => {
+                tracing::error!(?err, "tokio runtime metrics reporter panicked");
+            }
+        }
+    });
+    (worker_abort, monitor)
 }
 
 /// Emit `poll_time_histogram` bucket counts as a metrique distribution metric,

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -13,6 +13,11 @@ use tokio_metrics::RuntimeMonitor;
 
 const DEFAULT_METRIC_SAMPLING_INTERVAL: Duration = Duration::from_secs(30);
 
+/// Runtime metric field naming style used by the Tokio metrics bridge.
+///
+/// This is a re-export of [`metrique_core::DynamicNameStyle`].
+pub use metrique_core::DynamicNameStyle as MetricNameStyle;
+
 /// Configuration for Tokio runtime metrics bridge subscriptions.
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
@@ -20,12 +25,15 @@ const DEFAULT_METRIC_SAMPLING_INTERVAL: Duration = Duration::from_secs(30);
 pub struct TokioRuntimeMetricsConfig {
     /// Sampling interval used by the reporter loop.
     interval: Duration,
+    /// Name style for emitted metric fields.
+    name_style: MetricNameStyle,
 }
 
 impl Default for TokioRuntimeMetricsConfig {
     fn default() -> Self {
         Self {
             interval: DEFAULT_METRIC_SAMPLING_INTERVAL,
+            name_style: MetricNameStyle::default(),
         }
     }
 }
@@ -34,6 +42,13 @@ impl TokioRuntimeMetricsConfig {
     /// Return a config with a custom sampling interval.
     pub fn with_interval(self, interval: Duration) -> Self {
         Self { interval, ..self }
+    }
+
+    /// Set the name style for emitted metric fields.
+    ///
+    /// Defaults to [`MetricNameStyle::Identity`].
+    pub fn with_name_style(self, name_style: MetricNameStyle) -> Self {
+        Self { name_style, ..self }
     }
 }
 
@@ -53,13 +68,16 @@ impl TokioRuntimeMetricsConfig {
 /// # Example
 ///
 /// ```rust,ignore
-/// use metrique_util::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};
+/// use metrique_util::{
+///     AttachGlobalEntrySinkTokioMetricsExt, MetricNameStyle, TokioRuntimeMetricsConfig,
+/// };
 /// use std::time::Duration;
 ///
 /// let _handle = ServiceMetrics::attach_to_stream(emf.output_to(std::io::stderr()));
 ///
 /// let config = TokioRuntimeMetricsConfig::default()
-///     .with_interval(Duration::from_secs(30));
+///     .with_interval(Duration::from_secs(30))
+///     .with_name_style(MetricNameStyle::PascalCase);
 /// ServiceMetrics::subscribe_tokio_runtime_metrics(config);
 /// ```
 ///
@@ -103,12 +121,16 @@ fn spawn_tokio_runtime_metrics_task(
     config: TokioRuntimeMetricsConfig,
 ) -> (tokio::task::AbortHandle, JoinHandle<()>) {
     let interval = config.interval;
+    let name_style = config.name_style;
     let worker = tokio::spawn(async move {
         tracing::debug!("tokio runtime metrics reporter started");
         let handle = Handle::current();
         let monitor = RuntimeMonitor::new(&handle);
         for snapshot in monitor.intervals() {
-            sink.append(RootedEntry(snapshot.close()));
+            sink.append(RootedEntry {
+                entry: snapshot.close(),
+                name_style,
+            });
             tokio::time::sleep(interval).await;
         }
         tracing::debug!("tokio runtime metrics reporter stopped");
@@ -128,12 +150,46 @@ fn spawn_tokio_runtime_metrics_task(
     (worker_abort, monitor)
 }
 
-/// Wrapper that roots an [`InflectableEntry`] into an [`Entry`] for `sink.append()`.
-struct RootedEntry<M: InflectableEntry>(M);
+/// Wrapper that roots an [`InflectableEntry`] into an [`Entry`], applying the
+/// configured [`MetricNameStyle`].
+struct RootedEntry<M> {
+    entry: M,
+    name_style: MetricNameStyle,
+}
 
-impl<M: InflectableEntry> Entry for RootedEntry<M> {
+impl<M> Entry for RootedEntry<M>
+where
+    M: InflectableEntry<metrique_core::Identity>
+        + InflectableEntry<metrique_core::PascalCase>
+        + InflectableEntry<metrique_core::SnakeCase>
+        + InflectableEntry<metrique_core::KebabCase>,
+{
     fn write<'a>(&'a self, w: &mut impl EntryWriter<'a>) {
-        self.0.write(w);
+        use metrique_core::DynamicNameStyle;
+        match self.name_style {
+            DynamicNameStyle::Identity => {
+                InflectableEntry::<metrique_core::Identity>::write(&self.entry, w)
+            }
+            DynamicNameStyle::PascalCase => {
+                InflectableEntry::<metrique_core::PascalCase>::write(&self.entry, w)
+            }
+            DynamicNameStyle::SnakeCase => {
+                InflectableEntry::<metrique_core::SnakeCase>::write(&self.entry, w)
+            }
+            DynamicNameStyle::KebabCase => {
+                InflectableEntry::<metrique_core::KebabCase>::write(&self.entry, w)
+            }
+            _ => {
+                static WARNED_UNKNOWN_NAME_STYLE: AtomicBool = AtomicBool::new(false);
+                if !WARNED_UNKNOWN_NAME_STYLE.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        ?self.name_style,
+                        "unknown MetricNameStyle variant; falling back to Identity"
+                    );
+                }
+                InflectableEntry::<metrique_core::Identity>::write(&self.entry, w)
+            }
+        }
     }
 }
 
@@ -144,10 +200,10 @@ mod tests {
     use metrique_writer::sink::AttachGlobalEntrySink;
     use metrique_writer::test_util::{TestEntrySink, test_entry_sink};
 
-    use super::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};
+    use super::{AttachGlobalEntrySinkTokioMetricsExt, MetricNameStyle, TokioRuntimeMetricsConfig};
 
     #[tokio::test(start_paused = true)]
-    async fn subscribe_appends_metrics() {
+    async fn subscribe_appends_metrics_identity() {
         metrique_writer::sink::global_entry_sink! { Sink }
         let TestEntrySink { inspector, sink } = test_entry_sink();
         let _handle = Sink::attach((sink, ()));
@@ -156,30 +212,126 @@ mod tests {
             TokioRuntimeMetricsConfig::default().with_interval(Duration::from_millis(50)),
         );
 
-        // Advance past a few intervals so the reporter loop emits entries.
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let entries = inspector.entries();
+        assert!(!entries.is_empty(), "expected entries");
+
+        let entry = &entries[0];
         assert!(
-            !entries.is_empty(),
-            "expected tokio runtime metrics entries"
+            entry.metrics.contains_key("workers_count"),
+            "expected snake_case field names with Identity style, got keys: {:?}",
+            entry.metrics.keys().collect::<Vec<_>>()
+        );
+        assert!(entry.metrics.contains_key("total_park_count"));
+        assert!(entry.metrics.contains_key("elapsed"));
+
+        #[cfg(tokio_unstable)]
+        assert!(
+            entry.metrics.contains_key("poll_time_histogram"),
+            "expected poll_time_histogram under tokio_unstable, got keys: {:?}",
+            entry.metrics.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn subscribe_appends_metrics_pascal_case() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { inspector, sink } = test_entry_sink();
+        let _handle = Sink::attach((sink, ()));
+
+        Sink::subscribe_tokio_runtime_metrics(
+            TokioRuntimeMetricsConfig::default()
+                .with_interval(Duration::from_millis(50))
+                .with_name_style(MetricNameStyle::PascalCase),
         );
 
-        // Verify runtime metrics are present in the entry.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let entries = inspector.entries();
+        assert!(!entries.is_empty(), "expected entries");
+
         let entry = &entries[0];
         assert!(
             entry.metrics.contains_key("WorkersCount"),
-            "expected WorkersCount metric, got keys: {:?}",
+            "expected PascalCase field names, got keys: {:?}",
             entry.metrics.keys().collect::<Vec<_>>()
         );
         assert!(entry.metrics.contains_key("TotalParkCount"));
         assert!(entry.metrics.contains_key("Elapsed"));
 
-        // Under tokio_unstable, the histogram field should be present.
         #[cfg(tokio_unstable)]
         assert!(
             entry.metrics.contains_key("PollTimeHistogram"),
-            "expected PollTimeHistogram metric under tokio_unstable, got keys: {:?}",
+            "expected PollTimeHistogram under tokio_unstable, got keys: {:?}",
+            entry.metrics.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn subscribe_appends_metrics_snake_case() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { inspector, sink } = test_entry_sink();
+        let _handle = Sink::attach((sink, ()));
+
+        Sink::subscribe_tokio_runtime_metrics(
+            TokioRuntimeMetricsConfig::default()
+                .with_interval(Duration::from_millis(50))
+                .with_name_style(MetricNameStyle::SnakeCase),
+        );
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let entries = inspector.entries();
+        assert!(!entries.is_empty(), "expected entries");
+
+        let entry = &entries[0];
+        assert!(
+            entry.metrics.contains_key("workers_count"),
+            "expected snake_case field names, got keys: {:?}",
+            entry.metrics.keys().collect::<Vec<_>>()
+        );
+        assert!(entry.metrics.contains_key("total_park_count"));
+        assert!(entry.metrics.contains_key("elapsed"));
+
+        #[cfg(tokio_unstable)]
+        assert!(
+            entry.metrics.contains_key("poll_time_histogram"),
+            "expected poll_time_histogram under tokio_unstable, got keys: {:?}",
+            entry.metrics.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn subscribe_appends_metrics_kebab_case() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { inspector, sink } = test_entry_sink();
+        let _handle = Sink::attach((sink, ()));
+
+        Sink::subscribe_tokio_runtime_metrics(
+            TokioRuntimeMetricsConfig::default()
+                .with_interval(Duration::from_millis(50))
+                .with_name_style(MetricNameStyle::KebabCase),
+        );
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let entries = inspector.entries();
+        assert!(!entries.is_empty(), "expected entries");
+
+        let entry = &entries[0];
+        assert!(
+            entry.metrics.contains_key("workers-count"),
+            "expected kebab-case field names, got keys: {:?}",
+            entry.metrics.keys().collect::<Vec<_>>()
+        );
+        assert!(entry.metrics.contains_key("total-park-count"));
+        assert!(entry.metrics.contains_key("elapsed"));
+
+        #[cfg(tokio_unstable)]
+        assert!(
+            entry.metrics.contains_key("poll-time-histogram"),
+            "expected poll-time-histogram under tokio_unstable, got keys: {:?}",
             entry.metrics.keys().collect::<Vec<_>>()
         );
     }

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -4,9 +4,9 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use metrique_core::{CloseValue, InflectableEntry};
-use metrique_writer_core::global::{AttachGlobalEntrySink, GlobalEntrySink};
-use metrique_writer_core::{BoxEntrySink, Entry, EntrySink, EntryWriter};
+use crate::dynamic_inflection::DynamicInflectionEntry;
+use metrique::CloseValue;
+use metrique::writer::{AttachGlobalEntrySink, BoxEntrySink, EntrySink, GlobalEntrySink};
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tokio_metrics::RuntimeMonitor;
@@ -127,7 +127,7 @@ fn spawn_tokio_runtime_metrics_task(
         let handle = Handle::current();
         let monitor = RuntimeMonitor::new(&handle);
         for snapshot in monitor.intervals() {
-            sink.append(RootedEntry {
+            sink.append(DynamicInflectionEntry {
                 entry: snapshot.close(),
                 name_style,
             });
@@ -148,49 +148,6 @@ fn spawn_tokio_runtime_metrics_task(
         }
     });
     (worker_abort, monitor)
-}
-
-/// Wrapper that roots an [`InflectableEntry`] into an [`Entry`], applying the
-/// configured [`MetricNameStyle`].
-struct RootedEntry<M> {
-    entry: M,
-    name_style: MetricNameStyle,
-}
-
-impl<M> Entry for RootedEntry<M>
-where
-    M: InflectableEntry<metrique_core::Identity>
-        + InflectableEntry<metrique_core::PascalCase>
-        + InflectableEntry<metrique_core::SnakeCase>
-        + InflectableEntry<metrique_core::KebabCase>,
-{
-    fn write<'a>(&'a self, w: &mut impl EntryWriter<'a>) {
-        use metrique_core::DynamicNameStyle;
-        match self.name_style {
-            DynamicNameStyle::Identity => {
-                InflectableEntry::<metrique_core::Identity>::write(&self.entry, w)
-            }
-            DynamicNameStyle::PascalCase => {
-                InflectableEntry::<metrique_core::PascalCase>::write(&self.entry, w)
-            }
-            DynamicNameStyle::SnakeCase => {
-                InflectableEntry::<metrique_core::SnakeCase>::write(&self.entry, w)
-            }
-            DynamicNameStyle::KebabCase => {
-                InflectableEntry::<metrique_core::KebabCase>::write(&self.entry, w)
-            }
-            _ => {
-                static WARNED_UNKNOWN_NAME_STYLE: AtomicBool = AtomicBool::new(false);
-                if !WARNED_UNKNOWN_NAME_STYLE.swap(true, Ordering::Relaxed) {
-                    tracing::warn!(
-                        ?self.name_style,
-                        "unknown MetricNameStyle variant; falling back to Identity"
-                    );
-                }
-                InflectableEntry::<metrique_core::Identity>::write(&self.entry, w)
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::dynamic_inflection::DynamicInflectionEntry;
 use metrique::CloseValue;
-use metrique::writer::{AttachGlobalEntrySink, BoxEntrySink, EntrySink, GlobalEntrySink};
+use metrique::writer::{AttachGlobalEntrySink, BoxEntrySink, EntrySink};
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tokio_metrics::RuntimeMonitor;
@@ -79,17 +79,16 @@ impl TokioRuntimeMetricsConfig {
 ///     .with_name_style(MetricNameStyle::PascalCase);
 /// ServiceMetrics::subscribe_tokio_runtime_metrics(config);
 /// ```
-pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEntrySink {
+pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + 'static {
     /// Subscribe to Tokio runtime metrics, adding the subscription to this handle.
     ///
     /// The reporter task is automatically aborted when the [`AttachHandle`](metrique::writer::sink::AttachHandle) is dropped.
     /// If the handle is [`forgotten`](metrique::writer::sink::AttachHandle::forget), the reporter runs indefinitely.
     ///
-    /// # Panics
-    /// Panics if no sink has been attached yet, or if the underlying sink has been
-    /// detached (e.g. the `AttachHandle` was dropped or forgotten before this call).
+    /// If no sink has been attached yet, entries are silently discarded until one
+    /// is attached.
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
-        let sink = Self::sink();
+        let sink = BoxEntrySink::lazy(Self::try_sink);
         let (worker_abort, monitor) = spawn_tokio_runtime_metrics_task(sink, config);
         Self::register_shutdown_fn(Box::new(move || {
             worker_abort.abort();
@@ -98,7 +97,7 @@ pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEn
     }
 }
 
-impl<T: AttachGlobalEntrySink + GlobalEntrySink> AttachGlobalEntrySinkTokioMetricsExt for T {}
+impl<T: AttachGlobalEntrySink + 'static> AttachGlobalEntrySinkTokioMetricsExt for T {}
 
 fn spawn_tokio_runtime_metrics_task(
     sink: BoxEntrySink,

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -3,8 +3,9 @@
 
 use std::time::Duration;
 
+use metrique_core::{CloseValue, InflectableEntry};
 use metrique_writer_core::global::{AttachGlobalEntrySink, GlobalEntrySink};
-use metrique_writer_core::{BoxEntrySink, EntrySink};
+use metrique_writer_core::{BoxEntrySink, Entry, EntrySink, EntryWriter};
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tokio_metrics::RuntimeMonitor;
@@ -96,17 +97,7 @@ fn spawn_tokio_runtime_metrics_task(
         let handle = Handle::current();
         let monitor = RuntimeMonitor::new(&handle);
         for snapshot in monitor.intervals() {
-            // Take histogram counts before moving snapshot into append.
-            // Bucket ranges come from the runtime handle at format time.
-            #[cfg(tokio_unstable)]
-            let (snapshot, histogram_counts) = {
-                let mut snapshot = snapshot;
-                let counts = std::mem::take(&mut snapshot.poll_time_histogram);
-                (snapshot, counts)
-            };
-            sink.append(snapshot);
-            #[cfg(tokio_unstable)]
-            emit_poll_time_histogram(&sink, histogram_counts, handle.metrics());
+            sink.append(RootedEntry(snapshot.close()));
             tokio::time::sleep(interval).await;
         }
         tracing::debug!("tokio runtime metrics reporter stopped");
@@ -126,56 +117,13 @@ fn spawn_tokio_runtime_metrics_task(
     (worker_abort, monitor)
 }
 
-/// Emit `poll_time_histogram` bucket counts as a metrique distribution metric,
-/// pairing each bucket's count with its range from the runtime handle.
-#[cfg(tokio_unstable)]
-fn emit_poll_time_histogram(
-    sink: &BoxEntrySink,
-    counts: Vec<u64>,
-    rt: tokio::runtime::RuntimeMetrics,
-) {
-    use metrique_writer_core::value::MetricFlags;
-    use metrique_writer_core::{Entry, EntryWriter, Observation, Unit, unit::NegativeScale};
+/// Wrapper that roots an [`InflectableEntry`] into an [`Entry`] for `sink.append()`.
+struct RootedEntry<M: InflectableEntry>(M);
 
-    // Emitted as a separate entry alongside RuntimeMetrics because
-    // `poll_time_histogram` uses #[entry(ignore)] on RuntimeMetrics — the raw
-    // Vec<u64> counts need bucket ranges from the runtime handle to be
-    // meaningful, which Entry::write() doesn't have access to.
-    struct PollTimeHistogramEntry {
-        counts: Vec<u64>,
-        rt: tokio::runtime::RuntimeMetrics,
+impl<M: InflectableEntry> Entry for RootedEntry<M> {
+    fn write<'a>(&'a self, w: &mut impl EntryWriter<'a>) {
+        self.0.write(w);
     }
-
-    impl Entry for PollTimeHistogramEntry {
-        fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
-            writer.value("poll_time_histogram", self);
-        }
-    }
-
-    impl metrique_writer_core::Value for PollTimeHistogramEntry {
-        fn write(&self, writer: impl metrique_writer_core::ValueWriter) {
-            writer.metric(
-                self.counts
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, c)| **c > 0)
-                    .map(|(i, &count)| {
-                        let range = self.rt.poll_time_histogram_bucket_range(i);
-                        let midpoint_us =
-                            (range.start.as_micros() + range.end.as_micros()) as f64 / 2.0;
-                        Observation::Repeated {
-                            total: midpoint_us * count as f64,
-                            occurrences: count,
-                        }
-                    }),
-                Unit::Second(NegativeScale::Micro),
-                [],
-                MetricFlags::empty(),
-            );
-        }
-    }
-
-    sink.append(PollTimeHistogramEntry { counts, rt });
 }
 
 #[cfg(test)]
@@ -200,9 +148,28 @@ mod tests {
         // Advance past a few intervals so the reporter loop emits entries.
         tokio::time::sleep(Duration::from_millis(200)).await;
 
+        let entries = inspector.entries();
         assert!(
-            !inspector.entries().is_empty(),
+            !entries.is_empty(),
             "expected tokio runtime metrics entries"
+        );
+
+        // Verify runtime metrics are present in the entry.
+        let entry = &entries[0];
+        assert!(
+            entry.metrics.contains_key("WorkersCount"),
+            "expected WorkersCount metric, got keys: {:?}",
+            entry.metrics.keys().collect::<Vec<_>>()
+        );
+        assert!(entry.metrics.contains_key("TotalParkCount"));
+        assert!(entry.metrics.contains_key("Elapsed"));
+
+        // Under tokio_unstable, the histogram field should be present.
+        #[cfg(tokio_unstable)]
+        assert!(
+            entry.metrics.contains_key("PollTimeHistogram"),
+            "expected PollTimeHistogram metric under tokio_unstable, got keys: {:?}",
+            entry.metrics.keys().collect::<Vec<_>>()
         );
     }
 

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -56,7 +56,7 @@ impl TokioRuntimeMetricsConfig {
 ///
 /// Spawns a background task that periodically samples
 /// [`RuntimeMetrics`](tokio_metrics::RuntimeMetrics) and appends each snapshot to the sink.
-/// The task is automatically aborted when the [`AttachHandle`] is dropped.
+/// The task is automatically aborted when the [`AttachHandle`](metrique::writer::sink::AttachHandle) is dropped.
 ///
 /// # `tokio_unstable`
 ///
@@ -80,20 +80,15 @@ impl TokioRuntimeMetricsConfig {
 ///     .with_name_style(MetricNameStyle::PascalCase);
 /// ServiceMetrics::subscribe_tokio_runtime_metrics(config);
 /// ```
-///
-/// [`AttachHandle`]: metrique_writer_core::global::AttachHandle
 pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEntrySink {
     /// Subscribe to Tokio runtime metrics, adding the subscription to this handle.
     ///
-    /// The reporter task is automatically aborted when the [`AttachHandle`] is dropped.
-    /// If the handle is [`forgotten`], the reporter runs indefinitely.
+    /// The reporter task is automatically aborted when the [`AttachHandle`](metrique::writer::sink::AttachHandle) is dropped.
+    /// If the handle is [`forgotten`](metrique::writer::sink::AttachHandle::forget), the reporter runs indefinitely.
     ///
     /// # Panics
     /// Panics if no sink has been attached yet, or if the underlying sink has been
     /// detached (e.g. the `AttachHandle` was dropped or forgotten before this call).
-    ///
-    /// [`AttachHandle`]: metrique_writer_core::global::AttachHandle
-    /// [`forgotten`]: metrique_writer_core::global::AttachHandle::forget
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
         // Guard against duplicate subscriptions within the same attach cycle.
         // Reset in the shutdown fn so re-attaching can subscribe again cleanly.

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -135,9 +135,10 @@ fn spawn_tokio_runtime_metrics_task(
     // Spawn a monitor to log panics
     tokio::spawn(async move {
         if let Err(err) = worker.await
-            && !err.is_cancelled() {
-                tracing::error!("tokio runtime metrics reporter panicked: {err}");
-            }
+            && !err.is_cancelled()
+        {
+            tracing::error!("tokio runtime metrics reporter panicked: {err}");
+        }
     });
     abort
 }

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -36,6 +36,32 @@ impl TokioRuntimeMetricsConfig {
 }
 
 /// Extension methods for subscribing Tokio runtime metrics to a global entry sink.
+///
+/// Spawns a background task that periodically samples
+/// [`RuntimeMetrics`](tokio_metrics::RuntimeMetrics) and appends each snapshot to the sink.
+/// The task is automatically aborted when the [`AttachHandle`] is dropped.
+///
+/// # `tokio_unstable`
+///
+/// When the runtime is built with `RUSTFLAGS="--cfg tokio_unstable"` and
+/// `enable_metrics_poll_time_histogram` is called on the runtime builder, each
+/// snapshot also includes a `poll_time_histogram` entry emitted as a distribution
+/// metric with bucket ranges from the runtime handle.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use metrique_util::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};
+/// use std::time::Duration;
+///
+/// let _handle = ServiceMetrics::attach_to_stream(emf.output_to(std::io::stderr()));
+///
+/// let config = TokioRuntimeMetricsConfig::default()
+///     .with_interval(Duration::from_secs(30));
+/// ServiceMetrics::subscribe_tokio_runtime_metrics(config);
+/// ```
+///
+/// [`AttachHandle`]: metrique_writer_core::global::AttachHandle
 pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEntrySink {
     /// Subscribe to Tokio runtime metrics, adding the subscription to this handle.
     ///

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -1,0 +1,189 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use metrique_writer_core::global::{AttachGlobalEntrySink, GlobalEntrySink};
+use metrique_writer_core::{BoxEntrySink, EntrySink};
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
+use tokio_metrics::RuntimeMonitor;
+
+const DEFAULT_METRIC_SAMPLING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Configuration for Tokio runtime metrics bridge subscriptions.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct TokioRuntimeMetricsConfig {
+    /// Sampling interval used by the reporter loop.
+    pub interval: Duration,
+}
+
+impl Default for TokioRuntimeMetricsConfig {
+    fn default() -> Self {
+        Self {
+            interval: DEFAULT_METRIC_SAMPLING_INTERVAL,
+        }
+    }
+}
+
+impl TokioRuntimeMetricsConfig {
+    /// Return a config with a custom sampling interval.
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+}
+
+/// Extension methods for subscribing Tokio runtime metrics to a global entry sink.
+pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEntrySink {
+    /// Subscribe to Tokio runtime metrics, adding the subscription to this handle.
+    ///
+    /// The reporter task is automatically aborted when the [`AttachHandle`] is dropped.
+    ///
+    /// # Panics
+    /// Panics if the underlying sink has been detached (e.g. the `AttachHandle` was
+    /// dropped elsewhere before this call).
+    ///
+    /// [`AttachHandle`]: metrique_writer_core::global::AttachHandle
+    fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
+        let sink = Self::sink();
+        let task = spawn_tokio_runtime_metrics_task(sink, config);
+        Self::register_shutdown_fn(Box::new(move || {
+            task.abort();
+        }));
+    }
+}
+
+impl<T: AttachGlobalEntrySink + GlobalEntrySink> AttachGlobalEntrySinkTokioMetricsExt for T {}
+
+fn spawn_tokio_runtime_metrics_task(
+    sink: BoxEntrySink,
+    config: TokioRuntimeMetricsConfig,
+) -> JoinHandle<()> {
+    let interval = config.interval;
+    tokio::spawn(async move {
+        tracing::debug!("tokio runtime metrics reporter started");
+        let handle = Handle::current();
+        let monitor = RuntimeMonitor::new(&handle);
+        for snapshot in monitor.intervals() {
+            // Take histogram counts before moving snapshot into append.
+            // Bucket ranges come from the runtime handle at format time.
+            #[cfg(tokio_unstable)]
+            let (snapshot, histogram_counts) = {
+                let mut snapshot = snapshot;
+                let counts = std::mem::take(&mut snapshot.poll_time_histogram);
+                (snapshot, counts)
+            };
+            sink.append(snapshot);
+            #[cfg(tokio_unstable)]
+            emit_poll_time_histogram(&sink, histogram_counts, handle.metrics());
+            tokio::time::sleep(interval).await;
+        }
+        tracing::debug!("tokio runtime metrics reporter stopped");
+    })
+}
+
+/// Emit `poll_time_histogram` bucket counts as a metrique distribution metric,
+/// pairing each bucket's count with its range from the runtime handle.
+#[cfg(tokio_unstable)]
+fn emit_poll_time_histogram(
+    sink: &BoxEntrySink,
+    counts: Vec<u64>,
+    rt: tokio::runtime::RuntimeMetrics,
+) {
+    use metrique_writer_core::value::MetricFlags;
+    use metrique_writer_core::{Entry, EntryWriter, Observation, Unit, unit::NegativeScale};
+
+    // Emitted as a separate entry alongside RuntimeMetrics because
+    // `poll_time_histogram` uses #[entry(ignore)] on RuntimeMetrics — the raw
+    // Vec<u64> counts need bucket ranges from the runtime handle to be
+    // meaningful, which Entry::write() doesn't have access to.
+    struct PollTimeHistogramEntry {
+        counts: Vec<u64>,
+        rt: tokio::runtime::RuntimeMetrics,
+    }
+
+    impl Entry for PollTimeHistogramEntry {
+        fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+            writer.value("poll_time_histogram", self);
+        }
+    }
+
+    impl metrique_writer_core::Value for PollTimeHistogramEntry {
+        fn write(&self, writer: impl metrique_writer_core::ValueWriter) {
+            writer.metric(
+                self.counts
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, c)| **c > 0)
+                    .map(|(i, &count)| {
+                        let range = self.rt.poll_time_histogram_bucket_range(i);
+                        let midpoint_us =
+                            (range.start.as_micros() + range.end.as_micros()) as f64 / 2.0;
+                        Observation::Repeated {
+                            total: midpoint_us * count as f64,
+                            occurrences: count,
+                        }
+                    }),
+                Unit::Second(NegativeScale::Micro),
+                [],
+                MetricFlags::empty(),
+            );
+        }
+    }
+
+    sink.append(PollTimeHistogramEntry { counts, rt });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use metrique_writer::sink::AttachGlobalEntrySink;
+    use metrique_writer::test_util::{TestEntrySink, test_entry_sink};
+
+    use super::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};
+
+    #[tokio::test(start_paused = true)]
+    async fn subscribe_appends_metrics() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { inspector, sink } = test_entry_sink();
+        let _handle = Sink::attach((sink, ()));
+
+        Sink::subscribe_tokio_runtime_metrics(
+            TokioRuntimeMetricsConfig::default().with_interval(Duration::from_millis(50)),
+        );
+
+        // Advance past a few intervals so the reporter loop emits entries.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert!(
+            !inspector.entries().is_empty(),
+            "expected tokio runtime metrics entries"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn subscribe_aborted_on_handle_drop() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { inspector, sink } = test_entry_sink();
+        let handle = Sink::attach((sink, ()));
+
+        Sink::subscribe_tokio_runtime_metrics(
+            TokioRuntimeMetricsConfig::default().with_interval(Duration::from_millis(50)),
+        );
+
+        // Let some entries accumulate.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let count_before = inspector.entries().len();
+        assert!(count_before > 0);
+
+        // Drop the attach handle — this should abort the reporter task.
+        drop(handle);
+
+        // Advance time further; no new entries should appear.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(inspector.entries().len(), count_before);
+    }
+}

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use metrique_core::{CloseValue, InflectableEntry};
@@ -76,11 +77,21 @@ pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEn
     /// [`AttachHandle`]: metrique_writer_core::global::AttachHandle
     /// [`forgotten`]: metrique_writer_core::global::AttachHandle::forget
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
+        // Guard against duplicate subscriptions within the same attach cycle.
+        // Reset in the shutdown fn so re-attaching can subscribe again cleanly.
+        static SUBSCRIBED: AtomicBool = AtomicBool::new(false);
+        if SUBSCRIBED.swap(true, Ordering::Relaxed) {
+            tracing::warn!(
+                "subscribe_tokio_runtime_metrics called more than once; \
+                 duplicate reporter task will emit duplicate metrics"
+            );
+        }
         let sink = Self::sink();
         let (worker_abort, monitor) = spawn_tokio_runtime_metrics_task(sink, config);
         Self::register_shutdown_fn(Box::new(move || {
             worker_abort.abort();
             monitor.abort();
+            SUBSCRIBED.store(false, Ordering::Relaxed);
         }));
     }
 }

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -30,9 +30,8 @@ impl Default for TokioRuntimeMetricsConfig {
 
 impl TokioRuntimeMetricsConfig {
     /// Return a config with a custom sampling interval.
-    pub fn with_interval(mut self, interval: Duration) -> Self {
-        self.interval = interval;
-        self
+    pub fn with_interval(self, interval: Duration) -> Self {
+        Self { interval, ..self }
     }
 }
 

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::dynamic_inflection::DynamicInflectionEntry;
@@ -90,21 +89,11 @@ pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEn
     /// Panics if no sink has been attached yet, or if the underlying sink has been
     /// detached (e.g. the `AttachHandle` was dropped or forgotten before this call).
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
-        // Guard against duplicate subscriptions within the same attach cycle.
-        // Reset in the shutdown fn so re-attaching can subscribe again cleanly.
-        static SUBSCRIBED: AtomicBool = AtomicBool::new(false);
-        if SUBSCRIBED.swap(true, Ordering::Relaxed) {
-            tracing::warn!(
-                "subscribe_tokio_runtime_metrics called more than once; \
-                 duplicate reporter task will emit duplicate metrics"
-            );
-        }
         let sink = Self::sink();
         let (worker_abort, monitor) = spawn_tokio_runtime_metrics_task(sink, config);
         Self::register_shutdown_fn(Box::new(move || {
             worker_abort.abort();
             monitor.abort();
-            SUBSCRIBED.store(false, Ordering::Relaxed);
         }));
     }
 }

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::dynamic_inflection::DynamicInflectionEntry;
 use metrique::CloseValue;
-use metrique::writer::{AttachGlobalEntrySink, BoxEntrySink, EntrySink};
+use metrique::writer::{AttachGlobalEntrySink, BoxEntrySink, EntrySink, ShutdownFn};
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tokio_metrics::RuntimeMonitor;
@@ -104,7 +104,7 @@ pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + 'static 
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
         let sink = BoxEntrySink::lazy(Self::try_sink);
         let (worker_abort, monitor) = spawn_tokio_runtime_metrics_task(sink, config);
-        Self::register_shutdown_fn(Box::new(move || {
+        Self::register_shutdown_fn(ShutdownFn::new(move || {
             worker_abort.abort();
             monitor.abort();
         }));

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -7,7 +7,6 @@ use crate::dynamic_inflection::DynamicInflectionEntry;
 use metrique::CloseValue;
 use metrique::writer::{AttachGlobalEntrySink, BoxEntrySink, EntrySink, ShutdownFn};
 use tokio::runtime::Handle;
-use tokio::task::JoinHandle;
 use tokio_metrics::RuntimeMonitor;
 
 const DEFAULT_METRIC_SAMPLING_INTERVAL: Duration = Duration::from_secs(30);
@@ -103,10 +102,9 @@ pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + 'static 
     /// [`RuntimeMetrics`]: tokio_metrics::RuntimeMetrics
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
         let sink = BoxEntrySink::lazy(Self::try_sink);
-        let (worker_abort, monitor) = spawn_tokio_runtime_metrics_task(sink, config);
+        let abort = spawn_tokio_runtime_metrics_task(sink, config);
         Self::register_shutdown_fn(ShutdownFn::new(move || {
-            worker_abort.abort();
-            monitor.abort();
+            abort.abort();
         }));
     }
 }
@@ -116,7 +114,7 @@ impl<T: AttachGlobalEntrySink + 'static> AttachGlobalEntrySinkTokioMetricsExt fo
 fn spawn_tokio_runtime_metrics_task(
     sink: BoxEntrySink,
     config: TokioRuntimeMetricsConfig,
-) -> (tokio::task::AbortHandle, JoinHandle<()>) {
+) -> tokio::task::AbortHandle {
     let interval = config.interval;
     let name_style = config.name_style;
     let worker = tokio::spawn(async move {
@@ -132,19 +130,17 @@ fn spawn_tokio_runtime_metrics_task(
         }
         tracing::debug!("tokio runtime metrics reporter stopped");
     });
-    let worker_abort = worker.abort_handle();
-    let monitor = tokio::spawn(async move {
-        match worker.await {
-            Ok(()) => {}
-            Err(err) if err.is_cancelled() => {
-                tracing::debug!("tokio runtime metrics reporter cancelled");
-            }
-            Err(err) => {
-                tracing::error!(?err, "tokio runtime metrics reporter panicked");
+    let abort = worker.abort_handle();
+
+    // Spawn a monitor to log panics
+    tokio::spawn(async move {
+        if let Err(err) = worker.await {
+            if !err.is_cancelled() {
+                tracing::error!("tokio runtime metrics reporter panicked: {err}");
             }
         }
     });
-    (worker_abort, monitor)
+    abort
 }
 
 #[cfg(test)]
@@ -274,10 +270,10 @@ mod tests {
         let count_before = inspector.entries().len();
         check!(count_before > 0);
 
-        // Drop the attach handle — this should abort the reporter task.
+        // Dropping the handle should abort the reporter task.
         drop(handle);
 
-        // Advance time further; no new entries should appear.
+        // Advance time further, no new entries should be appended.
         tokio::time::sleep(Duration::from_millis(200)).await;
         check!(inspector.entries().len() == count_before);
     }

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -16,7 +16,7 @@ const DEFAULT_METRIC_SAMPLING_INTERVAL: Duration = Duration::from_secs(30);
 #[non_exhaustive]
 pub struct TokioRuntimeMetricsConfig {
     /// Sampling interval used by the reporter loop.
-    pub interval: Duration,
+    interval: Duration,
 }
 
 impl Default for TokioRuntimeMetricsConfig {

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -68,8 +68,8 @@ pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEn
     /// The reporter task is automatically aborted when the [`AttachHandle`] is dropped.
     ///
     /// # Panics
-    /// Panics if the underlying sink has been detached (e.g. the `AttachHandle` was
-    /// dropped elsewhere before this call).
+    /// Panics if no sink has been attached yet, or if the underlying sink has been
+    /// detached (e.g. the `AttachHandle` was dropped elsewhere before this call).
     ///
     /// [`AttachHandle`]: metrique_writer_core::global::AttachHandle
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -134,11 +134,10 @@ fn spawn_tokio_runtime_metrics_task(
 
     // Spawn a monitor to log panics
     tokio::spawn(async move {
-        if let Err(err) = worker.await {
-            if !err.is_cancelled() {
+        if let Err(err) = worker.await
+            && !err.is_cancelled() {
                 tracing::error!("tokio runtime metrics reporter panicked: {err}");
             }
-        }
     });
     abort
 }

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -54,15 +54,19 @@ impl TokioRuntimeMetricsConfig {
 /// Extension methods for subscribing Tokio runtime metrics to a global entry sink.
 ///
 /// Spawns a background task that periodically samples
-/// [`RuntimeMetrics`](tokio_metrics::RuntimeMetrics) and appends each snapshot to the sink.
+/// [`RuntimeMetrics`] and appends each snapshot to the sink.
 /// The task is automatically aborted when the [`AttachHandle`](metrique::writer::sink::AttachHandle) is dropped.
 ///
-/// # `tokio_unstable`
+/// ## `tokio_unstable`
 ///
-/// When the runtime is built with `RUSTFLAGS="--cfg tokio_unstable"` and
-/// `enable_metrics_poll_time_histogram` is called on the runtime builder, each
-/// snapshot also includes a `poll_time_histogram` entry emitted as a distribution
-/// metric with bucket ranges from the runtime handle.
+/// This works with and without `tokio_unstable`. Without it, snapshots include
+/// the stable runtime metrics: worker counts, park/steal counts, queue depths,
+/// busy durations, and more. See [`RuntimeMetrics`] for the full field list.
+///
+/// Building with `RUSTFLAGS="--cfg tokio_unstable"` adds additional fields
+/// such as `mean_poll_duration`, `num_remote_schedules`,
+/// `budget_forced_yield_count`, and `poll_time_histogram`. The histogram
+/// requires calling `enable_metrics_poll_time_histogram` on the runtime builder.
 ///
 /// # Example
 ///
@@ -79,14 +83,24 @@ impl TokioRuntimeMetricsConfig {
 ///     .with_name_style(MetricNameStyle::PascalCase);
 /// ServiceMetrics::subscribe_tokio_runtime_metrics(config);
 /// ```
+///
+/// [`RuntimeMetrics`]: tokio_metrics::RuntimeMetrics
 pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + 'static {
     /// Subscribe to Tokio runtime metrics, adding the subscription to this handle.
+    ///
+    /// Spawns a background task that periodically samples [`RuntimeMetrics`] and
+    /// appends each snapshot to the sink. Additional fields are available when
+    /// building with `tokio_unstable`, see the
+    /// [trait-level docs](AttachGlobalEntrySinkTokioMetricsExt)
+    /// for details.
     ///
     /// The reporter task is automatically aborted when the [`AttachHandle`](metrique::writer::sink::AttachHandle) is dropped.
     /// If the handle is [`forgotten`](metrique::writer::sink::AttachHandle::forget), the reporter runs indefinitely.
     ///
     /// If no sink has been attached yet, entries are silently discarded until one
     /// is attached.
+    ///
+    /// [`RuntimeMetrics`]: tokio_metrics::RuntimeMetrics
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
         let sink = BoxEntrySink::lazy(Self::try_sink);
         let (worker_abort, monitor) = spawn_tokio_runtime_metrics_task(sink, config);

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -66,12 +66,14 @@ pub trait AttachGlobalEntrySinkTokioMetricsExt: AttachGlobalEntrySink + GlobalEn
     /// Subscribe to Tokio runtime metrics, adding the subscription to this handle.
     ///
     /// The reporter task is automatically aborted when the [`AttachHandle`] is dropped.
+    /// If the handle is [`forgotten`], the reporter runs indefinitely.
     ///
     /// # Panics
     /// Panics if no sink has been attached yet, or if the underlying sink has been
-    /// detached (e.g. the `AttachHandle` was dropped elsewhere before this call).
+    /// detached (e.g. the `AttachHandle` was dropped or forgotten before this call).
     ///
     /// [`AttachHandle`]: metrique_writer_core::global::AttachHandle
+    /// [`forgotten`]: metrique_writer_core::global::AttachHandle::forget
     fn subscribe_tokio_runtime_metrics(config: TokioRuntimeMetricsConfig) {
         let sink = Self::sink();
         let (worker_abort, monitor) = spawn_tokio_runtime_metrics_task(sink, config);

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -151,6 +151,7 @@ fn spawn_tokio_runtime_metrics_task(
 mod tests {
     use std::time::Duration;
 
+    use assert2::check;
     use metrique_writer::sink::AttachGlobalEntrySink;
     use metrique_writer::test_util::{TestEntrySink, test_entry_sink};
 
@@ -169,15 +170,15 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let entries = inspector.entries();
-        assert!(!entries.is_empty(), "expected entries");
+        check!(!entries.is_empty());
 
-        let entry = &entries[0];
-        assert_eq!(entry.metrics["workers_count"], 1);
-        entry.metrics["total_park_count"].as_u64();
-        assert!(entry.metrics["elapsed"] > 0.0);
+        let entry = entries.last().unwrap();
+        check!(entry.metrics["workers_count"] == 1);
+        check!(entry.metrics["elapsed"] > 0.0);
+        check!(entry.metrics["total_park_count"] > 0);
 
         #[cfg(tokio_unstable)]
-        assert!(entry.metrics["poll_time_histogram"].num_observations() > 0);
+        check!(entry.metrics["poll_time_histogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -195,15 +196,15 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let entries = inspector.entries();
-        assert!(!entries.is_empty(), "expected entries");
+        check!(!entries.is_empty());
 
-        let entry = &entries[0];
-        assert_eq!(entry.metrics["WorkersCount"], 1);
-        entry.metrics["TotalParkCount"].as_u64();
-        assert!(entry.metrics["Elapsed"] > 0.0);
+        let entry = entries.last().unwrap();
+        check!(entry.metrics["WorkersCount"] == 1);
+        check!(entry.metrics["Elapsed"] > 0.0);
+        check!(entry.metrics["TotalParkCount"] > 0);
 
         #[cfg(tokio_unstable)]
-        assert!(entry.metrics["PollTimeHistogram"].num_observations() > 0);
+        check!(entry.metrics["PollTimeHistogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -221,15 +222,15 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let entries = inspector.entries();
-        assert!(!entries.is_empty(), "expected entries");
+        check!(!entries.is_empty());
 
-        let entry = &entries[0];
-        assert_eq!(entry.metrics["workers_count"], 1);
-        entry.metrics["total_park_count"].as_u64();
-        assert!(entry.metrics["elapsed"] > 0.0);
+        let entry = entries.last().unwrap();
+        check!(entry.metrics["workers_count"] == 1);
+        check!(entry.metrics["elapsed"] > 0.0);
+        check!(entry.metrics["total_park_count"] > 0);
 
         #[cfg(tokio_unstable)]
-        assert!(entry.metrics["poll_time_histogram"].num_observations() > 0);
+        check!(entry.metrics["poll_time_histogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -247,15 +248,15 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         let entries = inspector.entries();
-        assert!(!entries.is_empty(), "expected entries");
+        check!(!entries.is_empty());
 
-        let entry = &entries[0];
-        assert_eq!(entry.metrics["workers-count"], 1);
-        entry.metrics["total-park-count"].as_u64();
-        assert!(entry.metrics["elapsed"] > 0.0);
+        let entry = entries.last().unwrap();
+        check!(entry.metrics["workers-count"] == 1);
+        check!(entry.metrics["elapsed"] > 0.0);
+        check!(entry.metrics["total-park-count"] > 0);
 
         #[cfg(tokio_unstable)]
-        assert!(entry.metrics["poll-time-histogram"].num_observations() > 0);
+        check!(entry.metrics["poll-time-histogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -271,13 +272,13 @@ mod tests {
         // Let some entries accumulate.
         tokio::time::sleep(Duration::from_millis(200)).await;
         let count_before = inspector.entries().len();
-        assert!(count_before > 0);
+        check!(count_before > 0);
 
         // Drop the attach handle — this should abort the reporter task.
         drop(handle);
 
         // Advance time further; no new entries should appear.
         tokio::time::sleep(Duration::from_millis(200)).await;
-        assert_eq!(inspector.entries().len(), count_before);
+        check!(inspector.entries().len() == count_before);
     }
 }

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -1183,7 +1183,6 @@ mod tests {
 #[cfg(test)]
 mod shutdown_registry_tests {
     use std::sync::Arc;
-    use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use metrique_writer::sink::AttachGlobalEntrySink;

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -550,7 +550,7 @@ macro_rules! global_entry_sink {
                     weak.upgrade()
                         .expect("AttachHandle already dropped — cannot register shutdown after detach")
                         .lock().unwrap()
-                        .insert(0, f); // Pre-pend the functions so that they're in front of the sink when dropped.
+                        .insert(0, f); // Prepend the functions so that they're in front of the sink when dropped.
                 }
             }
 
@@ -1211,26 +1211,25 @@ mod shutdown_registry_tests {
         metrique_writer::sink::global_entry_sink! { Sink }
         let TestEntrySink { sink, .. } = test_entry_sink();
 
-        // Track call order: subscriber = 1, sink detach = 2
-        let order = Arc::new(Mutex::new(Vec::new()));
-        let order2 = order.clone();
+        let sink_was_attached_during_shutdown = Arc::new(AtomicBool::new(false));
+        let flag = sink_was_attached_during_shutdown.clone();
 
         let handle = Sink::attach((sink, ()));
 
-        // The sink detach fn is already at position 0 (pushed in AttachHandle::new).
-        // Subscriber should be prepended before it.
+        // The sink detach fn is already at position 0.
+        // Subscriber should be prepended before it, so the sink is still attached when this runs.
         Sink::register_shutdown_fn(Box::new(move || {
-            order2.lock().unwrap().push("subscriber");
+            flag.store(Sink::try_sink().is_some(), Ordering::SeqCst);
         }));
 
-        // Wrap the handle to also record when the sink detach runs.
-        // We can check that the sink is still attached when the subscriber runs
-        // by checking Sink::try_sink() inside the shutdown fn.
         drop(handle);
 
-        // subscriber was prepended, so it runs first
-        let calls = order.lock().unwrap();
-        assert_eq!(calls[0], "subscriber");
+        assert!(
+            sink_was_attached_during_shutdown.load(Ordering::SeqCst),
+            "subscriber shutdown fn should run while sink is still attached"
+        );
+        // And after drop completes, the sink should be detached.
+        assert!(Sink::try_sink().is_none());
     }
 
     #[test]

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -181,6 +181,10 @@ pub trait AttachGlobalEntrySink {
     fn try_append<E: Entry + Send + 'static>(entry: E) -> Result<(), E>;
 
     /// Register a function to be called when the attach handle is dropped.
+    ///
+    /// # Panics
+    /// Panics if no sink has been attached, or if the [`AttachHandle`] was
+    /// dropped or [`forgotten`](AttachHandle::forget).
     fn register_shutdown_fn(f: ShutdownFn);
 }
 
@@ -244,7 +248,8 @@ pub trait AttachGlobalEntrySink {
 #[must_use = "if unused the global sink will be immediately detached and shut down"]
 pub struct AttachHandle {
     /// Registry of shutdown functions to call when the attach handle is dropped.
-    shutdown_registry: Arc<ShutdownRegistry>,
+    /// `None` after `forget()` is called.
+    shutdown_registry: Option<Arc<ShutdownRegistry>>,
 }
 
 #[doc(hidden)]
@@ -325,9 +330,11 @@ impl Drop for TokioRuntimeTestSinkGuard {
 
 impl Drop for AttachHandle {
     fn drop(&mut self) {
-        // Shutdown functions are prepended, drain so that subscribers abort first, and the sink detaches last.
-        for shutdown_fn in self.shutdown_registry.lock().unwrap().drain(..) {
-            shutdown_fn();
+        if let Some(registry) = self.shutdown_registry.take() {
+            // Shutdown functions are prepended, drain so that subscribers abort first, and the sink detaches last.
+            for shutdown_fn in registry.lock().unwrap().drain(..) {
+                shutdown_fn();
+            }
         }
     }
 }
@@ -337,22 +344,29 @@ impl AttachHandle {
     #[doc(hidden)]
     pub fn new(join: fn()) -> Self {
         Self {
-            shutdown_registry: Arc::new(Mutex::new(vec![Box::new(join)])),
+            shutdown_registry: Some(Arc::new(Mutex::new(vec![Box::new(join)]))),
         }
     }
 
     /// Cause the attached global sink to remain attached forever.
     ///
+    /// The sink and any subscribed background tasks (e.g. tokio runtime metrics) will
+    /// continue running indefinitely. Registered shutdown functions will not run.
+    /// Subsequent calls to [`register_shutdown_fn`](AttachGlobalEntrySink::register_shutdown_fn)
+    /// will panic.
+    ///
     /// Note that this will prevent the sink from guaranteeing metric entries are flushed during
     /// shutdown. You *must* have another mechanism to ensure metrics are flushed.
-    pub fn forget(self) {
-        self.shutdown_registry.lock().unwrap().clear();
-        std::mem::forget(self);
+    pub fn forget(mut self) {
+        self.shutdown_registry = None;
     }
 
     #[doc(hidden)]
     pub fn shutdown_registry_weak(&self) -> Weak<ShutdownRegistry> {
-        Arc::downgrade(&self.shutdown_registry)
+        self.shutdown_registry
+            .as_ref()
+            .map(Arc::downgrade)
+            .unwrap_or_default()
     }
 }
 
@@ -548,7 +562,7 @@ macro_rules! global_entry_sink {
                     let read = SHUTDOWN_REGISTRY.read().unwrap();
                     let weak = read.as_ref().expect("No sink attached — call attach() before subscribing");
                     weak.upgrade()
-                        .expect("AttachHandle already dropped — cannot register shutdown after detach")
+                        .expect("AttachHandle was dropped or forgotten — cannot register shutdown functions")
                         .lock().unwrap()
                         .insert(0, f); // Prepend the functions so that they're in front of the sink when dropped.
                 }
@@ -1263,6 +1277,16 @@ mod shutdown_registry_tests {
     #[should_panic(expected = "No sink attached")]
     fn register_without_attach_panics() {
         metrique_writer::sink::global_entry_sink! { Sink }
+        Sink::register_shutdown_fn(Box::new(|| {}));
+    }
+
+    #[test]
+    #[should_panic(expected = "dropped or forgotten")]
+    fn register_after_forget_panics() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { sink, .. } = test_entry_sink();
+        let handle = Sink::attach((sink, ()));
+        handle.forget();
         Sink::register_shutdown_fn(Box::new(|| {}));
     }
 

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -19,7 +19,7 @@ use std::any::Any;
 use std::collections::HashMap;
 #[cfg(feature = "test-util")]
 use std::marker::PhantomData;
-#[cfg(feature = "test-util")]
+use std::sync::Weak;
 use std::sync::{Arc, Mutex};
 
 use crate::{
@@ -179,6 +179,9 @@ pub trait AttachGlobalEntrySink {
     /// Try to append the entry to the global sink, returning it an [`Err`] case if no sink
     /// is currently attached.
     fn try_append<E: Entry + Send + 'static>(entry: E) -> Result<(), E>;
+
+    /// Register a function to be called when the attach handle is dropped.
+    fn register_shutdown_fn(f: ShutdownFn);
 }
 
 /// Handle that, when dropped, will cause the attached global sink to flush remaining entries and
@@ -240,8 +243,15 @@ pub trait AttachGlobalEntrySink {
 /// ```
 #[must_use = "if unused the global sink will be immediately detached and shut down"]
 pub struct AttachHandle {
-    join: Option<fn()>,
+    /// Registry of shutdown functions to call when the attach handle is dropped.
+    shutdown_registry: Arc<ShutdownRegistry>,
 }
+
+#[doc(hidden)]
+pub type ShutdownFn = Box<dyn FnOnce() + Send>;
+
+#[doc(hidden)]
+pub type ShutdownRegistry = Mutex<Vec<ShutdownFn>>;
 
 /// Guard that manages the lifecycle of a thread-local test sink override.
 ///
@@ -315,8 +325,9 @@ impl Drop for TokioRuntimeTestSinkGuard {
 
 impl Drop for AttachHandle {
     fn drop(&mut self) {
-        if let Some(join) = self.join.take() {
-            join();
+        // Shutdown functions are pre-pended, drain so that subscribers abort first, and the sink detaches last.
+        for shutdown_fn in self.shutdown_registry.lock().unwrap().drain(..) {
+            shutdown_fn();
         }
     }
 }
@@ -325,15 +336,22 @@ impl AttachHandle {
     // pub so it can be accessed through macro
     #[doc(hidden)]
     pub fn new(join: fn()) -> Self {
-        Self { join: Some(join) }
+        Self {
+            shutdown_registry: Arc::new(Mutex::new(vec![Box::new(join)])),
+        }
     }
 
     /// Cause the attached global sink to remain attached forever.
     ///
     /// Note that this will prevent the sink from guaranteeing metric entries are flushed during
     /// shutdown. You *must* have another mechanism to ensure metrics are flushed.
-    pub fn forget(mut self) {
-        self.join = None;
+    pub fn forget(self) {
+        self.shutdown_registry.lock().unwrap().clear();
+    }
+
+    #[doc(hidden)]
+    pub fn shutdown_registry_weak(&self) -> Weak<ShutdownRegistry> {
+        Arc::downgrade(&self.shutdown_registry)
     }
 }
 
@@ -426,11 +444,12 @@ macro_rules! global_entry_sink {
         pub struct $name;
 
         const _: () = {
-            use ::std::{sync::RwLock, boxed::Box, option::Option::{self, Some, None}, result::Result, any::Any, marker::{Send, Sync}};
-            use $crate::{Entry, BoxEntry, BoxEntrySink, EntrySink, global::{AttachGlobalEntrySink, AttachHandle}};
+            use ::std::{sync::{RwLock, Weak}, boxed::Box, option::Option::{self, Some, None}, result::Result, any::Any, marker::{Send, Sync}};
+            use $crate::{Entry, BoxEntry, BoxEntrySink, EntrySink, global::{AttachGlobalEntrySink, AttachHandle, ShutdownFn, ShutdownRegistry}};
 
             const NAME: &'static str = ::std::stringify!($name);
             static SINK: RwLock<Option<(BoxEntrySink, Box<dyn Send + Sync + 'static>)>> = RwLock::new(None);
+            static SHUTDOWN_REGISTRY: RwLock<Option<Weak<ShutdownRegistry>>> = RwLock::new(None);
 
             $crate::__test_util! {
                 use ::std::cell::RefCell;
@@ -485,10 +504,14 @@ macro_rules! global_entry_sink {
                     if write.is_some() {
                         drop(write); // don't poison
                         panic!("Already installed a global {NAME} sink, drop the attach handle first if intentionally attaching a new sink");
-                    } else {
-                        *write = Some((BoxEntrySink::new(sink), Box::new(handle)));
                     }
-                    AttachHandle::new(|| { SINK.write().unwrap().take(); })
+                    let sink = BoxEntrySink::new(sink);
+                    *write = Some((sink, Box::new(handle)));
+                    drop(write);
+                    let attach_handle = AttachHandle::new(|| { SINK.write().unwrap().take(); });
+                    *SHUTDOWN_REGISTRY.write().unwrap() = Some(attach_handle.shutdown_registry_weak());
+
+                    attach_handle
                 }
 
                 fn try_sink() -> Option<BoxEntrySink> {
@@ -518,6 +541,15 @@ macro_rules! global_entry_sink {
                     } else {
                         Err(entry)
                     }
+                }
+
+                fn register_shutdown_fn(f: ShutdownFn) {
+                    let read = SHUTDOWN_REGISTRY.read().unwrap();
+                    let weak = read.as_ref().expect("No sink attached — call attach() before subscribing");
+                    weak.upgrade()
+                        .expect("AttachHandle already dropped — cannot register shutdown after detach")
+                        .lock().unwrap()
+                        .insert(0, f); // Pre-pend the functions so that they're in front of the sink when dropped.
                 }
             }
 
@@ -1144,6 +1176,139 @@ mod tests {
 
         lazy_sink.append(TestEntry);
         assert_eq!(inspector.entries().len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod shutdown_registry_tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use metrique_writer::sink::AttachGlobalEntrySink;
+    use metrique_writer::test_util::{TestEntrySink, test_entry_sink};
+
+    #[test]
+    fn shutdown_fn_runs_on_drop() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { sink, .. } = test_entry_sink();
+        let called = Arc::new(AtomicBool::new(false));
+        let called2 = called.clone();
+
+        let handle = Sink::attach((sink, ()));
+        Sink::register_shutdown_fn(Box::new(move || {
+            called2.store(true, Ordering::SeqCst);
+        }));
+
+        assert!(!called.load(Ordering::SeqCst));
+        drop(handle);
+        assert!(called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn shutdown_fns_run_before_sink_detach() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { sink, .. } = test_entry_sink();
+
+        // Track call order: subscriber = 1, sink detach = 2
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let order2 = order.clone();
+
+        let handle = Sink::attach((sink, ()));
+
+        // The sink detach fn is already at position 0 (pushed in AttachHandle::new).
+        // Subscriber should be prepended before it.
+        Sink::register_shutdown_fn(Box::new(move || {
+            order2.lock().unwrap().push("subscriber");
+        }));
+
+        // Wrap the handle to also record when the sink detach runs.
+        // We can check that the sink is still attached when the subscriber runs
+        // by checking Sink::try_sink() inside the shutdown fn.
+        drop(handle);
+
+        // subscriber was prepended, so it runs first
+        let calls = order.lock().unwrap();
+        assert_eq!(calls[0], "subscriber");
+    }
+
+    #[test]
+    fn forget_prevents_shutdown_fns_from_running() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { sink, .. } = test_entry_sink();
+        let called = Arc::new(AtomicBool::new(false));
+        let called2 = called.clone();
+
+        let handle = Sink::attach((sink, ()));
+        Sink::register_shutdown_fn(Box::new(move || {
+            called2.store(true, Ordering::SeqCst);
+        }));
+
+        handle.forget();
+        assert!(!called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn forget_keeps_sink_attached() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { sink, .. } = test_entry_sink();
+
+        let handle = Sink::attach((sink, ()));
+        handle.forget();
+
+        // Sink should still be usable
+        assert!(Sink::try_sink().is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "AttachHandle already dropped")]
+    fn register_after_forget_panics() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { sink, .. } = test_entry_sink();
+
+        let handle = Sink::attach((sink, ()));
+        handle.forget();
+
+        // forget consumes the handle, dropping the Arc. The Weak can no longer
+        // upgrade, registering new shutdown fns after forgetting is a user error.
+        Sink::register_shutdown_fn(Box::new(|| {}));
+    }
+
+    #[test]
+    #[should_panic(expected = "No sink attached")]
+    fn register_without_attach_panics() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        Sink::register_shutdown_fn(Box::new(|| {}));
+    }
+
+    #[test]
+    fn can_reattach_after_drop() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { sink, .. } = test_entry_sink();
+        let called = Arc::new(AtomicUsize::new(0));
+
+        // First attach + drop
+        {
+            let handle = Sink::attach((sink, ()));
+            let called2 = called.clone();
+            Sink::register_shutdown_fn(Box::new(move || {
+                called2.fetch_add(1, Ordering::SeqCst);
+            }));
+            drop(handle);
+        }
+        assert_eq!(called.load(Ordering::SeqCst), 1);
+
+        // Second attach + drop — new registry, new shutdown fns
+        let TestEntrySink { sink, .. } = test_entry_sink();
+        {
+            let handle = Sink::attach((sink, ()));
+            let called2 = called.clone();
+            Sink::register_shutdown_fn(Box::new(move || {
+                called2.fetch_add(1, Ordering::SeqCst);
+            }));
+            drop(handle);
+        }
+        assert_eq!(called.load(Ordering::SeqCst), 2);
     }
 }
 // Helper macro that conditionally expands based on the test-util feature

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -325,7 +325,7 @@ impl Drop for TokioRuntimeTestSinkGuard {
 
 impl Drop for AttachHandle {
     fn drop(&mut self) {
-        // Shutdown functions are pre-pended, drain so that subscribers abort first, and the sink detaches last.
+        // Shutdown functions are prepended, drain so that subscribers abort first, and the sink detaches last.
         for shutdown_fn in self.shutdown_registry.lock().unwrap().drain(..) {
             shutdown_fn();
         }
@@ -347,6 +347,7 @@ impl AttachHandle {
     /// shutdown. You *must* have another mechanism to ensure metrics are flushed.
     pub fn forget(self) {
         self.shutdown_registry.lock().unwrap().clear();
+        std::mem::forget(self);
     }
 
     #[doc(hidden)]
@@ -1258,20 +1259,6 @@ mod shutdown_registry_tests {
 
         // Sink should still be usable
         assert!(Sink::try_sink().is_some());
-    }
-
-    #[test]
-    #[should_panic(expected = "AttachHandle already dropped")]
-    fn register_after_forget_panics() {
-        metrique_writer::sink::global_entry_sink! { Sink }
-        let TestEntrySink { sink, .. } = test_entry_sink();
-
-        let handle = Sink::attach((sink, ()));
-        handle.forget();
-
-        // forget consumes the handle, dropping the Arc. The Weak can no longer
-        // upgrade, registering new shutdown fns after forgetting is a user error.
-        Sink::register_shutdown_fn(Box::new(|| {}));
     }
 
     #[test]

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -252,11 +252,43 @@ pub struct AttachHandle {
     shutdown_registry: Option<Arc<ShutdownRegistry>>,
 }
 
-#[doc(hidden)]
-pub type ShutdownFn = Box<dyn FnOnce() + Send>;
+/// A function to be called during shutdown when the [`AttachHandle`] is dropped.
+pub struct ShutdownFn(Box<dyn FnOnce() + Send>);
 
-#[doc(hidden)]
-pub type ShutdownRegistry = Mutex<Vec<ShutdownFn>>;
+impl ShutdownFn {
+    /// Create a new [`ShutdownFn`] from a closure.
+    pub fn new(f: impl FnOnce() + Send + 'static) -> Self {
+        Self(Box::new(f))
+    }
+
+    fn call(self) {
+        self.0();
+    }
+}
+
+/// Storage for [`ShutdownFn`]s registered on an [`AttachHandle`], to be run when the [`AttachHandle`] is dropped.
+///
+/// This type is public for macro-generated code. You should not need to use it directly,
+/// use [`AttachGlobalEntrySink::register_shutdown_fn`] instead.
+pub struct ShutdownRegistry(Mutex<Vec<ShutdownFn>>);
+
+impl ShutdownRegistry {
+    fn new(initial: ShutdownFn) -> Self {
+        Self(Mutex::new(vec![initial]))
+    }
+
+    /// Prepend a shutdown function so it runs before earlier ones (LIFO order).
+    #[doc(hidden)]
+    pub fn prepend(&self, f: ShutdownFn) {
+        self.0.lock().unwrap().insert(0, f);
+    }
+
+    pub(crate) fn drain_and_run(&self) {
+        for f in self.0.lock().unwrap().drain(..) {
+            f.call();
+        }
+    }
+}
 
 /// Guard that manages the lifecycle of a thread-local test sink override.
 ///
@@ -331,10 +363,7 @@ impl Drop for TokioRuntimeTestSinkGuard {
 impl Drop for AttachHandle {
     fn drop(&mut self) {
         if let Some(registry) = self.shutdown_registry.take() {
-            // Shutdown functions are prepended, drain so that subscribers abort first, and the sink detaches last.
-            for shutdown_fn in registry.lock().unwrap().drain(..) {
-                shutdown_fn();
-            }
+            registry.drain_and_run();
         }
     }
 }
@@ -344,7 +373,7 @@ impl AttachHandle {
     #[doc(hidden)]
     pub fn new(join: fn()) -> Self {
         Self {
-            shutdown_registry: Some(Arc::new(Mutex::new(vec![Box::new(join)]))),
+            shutdown_registry: Some(Arc::new(ShutdownRegistry::new(ShutdownFn::new(join)))),
         }
     }
 
@@ -563,8 +592,7 @@ macro_rules! global_entry_sink {
                     let weak = read.as_ref().expect("No sink attached — call attach() before subscribing");
                     weak.upgrade()
                         .expect("AttachHandle was dropped or forgotten — cannot register shutdown functions")
-                        .lock().unwrap()
-                        .insert(0, f); // Prepend the functions so that they're in front of the sink when dropped.
+                        .prepend(f);
                 }
             }
 
@@ -1202,6 +1230,8 @@ mod shutdown_registry_tests {
     use metrique_writer::sink::AttachGlobalEntrySink;
     use metrique_writer::test_util::{TestEntrySink, test_entry_sink};
 
+    use metrique_writer::ShutdownFn;
+
     #[test]
     fn shutdown_fn_runs_on_drop() {
         metrique_writer::sink::global_entry_sink! { Sink }
@@ -1210,7 +1240,7 @@ mod shutdown_registry_tests {
         let called2 = called.clone();
 
         let handle = Sink::attach((sink, ()));
-        Sink::register_shutdown_fn(Box::new(move || {
+        Sink::register_shutdown_fn(ShutdownFn::new(move || {
             called2.store(true, Ordering::SeqCst);
         }));
 
@@ -1231,7 +1261,7 @@ mod shutdown_registry_tests {
 
         // The sink detach fn is already at position 0.
         // Subscriber should be prepended before it, so the sink is still attached when this runs.
-        Sink::register_shutdown_fn(Box::new(move || {
+        Sink::register_shutdown_fn(ShutdownFn::new(move || {
             flag.store(Sink::try_sink().is_some(), Ordering::SeqCst);
         }));
 
@@ -1253,7 +1283,7 @@ mod shutdown_registry_tests {
         let called2 = called.clone();
 
         let handle = Sink::attach((sink, ()));
-        Sink::register_shutdown_fn(Box::new(move || {
+        Sink::register_shutdown_fn(ShutdownFn::new(move || {
             called2.store(true, Ordering::SeqCst);
         }));
 
@@ -1277,7 +1307,7 @@ mod shutdown_registry_tests {
     #[should_panic(expected = "No sink attached")]
     fn register_without_attach_panics() {
         metrique_writer::sink::global_entry_sink! { Sink }
-        Sink::register_shutdown_fn(Box::new(|| {}));
+        Sink::register_shutdown_fn(ShutdownFn::new(|| {}));
     }
 
     #[test]
@@ -1287,7 +1317,7 @@ mod shutdown_registry_tests {
         let TestEntrySink { sink, .. } = test_entry_sink();
         let handle = Sink::attach((sink, ()));
         handle.forget();
-        Sink::register_shutdown_fn(Box::new(|| {}));
+        Sink::register_shutdown_fn(ShutdownFn::new(|| {}));
     }
 
     #[test]
@@ -1300,7 +1330,7 @@ mod shutdown_registry_tests {
         {
             let handle = Sink::attach((sink, ()));
             let called2 = called.clone();
-            Sink::register_shutdown_fn(Box::new(move || {
+            Sink::register_shutdown_fn(ShutdownFn::new(move || {
                 called2.fetch_add(1, Ordering::SeqCst);
             }));
             drop(handle);
@@ -1312,7 +1342,7 @@ mod shutdown_registry_tests {
         {
             let handle = Sink::attach((sink, ()));
             let called2 = called.clone();
-            Sink::register_shutdown_fn(Box::new(move || {
+            Sink::register_shutdown_fn(ShutdownFn::new(move || {
                 called2.fetch_add(1, Ordering::SeqCst);
             }));
             drop(handle);

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -1229,8 +1229,8 @@ mod tests {
 
 #[cfg(test)]
 mod shutdown_registry_tests {
-    use std::sync::{Arc, Mutex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use metrique_writer::sink::AttachGlobalEntrySink;
     use metrique_writer::test_util::{TestEntrySink, test_entry_sink};

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -277,14 +277,15 @@ impl ShutdownRegistry {
         Self(Mutex::new(vec![initial]))
     }
 
-    /// Prepend a shutdown function so it runs before earlier ones (LIFO order).
+    /// Add a shutdown function. Functions run in LIFO order when the
+    /// [`AttachHandle`] is dropped.
     #[doc(hidden)]
-    pub fn prepend(&self, f: ShutdownFn) {
-        self.0.lock().unwrap().insert(0, f);
+    pub fn push(&self, f: ShutdownFn) {
+        self.0.lock().unwrap().push(f);
     }
 
     pub(crate) fn drain_and_run(&self) {
-        for f in self.0.lock().unwrap().drain(..) {
+        for f in self.0.lock().unwrap().drain(..).rev() {
             f.call();
         }
     }
@@ -592,7 +593,7 @@ macro_rules! global_entry_sink {
                     let weak = read.as_ref().expect("No sink attached — call attach() before subscribing");
                     weak.upgrade()
                         .expect("AttachHandle was dropped or forgotten — cannot register shutdown functions")
-                        .prepend(f);
+                        .push(f);
                 }
             }
 
@@ -1259,8 +1260,8 @@ mod shutdown_registry_tests {
 
         let handle = Sink::attach((sink, ()));
 
-        // The sink detach fn is already at position 0.
-        // Subscriber should be prepended before it, so the sink is still attached when this runs.
+        // The sink detach fn was registered first. Since shutdown runs in LIFO order,
+        // this subscriber fn runs before the sink detaches.
         Sink::register_shutdown_fn(ShutdownFn::new(move || {
             flag.store(Sink::try_sink().is_some(), Ordering::SeqCst);
         }));

--- a/metrique-writer-core/src/global.rs
+++ b/metrique-writer-core/src/global.rs
@@ -284,8 +284,8 @@ impl ShutdownRegistry {
         self.0.lock().unwrap().push(f);
     }
 
-    pub(crate) fn drain_and_run(&self) {
-        for f in self.0.lock().unwrap().drain(..).rev() {
+    pub(crate) fn drain_and_run(self) {
+        for f in self.0.into_inner().unwrap().into_iter().rev() {
             f.call();
         }
     }
@@ -363,8 +363,12 @@ impl Drop for TokioRuntimeTestSinkGuard {
 
 impl Drop for AttachHandle {
     fn drop(&mut self) {
-        if let Some(registry) = self.shutdown_registry.take() {
-            registry.drain_and_run();
+        if let Some(arc) = self.shutdown_registry.take() {
+            // The macro holds only a Weak reference, so this is the sole strong ref.
+            match Arc::try_unwrap(arc) {
+                Ok(registry) => registry.drain_and_run(),
+                Err(_) => unreachable!("ShutdownRegistry should have no other strong references"),
+            }
         }
     }
 }
@@ -1225,7 +1229,7 @@ mod tests {
 
 #[cfg(test)]
 mod shutdown_registry_tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use metrique_writer::sink::AttachGlobalEntrySink;
@@ -1349,6 +1353,29 @@ mod shutdown_registry_tests {
             drop(handle);
         }
         assert_eq!(called.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn shutdown_fns_run_in_lifo_order() {
+        metrique_writer::sink::global_entry_sink! { Sink }
+        let TestEntrySink { sink, .. } = test_entry_sink();
+
+        let order = Arc::new(Mutex::new(Vec::new()));
+
+        let handle = Sink::attach((sink, ()));
+
+        // The attach call registers the sink detach fn first
+        // Register three more in order:
+        for i in 1..=3 {
+            let order = order.clone();
+            Sink::register_shutdown_fn(ShutdownFn::new(move || {
+                order.lock().unwrap().push(i);
+            }));
+        }
+
+        drop(handle);
+
+        assert_eq!(*order.lock().unwrap(), vec![3, 2, 1]);
     }
 }
 // Helper macro that conditionally expands based on the test-util feature

--- a/metrique-writer-core/src/lib.rs
+++ b/metrique-writer-core/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use crate::entry::{BoxEntry, Entry, EntryConfig, EntryWriter};
 pub use crate::global::GlobalEntrySink;

--- a/metrique-writer-core/src/lib.rs
+++ b/metrique-writer-core/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use crate::entry::{BoxEntry, Entry, EntryConfig, EntryWriter};
 pub use crate::global::GlobalEntrySink;

--- a/metrique-writer/src/lib.rs
+++ b/metrique-writer/src/lib.rs
@@ -32,7 +32,7 @@ pub mod value;
 pub use metrique_writer_core as core;
 
 pub use format::FormatExt;
-pub use metrique_writer_core::global::AttachGlobalEntrySink;
+pub use metrique_writer_core::global::{AttachGlobalEntrySink, ShutdownFn};
 pub use metrique_writer_core::unit;
 pub use stream::EntryIoStreamExt;
 

--- a/metrique-writer/src/sink/mod.rs
+++ b/metrique-writer/src/sink/mod.rs
@@ -23,7 +23,7 @@ pub use immediate_flush::{
 pub use metrique_writer_core::sink::{AnyEntrySink, AppendOnDrop, FlushWait};
 use metrique_writer_core::{BoxEntrySink, EntryIoStream, EntrySink};
 pub use metrique_writer_core::{
-    global::AttachGlobalEntrySink, global::AttachHandle, global_entry_sink,
+    global::AttachGlobalEntrySink, global::AttachHandle, global::ShutdownFn, global_entry_sink,
 };
 
 /// Extension trait for `AttachGlobalEntrySink`, containing functions that use

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -67,7 +67,7 @@ tokio-util = { workspace = true, features = ["rt"] }
 trybuild = { workspace = true }
 rustversion = { workspace = true }
 metrique = { path = ".", features = ["emf", "test-util", "local-format"] }
-metrique-util = { path = "../metrique-util", features = ["state"] }
+metrique-util = { path = "../metrique-util", features = ["state", "tokio-metrics-bridge"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
@@ -84,6 +84,11 @@ doc-scrape-examples = false
 [[example]]
 name = "json"
 required-features = ["json"]
+
+[[example]]
+name = "tokio-metrics"
+required-features = ["emf", "service-metrics"]
+doc-scrape-examples = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/metrique/docs/sinks.md
+++ b/metrique/docs/sinks.md
@@ -209,6 +209,25 @@ if you use metric entries to track user log-in operations, and your application 
 
 In that case, you should not be using [`BackgroundQueue`] or sampling. It is probably fine to use the [`Format`] implementations in that case, but it is recommended to test and audit your use-case to make sure nothing is being missed.
 
+## Metric source integrations
+
+Global entry sinks support subscribing background metric sources that
+automatically append entries at a configured interval. The subscription
+is tied to the [`AttachHandle`] — when it drops, the background task is
+aborted.
+
+Available integrations (via [`metrique-util`]):
+
+- **Tokio runtime metrics** — enable the `tokio-metrics-bridge` feature on
+  `metrique-util` and call [`subscribe_tokio_runtime_metrics`] to
+  start appending [`RuntimeMetrics`] snapshots (worker
+  utilization, queue depths, poll durations, and more).
+
+[`AttachHandle`]: https://docs.rs/metrique-writer/latest/metrique_writer/sink/struct.AttachHandle.html
+[`metrique-util`]: https://docs.rs/metrique-util/latest/metrique_util/
+[`subscribe_tokio_runtime_metrics`]: https://docs.rs/metrique-util/latest/metrique_util/trait.AttachGlobalEntrySinkTokioMetricsExt.html#method.subscribe_tokio_runtime_metrics
+[`RuntimeMetrics`]: https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html
+
 ## Use of exporters
 
 The `metrique` library does not currently contain any code that exports the metrics outside of the current process. To make a working system, you normally need to integrate the `metrique` library with some exporter such as the [Amazon CloudWatch Agent].

--- a/metrique/examples/tokio-metrics.rs
+++ b/metrique/examples/tokio-metrics.rs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use metrique::ServiceMetrics;
+use metrique::emf::Emf;
+use metrique::writer::{AttachGlobalEntrySinkExt, FormatExt};
+use metrique_util::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};
+
+const SAMPLING_INTERVAL: Duration = Duration::from_secs(1);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt::init();
+
+    let _attach_handle = ServiceMetrics::attach_to_stream(
+        Emf::all_validations("TokioMetricsExample".to_string(), vec![vec![]])
+            .output_to(std::io::stderr()),
+    );
+
+    let config = TokioRuntimeMetricsConfig::default().with_interval(SAMPLING_INTERVAL);
+    ServiceMetrics::subscribe_tokio_runtime_metrics(config);
+
+    tokio::join![do_work(), do_work(), do_work()];
+
+    Ok(())
+}
+
+async fn do_work() {
+    for _ in 0..25 {
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/metrique/examples/tokio-metrics.rs
+++ b/metrique/examples/tokio-metrics.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 use metrique::ServiceMetrics;
 use metrique::emf::Emf;
 use metrique::writer::{AttachGlobalEntrySinkExt, FormatExt};
-use metrique_util::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};
+use metrique_util::{
+    AttachGlobalEntrySinkTokioMetricsExt, MetricNameStyle, TokioRuntimeMetricsConfig,
+};
 
 const SAMPLING_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -19,7 +21,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             .output_to(std::io::stderr()),
     );
 
-    let config = TokioRuntimeMetricsConfig::default().with_interval(SAMPLING_INTERVAL);
+    let config = TokioRuntimeMetricsConfig::default()
+        .with_interval(SAMPLING_INTERVAL)
+        .with_name_style(MetricNameStyle::KebabCase);
     ServiceMetrics::subscribe_tokio_runtime_metrics(config);
 
     tokio::join![do_work(), do_work(), do_work()];

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -678,7 +678,7 @@ pub mod writer {
     pub use metrique_writer_macro::MetriqueEntry as Entry;
 
     pub use metrique_writer::AttachGlobalEntrySinkExt;
-    pub use metrique_writer::{AttachGlobalEntrySink, EntryIoStreamExt, FormatExt};
+    pub use metrique_writer::{AttachGlobalEntrySink, EntryIoStreamExt, FormatExt, ShutdownFn};
     pub use metrique_writer::{entry, format, sample, sink, stream, value};
 
     #[cfg(feature = "test-util")]


### PR DESCRIPTION
Closes #248

## Depends on 
https://github.com/tokio-rs/tokio-metrics/pull/121 - once merged and released, will update `metrique-util/Cargo.toml` from git dep to crates.io version. The `[patch.crates-io]` section in the workspace `Cargo.toml` should needs to be removed.

## Summary

Adds a new feature `tokio-metrics-bridge` to `metrique-util` which adds a bridge for tokio-metrics.
 
**Main Changes**
- **metrique-writer-core**: Refactors `join` in `AttachHandle` into a shutdown registry. Background tasks register cleanup functions via `register_shutdown_fn` that run (in LIFO order) before the sink detaches on drop.
- **metrique-util**: New `tokio-metrics-bridge` feature with `AttachGlobalEntrySinkTokioMetricsExt::subscribe_tokio_runtime_metrics`. Spawns a reporter task that appends `RuntimeMetrics` snapshots at a configurable interval, automatically aborted on handle drop.

## Usage

```rust
use metrique_util::{AttachGlobalEntrySinkTokioMetricsExt, TokioRuntimeMetricsConfig};

// After attaching a sink:
let _handle = ServiceMetrics::attach_to_stream(emf.output_to(std::io::stderr()));

// Subscribe: reporter runs in the background, aborted when _handle drops.
let config = TokioRuntimeMetricsConfig::default().with_interval(Duration::from_secs(30));
ServiceMetrics::subscribe_tokio_runtime_metrics(config);
```
See `metrique/examples/tokio-metrics.rs` for a better example.

## How it works

The `RuntimeMetrics` struct in tokio-metrics derives `metrique_writer::Entry` (behind the `metrique-integration` feature flag), so each snapshot is appended directly to the sink as a structured metric record with all runtime fields (worker utilization, park counts, queue depths, steal counts, poll durations, etc.).

## Open question: duplicate subscriptions

Right now nothing prevents calling `subscribe_tokio_runtime_metrics` twice, which would just spawn two reporter tasks appending duplicate metrics. It won't break anything, but it's almost certainly users won't intend that to happen.

I left it unguarded for now since the options each have tradeoffs and I'd rather get some input:

- Panic on duplicate: track whether a sink type has already subscribed and panic on the second call. Needs a per-type flag.
- Just log a warning
- Do nothing 

Happy to add a guard if there is a preferred approach, otherwise I'm leaning towards having at least a warning. 

**_Update_:** this now warns of duplicate subscriptions

## Testing
- Adds some shutdown registry tests to metrique-writer-core
- Adds tests to metrique-util for the tokio-metrics-feature

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.