### PR TITLE
feat(core): add OwnedCounterGuard for cross-boundary tracking

### DIFF
--- a/metrique-core/src/atomics.rs
+++ b/metrique-core/src/atomics.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, AtomicU32, AtomicU64, AtomicUsize};
 
 use crate::CloseValue;
@@ -38,11 +40,28 @@ impl Counter {
     pub fn set(&self, i: u64) {
         self.0.store(i, std::sync::atomic::Ordering::SeqCst);
     }
+
+    /// Increments the count by 1, returning an owned guard that decrements the
+    /// count on drop, and the new value.
+    ///
+    /// Unlike [`increment_scoped`](Self::increment_scoped), the returned
+    /// [`OwnedCounterGuard`] can be moved across async boundaries or stored
+    /// in structs without lifetime constraints.
+    pub fn increment_owned(self: &Arc<Self>) -> (OwnedCounterGuard, u64) {
+        let count = self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        (
+            OwnedCounterGuard {
+                counter: Arc::clone(self),
+            },
+            count,
+        )
+    }
 }
 
 /// A guard that decrements a [`Counter`] when dropped.
 ///
 /// Returned by [`Counter::increment_scoped`].
+#[must_use]
 pub struct CounterGuard<'a>(&'a AtomicU64);
 
 impl Drop for CounterGuard<'_> {
@@ -68,6 +87,48 @@ impl CloseValue for &CounterGuard<'_> {
 
 #[diagnostic::do_not_recommend]
 impl CloseValue for CounterGuard<'_> {
+    type Closed = u64;
+
+    fn close(self) -> Self::Closed {
+        (&self).close()
+    }
+}
+
+/// An owned guard that decrements a [`Counter`] when dropped.
+///
+/// Unlike [`CounterGuard`], this guard can be moved across async boundaries
+/// or stored in structs without lifetime constraints.
+///
+/// Returned by [`Counter::increment_owned`].
+#[must_use]
+pub struct OwnedCounterGuard {
+    counter: Arc<Counter>,
+}
+
+impl Drop for OwnedCounterGuard {
+    fn drop(&mut self) {
+        self.counter
+            .0
+            .fetch_update(
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+                |v| Some(v.saturating_sub(1)),
+            )
+            .ok();
+    }
+}
+
+#[diagnostic::do_not_recommend]
+impl CloseValue for &OwnedCounterGuard {
+    type Closed = u64;
+
+    fn close(self) -> Self::Closed {
+        self.counter.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+#[diagnostic::do_not_recommend]
+impl CloseValue for OwnedCounterGuard {
     type Closed = u64;
 
     fn close(self) -> Self::Closed {
@@ -121,6 +182,8 @@ close_value_atomic!(atomic: AtomicBool, inner: bool);
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -149,6 +212,66 @@ mod tests {
         assert_eq!((&guard).close(), 1);
         // Guard still decrements on drop.
         drop(guard);
+        assert_eq!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn owned_counter_guard_increment_and_drop() {
+        let counter = Arc::new(Counter::new(0));
+        let (guard, count) = counter.increment_owned();
+        assert_eq!(count, 1);
+        assert_eq!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 1);
+        drop(guard);
+        assert_eq!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn owned_counter_guard_saturates_at_zero() {
+        let counter = Arc::new(Counter::new(0));
+        let (guard, _) = counter.increment_owned();
+        // Manually set to 0 to test saturating_sub
+        counter.0.store(0, std::sync::atomic::Ordering::Relaxed);
+        drop(guard);
+        assert_eq!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn owned_counter_guard_close_value() {
+        let counter = Arc::new(Counter::new(0));
+        let (guard, _) = counter.increment_owned();
+        assert_eq!((&guard).close(), 1);
+        // Guard still decrements on drop.
+        drop(guard);
+        assert_eq!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn owned_counter_guard_move_across_threads() {
+        let counter = Arc::new(Counter::new(0));
+        let (guard, count) = counter.increment_owned();
+        assert_eq!(count, 1);
+        let counter_clone = Arc::clone(&counter);
+        let handle = std::thread::spawn(move || {
+            assert_eq!(
+                counter_clone.0.load(std::sync::atomic::Ordering::Relaxed),
+                1
+            );
+            drop(guard);
+        });
+        handle.join().unwrap();
+        assert_eq!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn owned_counter_guard_multiple_guards() {
+        let counter = Arc::new(Counter::new(0));
+        let (g1, c1) = counter.increment_owned();
+        let (g2, c2) = counter.increment_owned();
+        assert_eq!(c1, 1);
+        assert_eq!(c2, 2);
+        drop(g1);
+        assert_eq!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 1);
+        drop(g2);
         assert_eq!(counter.0.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 }

--- a/metrique-core/src/lib.rs
+++ b/metrique-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod concat;
 mod inflectable_entry_impls;
 mod namestyle;
 
-pub use atomics::{Counter, CounterGuard};
+pub use atomics::{Counter, CounterGuard, OwnedCounterGuard};
 pub use namestyle::NameStyle;
 
 /// Close a given value

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -94,6 +94,7 @@ use std::sync::Arc;
 
 pub use metrique_core::{
     CloseValue, CloseValueRef, Counter, CounterGuard, InflectableEntry, NameStyle,
+    OwnedCounterGuard,
 };
 
 /// Unit types and utilities for metrics.


### PR DESCRIPTION
📬 *Issue #, if available:*

Closes #264

✍️ *Description of changes:*

### Summary

`CounterGuard` borrows `&'a AtomicU64`, which prevents it from being stored in structs that outlive the borrow (e.g. response body wrappers in tower middleware). Users currently fall back to manual `fetch_add`/`fetch_sub`, losing RAII safety.

This adds `OwnedCounterGuard`, which holds an `Arc<Counter>` instead of a reference. It has the same `Drop` behavior (saturating decrement) and the same `CloseValue` impls as `CounterGuard`, but can be freely moved across async boundaries.
a📬 *Issue #, if available:*

Closes #264

✍️ *Description of changes:*

### Summary

`CounterGuard` borrows `&'a AtomicU64`, which prevents it from being stored in structs that outlive the borrow (e.g. response body wrappers in tower middleware). Users currently fall back to manual `fetch_add`/`fetch_sub`, losing RAII safety.

This adds `OwnedCounterGuard`, which internally shares the counter and can be freely moved across async boundaries. It has the same `Drop` behavior (saturating decrement) and the same `CloseValue` impls as `CounterGuard`.

The guard is `Clone`. Cloning shares the underlying counter without incrementing it; each clone independently decrements on drop. Callers are responsible for ensuring the counter has been incremented a corresponding number of times.

The constructor is `Counter::increment_scoped_owned(self: &Arc<Self>)`, mirroring the existing `Counter::increment_scoped(&self)` API.

`OwnedCounterGuard` is re-exported from both `metrique-core` and the top-level `metrique` crate.

### Testing

Unit tests covering increment/drop semantics, saturation at zero, `CloseValue` behavior, cross-thread movement, and multiple concurrent guards on the same counter.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
The constructor is `Counter::increment_scoped_owned(self: &Arc<Self>)`, mirroring the existing `Counter::increment_scoped(&self)` API. The caller wraps their `Counter` in an `Arc`, which is the natural choice for shared state in async contexts.

`OwnedCounterGuard` is re-exported from both `metrique-core` and the top-level `metrique` crate.

### Testing

Unit tests covering increment/drop semantics, saturation at zero, `CloseValue` behavior, cross-thread movement, and multiple concurrent guards on the same counter.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.