### PR TITLE
fix(metrics): suppress dead_code and unreachable_pub on macro-generated items

### DIFF
--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -1479,13 +1479,16 @@ pub(crate) fn generate_on_drop_wrapper(
 
     quote! {
         #[doc = concat!("Metrics guard returned from [`", #inner_str, "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped.")]
+        #[allow(dead_code, unreachable_pub)]
         #vis type #guard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<#inner_static, Q>;
 
         #[doc = concat!("Metrics handle returned from [`", #guard_str, "::handle`], similar to an `Arc<", #guard_str, ">`.")]
+        #[allow(dead_code, unreachable_pub)]
         #vis type #handle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<#inner_static, Q>;
 
         impl #inner_static #where_clause {
             #[doc = "Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop."]
+            #[allow(dead_code, unreachable_pub)]
             #vis fn append_on_drop<Q: ::metrique::writer::EntrySink<::metrique::RootEntry<#target_static>> + Send + Sync + 'static>(self, sink: Q) -> #guard<Q> {
                 ::metrique::append_and_close(self, sink)
             }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1976
 expression: parsed_file
 ---
 #[derive(Debug, Clone)]
@@ -83,6 +84,7 @@ impl metrique::CloseValue for Metrics {
     "Metrics guard returned from [`", "Metrics",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type MetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     Metrics,
     Q,
@@ -91,12 +93,14 @@ type MetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDro
     "Metrics handle returned from [`", "MetricsGuard", "::handle`], similar to an `Arc<",
     "MetricsGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type MetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     Metrics,
     Q,
 >;
 impl Metrics {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<MetricsEntry>> + Send
             + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1859
 expression: parsed_file
 ---
 struct Nested {
@@ -475,6 +476,7 @@ impl ::metrique::writer::core::SampleGroup for Operation {
     "Metrics guard returned from [`", "Operation",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type OperationGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     Operation,
     Q,
@@ -483,12 +485,14 @@ type OperationGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnD
     "Metrics handle returned from [`", "OperationGuard",
     "::handle`], similar to an `Arc<", "OperationGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type OperationHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     Operation,
     Q,
 >;
 impl Operation {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<OperationEntry>> + Send
             + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1948
 expression: parsed_file
 ---
 struct Nested {
@@ -299,6 +300,7 @@ impl ::metrique::writer::core::SampleGroup for Operation {
     "Metrics guard returned from [`", "Operation",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type OperationGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     Operation,
     Q,
@@ -307,12 +309,14 @@ type OperationGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnD
     "Metrics handle returned from [`", "OperationGuard",
     "::handle`], similar to an `Arc<", "OperationGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type OperationHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     Operation,
     Q,
 >;
 impl Operation {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<OperationEntry>> + Send
             + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag_sample_group.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag_sample_group.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1963
 expression: root
 ---
 enum Operation {
@@ -191,6 +192,7 @@ impl ::metrique::writer::core::SampleGroup for Operation {
     "Metrics guard returned from [`", "Operation",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type OperationGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     Operation,
     Q,
@@ -199,12 +201,14 @@ type OperationGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnD
     "Metrics handle returned from [`", "OperationGuard",
     "::handle`], similar to an `Arc<", "OperationGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type OperationHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     Operation,
     Q,
 >;
 impl Operation {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<OperationEntry>> + Send
             + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1738
 expression: parsed_file
 ---
 struct RequestMetrics {
@@ -121,6 +122,7 @@ impl metrique::CloseValue for RequestMetrics {
     "Metrics guard returned from [`", "RequestMetrics",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
@@ -129,12 +131,14 @@ type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndClo
     "Metrics handle returned from [`", "RequestMetricsGuard",
     "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1752
 expression: parsed_file
 ---
 struct RequestMetrics {
@@ -96,6 +97,7 @@ impl metrique::CloseValue for RequestMetrics {
     "Metrics guard returned from [`", "RequestMetrics",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
@@ -104,12 +106,14 @@ type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndClo
     "Metrics handle returned from [`", "RequestMetricsGuard",
     "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1816
 expression: parsed_file
 ---
 struct RequestMetrics {
@@ -115,6 +116,7 @@ impl metrique::CloseValue for RequestMetrics {
     "Metrics guard returned from [`", "RequestMetrics",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
@@ -123,12 +125,14 @@ type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndClo
     "Metrics handle returned from [`", "RequestMetricsGuard",
     "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_cow_lifetime.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_cow_lifetime.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1802
 expression: parsed_file
 ---
 struct Foo<'a> {
@@ -119,6 +120,7 @@ impl<'a> metrique::CloseValue for Foo<'a> {
     "Metrics guard returned from [`", "Foo",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type FooGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     Foo<'static>,
     Q,
@@ -127,12 +129,14 @@ type FooGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     "Metrics handle returned from [`", "FooGuard", "::handle`], similar to an `Arc<",
     "FooGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type FooHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     Foo<'static>,
     Q,
 >;
 impl Foo<'static> {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<FooEntry<'static>>> + Send
             + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_lifetime.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_lifetime.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1789
 expression: parsed_file
 ---
 struct Foo<'a> {
@@ -119,6 +120,7 @@ impl<'a> metrique::CloseValue for Foo<'a> {
     "Metrics guard returned from [`", "Foo",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type FooGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     Foo<'static>,
     Q,
@@ -127,12 +129,14 @@ type FooGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     "Metrics handle returned from [`", "FooGuard", "::handle`], similar to an `Arc<",
     "FooGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type FooHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     Foo<'static>,
     Q,
 >;
 impl Foo<'static> {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<FooEntry<'static>>> + Send
             + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1922
 expression: parsed_file
 ---
 enum Operation {
@@ -614,6 +615,7 @@ impl ::metrique::writer::core::SampleGroup for RequestResult {
     "Metrics guard returned from [`", "RequestResult",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestResultGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestResult,
     Q,
@@ -622,12 +624,14 @@ type RequestResultGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndClos
     "Metrics handle returned from [`", "RequestResultGuard",
     "::handle`], similar to an `Arc<", "RequestResultGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestResultHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestResult,
     Q,
 >;
 impl RequestResult {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestResultEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1672
 expression: parsed_file
 ---
 struct RequestMetrics {
@@ -151,6 +152,7 @@ impl metrique::CloseValue for RequestMetrics {
     "Metrics guard returned from [`", "RequestMetrics",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
@@ -159,12 +161,14 @@ type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndClo
     "Metrics handle returned from [`", "RequestMetricsGuard",
     "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
@@ -1,5 +1,6 @@
 ---
 source: metrique-macro/src/lib.rs
+assertion_line: 1658
 expression: parsed_file
 ---
 struct RequestMetrics {
@@ -121,6 +122,7 @@ impl metrique::CloseValue for RequestMetrics {
     "Metrics guard returned from [`", "RequestMetrics",
     "::append_on_drop`], closes the entry and appends the metrics to a sink when dropped."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDrop<
     RequestMetrics,
     Q,
@@ -129,12 +131,14 @@ type RequestMetricsGuard<Q = ::metrique::DefaultSink> = ::metrique::AppendAndClo
     "Metrics handle returned from [`", "RequestMetricsGuard",
     "::handle`], similar to an `Arc<", "RequestMetricsGuard", ">`."
 )]
+#[allow(dead_code, unreachable_pub)]
 type RequestMetricsHandle<Q = ::metrique::DefaultSink> = ::metrique::AppendAndCloseOnDropHandle<
     RequestMetrics,
     Q,
 >;
 impl RequestMetrics {
     ///Creates an AppendAndCloseOnDrop that will be automatically appended to `sink` on drop.
+    #[allow(dead_code, unreachable_pub)]
     fn append_on_drop<
         Q: ::metrique::writer::EntrySink<::metrique::RootEntry<RequestMetricsEntry>>
             + Send + Sync + 'static,


### PR DESCRIPTION
## Summary

The `#[metrics]` macro generates type aliases (`*Guard`, `*Handle`)
and an `append_on_drop` method for every metrics struct. Consumers may never use or re-export them.

Crates that compile with `-D warnings` (like tokio-metrics) get hard errors from `dead_code` and `unreachable_pub` on these generated items.
                                                                                                                                                               
This adds `#[allow(dead_code, unreachable_pub)]` to the generated Guard, Handle, and append_on_drop items.  
  
🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.