### PR TITLE
 feat(core): add Value impl for Vec<V> with native EMF/json array support 

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-core"
-version = "0.1.16"
+version = "0.1.18"
 dependencies = [
  "itertools",
  "metrique-writer-core",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer"
-version = "0.1.18"
+version = "0.1.20"
 dependencies = [
  "ahash",
  "crossbeam-queue",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-core"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "derive-where",
  "itertools",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-emf"
-version = "0.1.17"
+version = "0.1.19"
 dependencies = [
  "bit-set",
  "dtoa",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-json"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "dtoa",
  "itoa",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-macro"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/fuzz/fuzz_targets/fuzz_emf.rs
+++ b/fuzz/fuzz_targets/fuzz_emf.rs
@@ -93,6 +93,9 @@ impl Entry for EmfFuzzEntry {
                         }
                     }
                 }
+                FuzzField::ValueList { name, values } => {
+                    writer.value(name.0.as_str(), values);
+                }
             }
         }
     }

--- a/fuzz/fuzz_targets/fuzz_entry.rs
+++ b/fuzz/fuzz_targets/fuzz_entry.rs
@@ -74,6 +74,11 @@ pub enum FuzzField {
         dimensions: Vec<(String, String)>,
         unit: FuzzUnit,
     },
+    /// A list of optional string values, exercising `ValueWriter::values()`
+    ValueList {
+        name: FuzzFieldName,
+        values: Vec<Option<String>>,
+    },
 }
 
 #[derive(Debug, Arbitrary)]
@@ -173,6 +178,9 @@ impl Entry for FuzzEntry {
                         unit: unit.0,
                     };
                     writer.value(name.0.as_str(), &metric);
+                }
+                FuzzField::ValueList { name, values } => {
+                    writer.value(name.0.as_str(), values);
                 }
             }
         }

--- a/metrique-core/src/close_value_impls.rs
+++ b/metrique-core/src/close_value_impls.rs
@@ -215,6 +215,15 @@ where
 }
 
 #[diagnostic::do_not_recommend]
+impl<V: CloseValue> CloseValue for Vec<V> {
+    type Closed = Vec<V::Closed>;
+
+    fn close(self) -> Self::Closed {
+        self.into_iter().map(CloseValue::close).collect()
+    }
+}
+
+#[diagnostic::do_not_recommend]
 impl<T: CloseValue, const N: usize> CloseValue for WithDimensions<T, N> {
     type Closed = WithDimensions<T::Closed, N>;
 

--- a/metrique-writer-core/src/entry/boxed.rs
+++ b/metrique-writer-core/src/entry/boxed.rs
@@ -79,6 +79,8 @@ trait DynValueWriter {
     );
 
     fn error(&mut self, error: ValidationError);
+
+    fn values_str(&mut self, values: &[&str]);
 }
 
 impl<E: Entry + Send + 'static> DynEntry for E {
@@ -163,6 +165,10 @@ impl<W: ValueWriter> DynValueWriter for ValueWriterToDyn<W> {
     fn error(&mut self, error: ValidationError) {
         self.0.take().unwrap().error(error)
     }
+
+    fn values_str(&mut self, values: &[&str]) {
+        self.0.take().unwrap().values(values.iter())
+    }
 }
 
 impl ValueWriter for ValueWriterFromDyn<'_> {
@@ -193,6 +199,19 @@ impl ValueWriter for ValueWriterFromDyn<'_> {
 
     fn error(self, error: ValidationError) {
         self.0.error(error)
+    }
+
+    fn values<'a, V: Value + 'a>(self, values: impl IntoIterator<Item = &'a V>) {
+        let strs: SmallVec<[String; 8]> = values
+            .into_iter()
+            .filter_map(|v| {
+                let mut s = String::new();
+                v.write(crate::value::StringCapture(&mut s));
+                if s.is_empty() { None } else { Some(s) }
+            })
+            .collect();
+        let refs: SmallVec<[&str; 8]> = strs.iter().map(|s| s.as_str()).collect();
+        self.0.values_str(&refs)
     }
 }
 

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -85,19 +85,19 @@ pub trait ValueWriter: Sized {
     }
 
     /// Write a list of values. Formats that support native arrays (e.g. EMF) can override this
-    /// to emit a structured representation. The default joins each element's string representation
-    /// with `", "`, skipping elements that write nothing (e.g. `None`).
+    /// to emit a structured representation. The default comma-joins each element's string
+    /// representation, skipping elements that write nothing (e.g. `None`).
     fn values<'a, V: Value + 'a>(self, values: impl IntoIterator<Item = &'a V>) {
         let mut buf = String::new();
-        let mut elem = String::new();
         for value in values {
-            elem.clear();
-            value.write(StringCapture(&mut elem));
-            if !elem.is_empty() {
-                if !buf.is_empty() {
-                    buf.push_str(", ");
-                }
-                buf.push_str(&elem);
+            let before = buf.len();
+            if !buf.is_empty() {
+                buf.push(',');
+            }
+            let after_sep = buf.len();
+            value.write(StringCapture(&mut buf));
+            if buf.len() <= after_sep {
+                buf.truncate(before);
             }
         }
         self.string(&buf);
@@ -105,6 +105,7 @@ pub trait ValueWriter: Sized {
 }
 
 /// Adapter that captures a [`Value`]'s string representation into a buffer.
+/// Only captures string values; metrics and errors are ignored.
 struct StringCapture<'a>(&'a mut String);
 
 impl ValueWriter for StringCapture<'_> {
@@ -114,25 +115,12 @@ impl ValueWriter for StringCapture<'_> {
 
     fn metric<'a>(
         self,
-        distribution: impl IntoIterator<Item = Observation>,
+        _distribution: impl IntoIterator<Item = Observation>,
         _unit: Unit,
         _dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
         _flags: MetricFlags<'_>,
     ) {
-        use std::fmt::Write;
-        if let Some(obs) = distribution.into_iter().next() {
-            match obs {
-                Observation::Unsigned(v) => {
-                    let _ = write!(self.0, "{v}");
-                }
-                Observation::Floating(v) => {
-                    let _ = write!(self.0, "{v}");
-                }
-                Observation::Repeated { total, .. } => {
-                    let _ = write!(self.0, "{total}");
-                }
-            }
-        }
+        // Intentionally a no-op: values() is for string properties only.
     }
 
     fn error(self, _error: ValidationError) {}

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -106,7 +106,7 @@ pub trait ValueWriter: Sized {
 
 /// Adapter that captures a [`Value`]'s string representation into a buffer.
 /// Only captures string values; metrics and errors are ignored.
-struct StringCapture<'a>(&'a mut String);
+pub(crate) struct StringCapture<'a>(pub(crate) &'a mut String);
 
 impl ValueWriter for StringCapture<'_> {
     fn string(self, value: &str) {

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -86,14 +86,19 @@ pub trait ValueWriter: Sized {
 
     /// Write a list of values. Formats that support native arrays (e.g. EMF) can override this
     /// to emit a structured representation. The default joins each element's string representation
-    /// with `", "`.
+    /// with `", "`, skipping elements that write nothing (e.g. `None`).
     fn values<'a, V: Value + 'a>(self, values: impl IntoIterator<Item = &'a V>) {
         let mut buf = String::new();
+        let mut elem = String::new();
         for value in values {
-            if !buf.is_empty() {
-                buf.push_str(", ");
+            elem.clear();
+            value.write(StringCapture(&mut elem));
+            if !elem.is_empty() {
+                if !buf.is_empty() {
+                    buf.push_str(", ");
+                }
+                buf.push_str(&elem);
             }
-            value.write(StringCapture(&mut buf));
         }
         self.string(&buf);
     }
@@ -116,7 +121,6 @@ impl ValueWriter for StringCapture<'_> {
     ) {
         use std::fmt::Write;
         if let Some(obs) = distribution.into_iter().next() {
-            #[allow(unreachable_patterns)] // Observation is #[non_exhaustive]
             match obs {
                 Observation::Unsigned(v) => {
                     let _ = write!(self.0, "{v}");
@@ -127,7 +131,6 @@ impl ValueWriter for StringCapture<'_> {
                 Observation::Repeated { total, .. } => {
                     let _ = write!(self.0, "{total}");
                 }
-                _ => {}
             }
         }
     }

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -83,6 +83,56 @@ pub trait ValueWriter: Sized {
     fn invalid(self, reason: impl Into<String>) {
         self.error(ValidationError::invalid(reason))
     }
+
+    /// Write a list of values. Formats that support native arrays (e.g. EMF) can override this
+    /// to emit a structured representation. The default joins each element's string representation
+    /// with `", "`.
+    fn values<'a, V: Value + 'a>(self, values: impl IntoIterator<Item = &'a V>) {
+        let mut buf = String::new();
+        for value in values {
+            if !buf.is_empty() {
+                buf.push_str(", ");
+            }
+            value.write(StringCapture(&mut buf));
+        }
+        self.string(&buf);
+    }
+}
+
+/// Adapter that captures a [`Value`]'s string representation into a buffer.
+struct StringCapture<'a>(&'a mut String);
+
+impl ValueWriter for StringCapture<'_> {
+    fn string(self, value: &str) {
+        self.0.push_str(value);
+    }
+
+    fn metric<'a>(
+        self,
+        distribution: impl IntoIterator<Item = Observation>,
+        _unit: Unit,
+        _dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
+        _flags: MetricFlags<'_>,
+    ) {
+        use std::fmt::Write;
+        if let Some(obs) = distribution.into_iter().next() {
+            #[allow(unreachable_patterns)] // Observation is #[non_exhaustive]
+            match obs {
+                Observation::Unsigned(v) => {
+                    let _ = write!(self.0, "{v}");
+                }
+                Observation::Floating(v) => {
+                    let _ = write!(self.0, "{v}");
+                }
+                Observation::Repeated { total, .. } => {
+                    let _ = write!(self.0, "{total}");
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn error(self, _error: ValidationError) {}
 }
 
 /// The numeric value of a observation to include in a metric value.

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -15,7 +15,7 @@ mod primitive;
 pub use dimensions::{WithDimension, WithDimensions, WithVecDimensions};
 pub use force::{FlagConstructor, ForceFlag};
 pub use formatter::{FormattedValue, Lifted, NotLifted, ToString, ValueFormatter};
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, fmt::Write, sync::Arc};
 
 pub use flags::{Distribution, MetricFlags, MetricOptions};
 
@@ -105,7 +105,8 @@ pub trait ValueWriter: Sized {
 }
 
 /// Adapter that captures a [`Value`]'s string representation into a buffer.
-/// Only captures string values; metrics and errors are ignored.
+/// Strings are appended directly. Metric observations are written as their
+/// numeric string representation, comma-separated within a single element.
 pub(crate) struct StringCapture<'a>(pub(crate) &'a mut String);
 
 impl ValueWriter for StringCapture<'_> {
@@ -115,12 +116,29 @@ impl ValueWriter for StringCapture<'_> {
 
     fn metric<'a>(
         self,
-        _distribution: impl IntoIterator<Item = Observation>,
+        distribution: impl IntoIterator<Item = Observation>,
         _unit: Unit,
         _dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
         _flags: MetricFlags<'_>,
     ) {
-        // Intentionally a no-op: values() is for string properties only.
+        let mut first = true;
+        for obs in distribution {
+            if !first {
+                self.0.push(',');
+            }
+            first = false;
+            match obs {
+                Observation::Unsigned(v) => {
+                    let _ = write!(self.0, "{v}");
+                }
+                Observation::Floating(v) => {
+                    let _ = write!(self.0, "{v}");
+                }
+                Observation::Repeated { total, .. } => {
+                    let _ = write!(self.0, "{total}");
+                }
+            }
+        }
     }
 
     fn error(self, _error: ValidationError) {}

--- a/metrique-writer-core/src/value/primitive.rs
+++ b/metrique-writer-core/src/value/primitive.rs
@@ -122,3 +122,15 @@ impl Value for Duration {
 impl MetricValue for Duration {
     type Unit = unit::Millisecond;
 }
+
+impl<V: Value> Value for Vec<V> {
+    fn write(&self, writer: impl ValueWriter) {
+        writer.values(self.iter());
+    }
+}
+
+impl<V: Value> Value for [V] {
+    fn write(&self, writer: impl ValueWriter) {
+        writer.values(self.iter());
+    }
+}

--- a/metrique-writer-format-emf/src/emf.rs
+++ b/metrique-writer-format-emf/src/emf.rs
@@ -1668,6 +1668,49 @@ impl ValueWriter<'_, '_> {
     }
 }
 
+/// Adapter for writing individual elements inside a JSON array in EMF output.
+struct EmfArrayElementWriter<'a>(&'a mut PrefixedStringBuf);
+
+impl metrique_writer_core::ValueWriter for EmfArrayElementWriter<'_> {
+    fn string(self, value: &str) {
+        self.0.json_string(value);
+    }
+
+    fn metric<'a>(
+        self,
+        distribution: impl IntoIterator<Item = Observation>,
+        _unit: Unit,
+        _dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
+        _flags: MetricFlags<'_>,
+    ) {
+        if let Some(obs) = distribution.into_iter().next() {
+            match obs {
+                Observation::Unsigned(v) => {
+                    self.0.push_integer(v);
+                }
+                Observation::Floating(v) => {
+                    if let Some(v) = clamp_to_finite(v, "") {
+                        ValueWriter::write_float(self.0, v);
+                    }
+                }
+                Observation::Repeated { total, occurrences } => {
+                    let mean = if occurrences == 0 {
+                        0.0
+                    } else {
+                        total / occurrences as f64
+                    };
+                    if let Some(v) = clamp_to_finite(mean, "") {
+                        ValueWriter::write_float(self.0, v);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn error(self, _error: ValidationError) {}
+}
+
 impl metrique_writer_core::ValueWriter for ValueWriter<'_, '_> {
     fn string(mut self, value: &str) {
         self.entry
@@ -1677,6 +1720,24 @@ impl metrique_writer_core::ValueWriter for ValueWriter<'_, '_> {
             .json_string(&self.name)
             .push(':')
             .json_string(value);
+
+        if !self.entry.validations.skip_validate_unique {
+            self.validate_string();
+        }
+    }
+
+    fn values<'a, V: Value + 'a>(mut self, values: impl IntoIterator<Item = &'a V>) {
+        let buf = &mut self.entry.state.string_fields_buf;
+        buf.push(',').json_string(&self.name).push(':').push('[');
+        let mut first = true;
+        for value in values {
+            if !first {
+                buf.push(',');
+            }
+            first = false;
+            value.write(EmfArrayElementWriter(buf));
+        }
+        buf.push(']');
 
         if !self.entry.validations.skip_validate_unique {
             self.validate_string();

--- a/metrique-writer-format-emf/src/emf.rs
+++ b/metrique-writer-format-emf/src/emf.rs
@@ -1729,13 +1729,19 @@ impl metrique_writer_core::ValueWriter for ValueWriter<'_, '_> {
     fn values<'a, V: Value + 'a>(mut self, values: impl IntoIterator<Item = &'a V>) {
         let buf = &mut self.entry.state.string_fields_buf;
         buf.push(',').json_string(&self.name).push(':').push('[');
-        let mut first = true;
+        let mut wrote_any = false;
         for value in values {
-            if !first {
+            let before = buf.as_str().len();
+            if wrote_any {
                 buf.push(',');
             }
-            first = false;
+            let after_sep = buf.as_str().len();
             value.write(EmfArrayElementWriter(buf));
+            if buf.as_str().len() > after_sep {
+                wrote_any = true;
+            } else {
+                buf.truncate(before);
+            }
         }
         buf.push(']');
 

--- a/metrique-writer-format-emf/src/emf.rs
+++ b/metrique-writer-format-emf/src/emf.rs
@@ -1669,6 +1669,9 @@ impl ValueWriter<'_, '_> {
 }
 
 /// Adapter for writing individual elements inside a JSON array in EMF output.
+///
+/// String values are JSON-escaped. Metric values write their observations as
+/// numeric scalars (single observation) or nested sub-arrays (multiple observations).
 struct EmfArrayElementWriter<'a>(&'a mut PrefixedStringBuf);
 
 impl metrique_writer_core::ValueWriter for EmfArrayElementWriter<'_> {
@@ -1676,10 +1679,6 @@ impl metrique_writer_core::ValueWriter for EmfArrayElementWriter<'_> {
         self.0.json_string(value);
     }
 
-    /// Write a single numeric value from the first observation in the distribution.
-    /// Only the first observation is used; additional observations, units, and
-    /// dimensions are ignored since this element lives inside a JSON array, not
-    /// in the `_aws` metric definition block.
     fn metric<'a>(
         self,
         distribution: impl IntoIterator<Item = Observation>,
@@ -1687,32 +1686,61 @@ impl metrique_writer_core::ValueWriter for EmfArrayElementWriter<'_> {
         _dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
         _flags: MetricFlags<'_>,
     ) {
-        if let Some(obs) = distribution.into_iter().next() {
-            match obs {
-                Observation::Unsigned(v) => {
-                    self.0.push_integer(v);
-                }
-                Observation::Floating(v) => {
-                    if let Some(v) = clamp_to_finite(v, "") {
-                        ValueWriter::write_float(self.0, v);
+        let buf = self.0;
+        let mut iter = distribution.into_iter();
+        let Some(first) = iter.next() else { return };
+        match iter.next() {
+            None => write_emf_observation(buf, first),
+            Some(second) => {
+                buf.push('[');
+                let mut wrote_any = false;
+                for obs in std::iter::once(first)
+                    .chain(std::iter::once(second))
+                    .chain(iter)
+                {
+                    let before = buf.as_str().len();
+                    if wrote_any {
+                        buf.push(',');
                     }
-                }
-                Observation::Repeated { total, occurrences } => {
-                    let mean = if occurrences == 0 {
-                        0.0
+                    let after_sep = buf.as_str().len();
+                    write_emf_observation(buf, obs);
+                    if buf.as_str().len() > after_sep {
+                        wrote_any = true;
                     } else {
-                        total / occurrences as f64
-                    };
-                    if let Some(v) = clamp_to_finite(mean, "") {
-                        ValueWriter::write_float(self.0, v);
+                        buf.truncate(before);
                     }
                 }
-                _ => {}
+                buf.push(']');
             }
         }
     }
 
     fn error(self, _error: ValidationError) {}
+}
+
+/// Write a single observation value into an EMF buffer.
+fn write_emf_observation(buf: &mut PrefixedStringBuf, obs: Observation) {
+    match obs {
+        Observation::Unsigned(v) => {
+            buf.push_integer(v);
+        }
+        Observation::Floating(v) => {
+            if let Some(v) = clamp_to_finite(v, "") {
+                ValueWriter::write_float(buf, v);
+            }
+        }
+        Observation::Repeated { total, occurrences } => {
+            let mean = if occurrences == 0 {
+                0.0
+            } else {
+                total / occurrences as f64
+            };
+            if let Some(v) = clamp_to_finite(mean, "") {
+                ValueWriter::write_float(buf, v);
+            }
+        }
+        _ => {}
+    }
 }
 
 impl metrique_writer_core::ValueWriter for ValueWriter<'_, '_> {

--- a/metrique-writer-format-emf/src/emf.rs
+++ b/metrique-writer-format-emf/src/emf.rs
@@ -1676,6 +1676,10 @@ impl metrique_writer_core::ValueWriter for EmfArrayElementWriter<'_> {
         self.0.json_string(value);
     }
 
+    /// Write a single numeric value from the first observation in the distribution.
+    /// Only the first observation is used; additional observations, units, and
+    /// dimensions are ignored since this element lives inside a JSON array, not
+    /// in the `_aws` metric definition block.
     fn metric<'a>(
         self,
         distribution: impl IntoIterator<Item = Observation>,

--- a/metrique-writer-format-emf/tests/misc.rs
+++ b/metrique-writer-format-emf/tests/misc.rs
@@ -122,3 +122,39 @@ fn test_background_queue_with_invalid_metric() {
         })
     );
 }
+
+struct VecEntry {
+    plugins: Vec<String>,
+}
+
+impl Entry for VecEntry {
+    fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+        writer.timestamp(SystemTime::UNIX_EPOCH + Duration::from_secs(1));
+        writer.value("Plugins", &self.plugins);
+    }
+}
+
+#[test]
+fn test_vec_emits_json_array_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream
+        .next(&VecEntry {
+            plugins: vec!["auth".into(), "logging".into(), "cache".into()],
+        })
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(
+        output["Plugins"],
+        serde_json::json!(["auth", "logging", "cache"])
+    );
+}
+
+#[test]
+fn test_empty_vec_emits_empty_array_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream.next(&VecEntry { plugins: vec![] }).unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Plugins"], serde_json::json!([]));
+}

--- a/metrique-writer-format-emf/tests/misc.rs
+++ b/metrique-writer-format-emf/tests/misc.rs
@@ -195,3 +195,16 @@ fn test_single_element_vec_in_emf() {
     let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
     assert_json_diff::assert_json_eq!(output["Plugins"], serde_json::json!(["only"]));
 }
+
+#[test]
+fn test_vec_emits_json_array_through_boxed_entry() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    let boxed = VecEntry {
+        plugins: vec!["a".into(), "b".into()],
+    }
+    .boxed();
+    stream.next(&boxed).unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Plugins"], serde_json::json!(["a", "b"]));
+}

--- a/metrique-writer-format-emf/tests/misc.rs
+++ b/metrique-writer-format-emf/tests/misc.rs
@@ -182,3 +182,16 @@ fn test_vec_with_none_elements_skips_them_in_emf() {
     let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
     assert_json_diff::assert_json_eq!(output["Tags"], serde_json::json!(["a", "c"]));
 }
+
+#[test]
+fn test_single_element_vec_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream
+        .next(&VecEntry {
+            plugins: vec!["only".into()],
+        })
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Plugins"], serde_json::json!(["only"]));
+}

--- a/metrique-writer-format-emf/tests/misc.rs
+++ b/metrique-writer-format-emf/tests/misc.rs
@@ -158,3 +158,27 @@ fn test_empty_vec_emits_empty_array_in_emf() {
     let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
     assert_json_diff::assert_json_eq!(output["Plugins"], serde_json::json!([]));
 }
+
+struct VecOptionEntry {
+    tags: Vec<Option<String>>,
+}
+
+impl Entry for VecOptionEntry {
+    fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+        writer.timestamp(SystemTime::UNIX_EPOCH + Duration::from_secs(1));
+        writer.value("Tags", &self.tags);
+    }
+}
+
+#[test]
+fn test_vec_with_none_elements_skips_them_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream
+        .next(&VecOptionEntry {
+            tags: vec![Some("a".into()), None, Some("c".into())],
+        })
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Tags"], serde_json::json!(["a", "c"]));
+}

--- a/metrique-writer-format-emf/tests/misc.rs
+++ b/metrique-writer-format-emf/tests/misc.rs
@@ -250,3 +250,57 @@ fn test_empty_u64_vec_in_emf() {
     let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
     assert_json_diff::assert_json_eq!(output["Counts"], serde_json::json!([]));
 }
+
+/// A custom Value that emits multiple observations, exercising the nested
+/// sub-array path in EmfArrayElementWriter::metric().
+struct MultiObsValue(Vec<u64>);
+
+impl metrique_writer_core::Value for MultiObsValue {
+    fn write(&self, writer: impl metrique_writer_core::ValueWriter) {
+        writer.metric(
+            self.0
+                .iter()
+                .map(|&v| metrique_writer_core::Observation::Unsigned(v)),
+            metrique_writer_core::Unit::None,
+            [],
+            metrique_writer_core::MetricFlags::empty(),
+        );
+    }
+}
+
+struct VecMultiObsEntry {
+    data: Vec<MultiObsValue>,
+}
+
+impl Entry for VecMultiObsEntry {
+    fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+        writer.timestamp(SystemTime::UNIX_EPOCH + Duration::from_secs(1));
+        writer.value("Data", &self.data);
+    }
+}
+
+#[test]
+fn test_vec_multi_observation_nests_sub_arrays_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream
+        .next(&VecMultiObsEntry {
+            data: vec![MultiObsValue(vec![1, 2, 3]), MultiObsValue(vec![4, 5])],
+        })
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Data"], serde_json::json!([[1, 2, 3], [4, 5]]));
+}
+
+#[test]
+fn test_vec_single_observation_stays_scalar_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream
+        .next(&VecMultiObsEntry {
+            data: vec![MultiObsValue(vec![10]), MultiObsValue(vec![20])],
+        })
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Data"], serde_json::json!([10, 20]));
+}

--- a/metrique-writer-format-emf/tests/misc.rs
+++ b/metrique-writer-format-emf/tests/misc.rs
@@ -208,3 +208,45 @@ fn test_vec_emits_json_array_through_boxed_entry() {
     let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
     assert_json_diff::assert_json_eq!(output["Plugins"], serde_json::json!(["a", "b"]));
 }
+
+struct VecU64Entry {
+    counts: Vec<u64>,
+}
+
+impl Entry for VecU64Entry {
+    fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+        writer.timestamp(SystemTime::UNIX_EPOCH + Duration::from_secs(1));
+        writer.value("Counts", &self.counts);
+    }
+}
+
+#[test]
+fn test_vec_u64_emits_json_array_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream
+        .next(&VecU64Entry {
+            counts: vec![10, 20, 30],
+        })
+        .unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Counts"], serde_json::json!([10, 20, 30]));
+}
+
+#[test]
+fn test_single_u64_vec_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream.next(&VecU64Entry { counts: vec![42] }).unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Counts"], serde_json::json!([42]));
+}
+
+#[test]
+fn test_empty_u64_vec_in_emf() {
+    let sink = TestSink::default();
+    let mut stream = Emf::all_validations("App".into(), vec![vec![]]).output_to(sink.clone());
+    stream.next(&VecU64Entry { counts: vec![] }).unwrap();
+    let output: serde_json::Value = serde_json::from_str(&sink.dump()).unwrap();
+    assert_json_diff::assert_json_eq!(output["Counts"], serde_json::json!([]));
+}

--- a/metrique-writer-format-json/src/json.rs
+++ b/metrique-writer-format-json/src/json.rs
@@ -215,6 +215,26 @@ struct JsonValueWriter<'b, 'c> {
     error: &'b mut ValidationErrorBuilder,
 }
 
+/// Adapter for writing individual elements inside a JSON array.
+struct JsonArrayElementWriter<'a>(&'a mut String);
+
+impl ValueWriter for JsonArrayElementWriter<'_> {
+    fn string(self, value: &str) {
+        push_json_string(self.0, value);
+    }
+
+    fn metric<'a>(
+        self,
+        _distribution: impl IntoIterator<Item = Observation>,
+        _unit: Unit,
+        _dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
+        _flags: MetricFlags<'_>,
+    ) {
+    }
+
+    fn error(self, _error: ValidationError) {}
+}
+
 impl<'b, 'c> ValueWriter for JsonValueWriter<'b, 'c> {
     fn string(self, value: &str) {
         let buf = self.properties_buf;
@@ -222,6 +242,28 @@ impl<'b, 'c> ValueWriter for JsonValueWriter<'b, 'c> {
         push_json_string(buf, self.name);
         buf.push(':');
         push_json_string(buf, value);
+    }
+
+    fn values<'a, V: Value + 'a>(self, values: impl IntoIterator<Item = &'a V>) {
+        let buf = self.properties_buf;
+        buf.push(',');
+        push_json_string(buf, self.name);
+        buf.push_str(":[");
+        let mut wrote_any = false;
+        for value in values {
+            let before = buf.len();
+            if wrote_any {
+                buf.push(',');
+            }
+            let after_sep = buf.len();
+            value.write(JsonArrayElementWriter(buf));
+            if buf.len() > after_sep {
+                wrote_any = true;
+            } else {
+                buf.truncate(before);
+            }
+        }
+        buf.push(']');
     }
 
     fn metric<'a>(
@@ -767,5 +809,88 @@ mod tests {
 
         let result = format.format_with_sample_rate(&SimpleEntry, &mut output, f32::NAN);
         assert!(result.is_err());
+    }
+
+    struct VecEntry {
+        plugins: Vec<String>,
+    }
+
+    impl Entry for VecEntry {
+        fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+            writer.timestamp(SystemTime::UNIX_EPOCH);
+            writer.value("Plugins", &self.plugins);
+        }
+    }
+
+    #[test]
+    fn test_vec_emits_json_array() {
+        let mut format = Json::new();
+        let mut output = Vec::new();
+        format
+            .format(
+                &VecEntry {
+                    plugins: vec!["auth".into(), "cache".into()],
+                },
+                &mut output,
+            )
+            .unwrap();
+        let json = parse_output(&output);
+        assert_eq!(
+            json["properties"]["Plugins"],
+            serde_json::json!(["auth", "cache"])
+        );
+    }
+
+    #[test]
+    fn test_single_element_vec_in_json() {
+        let mut format = Json::new();
+        let mut output = Vec::new();
+        format
+            .format(
+                &VecEntry {
+                    plugins: vec!["only".into()],
+                },
+                &mut output,
+            )
+            .unwrap();
+        let json = parse_output(&output);
+        assert_eq!(json["properties"]["Plugins"], serde_json::json!(["only"]));
+    }
+
+    #[test]
+    fn test_empty_vec_in_json() {
+        let mut format = Json::new();
+        let mut output = Vec::new();
+        format
+            .format(&VecEntry { plugins: vec![] }, &mut output)
+            .unwrap();
+        let json = parse_output(&output);
+        assert_eq!(json["properties"]["Plugins"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_vec_with_none_elements_in_json() {
+        struct VecOptionEntry {
+            tags: Vec<Option<String>>,
+        }
+        impl Entry for VecOptionEntry {
+            fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+                writer.timestamp(SystemTime::UNIX_EPOCH);
+                writer.value("Tags", &self.tags);
+            }
+        }
+
+        let mut format = Json::new();
+        let mut output = Vec::new();
+        format
+            .format(
+                &VecOptionEntry {
+                    tags: vec![Some("a".into()), None, Some("c".into())],
+                },
+                &mut output,
+            )
+            .unwrap();
+        let json = parse_output(&output);
+        assert_eq!(json["properties"]["Tags"], serde_json::json!(["a", "c"]));
     }
 }

--- a/metrique-writer-format-json/src/json.rs
+++ b/metrique-writer-format-json/src/json.rs
@@ -216,6 +216,9 @@ struct JsonValueWriter<'b, 'c> {
 }
 
 /// Adapter for writing individual elements inside a JSON array.
+///
+/// String values are JSON-escaped. Metric values write their observations as
+/// numeric scalars (single observation) or nested sub-arrays (multiple observations).
 struct JsonArrayElementWriter<'a>(&'a mut String);
 
 impl ValueWriter for JsonArrayElementWriter<'_> {
@@ -230,9 +233,22 @@ impl ValueWriter for JsonArrayElementWriter<'_> {
         _dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
         _flags: MetricFlags<'_>,
     ) {
-        // Write only the first observation as a scalar value in the array.
-        if let Some(obs) = distribution.into_iter().next() {
-            push_observation(self.0, obs, None);
+        let buf = self.0;
+        let mut iter = distribution.into_iter();
+        let Some(first) = iter.next() else { return };
+        match iter.next() {
+            None => push_observation(buf, first, None),
+            Some(second) => {
+                buf.push('[');
+                push_observation(buf, first, None);
+                buf.push(',');
+                push_observation(buf, second, None);
+                for obs in iter {
+                    buf.push(',');
+                    push_observation(buf, obs, None);
+                }
+                buf.push(']');
+            }
         }
     }
 
@@ -924,6 +940,46 @@ mod tests {
         assert_eq!(
             json["properties"]["Counts"],
             serde_json::json!([10, 20, 30])
+        );
+    }
+
+    #[test]
+    fn test_vec_multi_observation_nests_sub_arrays_in_json() {
+        struct MultiObsValue(Vec<u64>);
+        impl Value for MultiObsValue {
+            fn write(&self, writer: impl ValueWriter) {
+                writer.metric(
+                    self.0.iter().map(|&v| Observation::Unsigned(v)),
+                    Unit::None,
+                    [],
+                    MetricFlags::empty(),
+                );
+            }
+        }
+        struct VecMultiObsEntry {
+            data: Vec<MultiObsValue>,
+        }
+        impl Entry for VecMultiObsEntry {
+            fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+                writer.timestamp(SystemTime::UNIX_EPOCH);
+                writer.value("Data", &self.data);
+            }
+        }
+
+        let mut format = Json::new();
+        let mut output = Vec::new();
+        format
+            .format(
+                &VecMultiObsEntry {
+                    data: vec![MultiObsValue(vec![1, 2, 3]), MultiObsValue(vec![4, 5])],
+                },
+                &mut output,
+            )
+            .unwrap();
+        let json = parse_output(&output);
+        assert_eq!(
+            json["properties"]["Data"],
+            serde_json::json!([[1, 2, 3], [4, 5]])
         );
     }
 }

--- a/metrique-writer-format-json/src/json.rs
+++ b/metrique-writer-format-json/src/json.rs
@@ -225,11 +225,15 @@ impl ValueWriter for JsonArrayElementWriter<'_> {
 
     fn metric<'a>(
         self,
-        _distribution: impl IntoIterator<Item = Observation>,
+        distribution: impl IntoIterator<Item = Observation>,
         _unit: Unit,
         _dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
         _flags: MetricFlags<'_>,
     ) {
+        // Write only the first observation as a scalar value in the array.
+        if let Some(obs) = distribution.into_iter().next() {
+            push_observation(self.0, obs, None);
+        }
     }
 
     fn error(self, _error: ValidationError) {}
@@ -892,5 +896,34 @@ mod tests {
             .unwrap();
         let json = parse_output(&output);
         assert_eq!(json["properties"]["Tags"], serde_json::json!(["a", "c"]));
+    }
+
+    #[test]
+    fn test_vec_u64_emits_json_array() {
+        struct VecU64Entry {
+            counts: Vec<u64>,
+        }
+        impl Entry for VecU64Entry {
+            fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+                writer.timestamp(SystemTime::UNIX_EPOCH);
+                writer.value("Counts", &self.counts);
+            }
+        }
+
+        let mut format = Json::new();
+        let mut output = Vec::new();
+        format
+            .format(
+                &VecU64Entry {
+                    counts: vec![10, 20, 30],
+                },
+                &mut output,
+            )
+            .unwrap();
+        let json = parse_output(&output);
+        assert_eq!(
+            json["properties"]["Counts"],
+            serde_json::json!([10, 20, 30])
+        );
     }
 }

--- a/metrique/examples/emf.rs
+++ b/metrique/examples/emf.rs
@@ -26,6 +26,7 @@ struct RequestMetrics {
     number_of_ducks: usize,
     no_metric: NoMetric<usize>,
     high_storage_resolution: HighStorageResolution<usize>,
+    active_plugins: Vec<String>,
 }
 
 impl RequestMetrics {
@@ -37,6 +38,7 @@ impl RequestMetrics {
             number_of_ducks: 0,
             no_metric: (0).into(),
             high_storage_resolution: (0).into(),
+            active_plugins: vec!["auth".into(), "logging".into()],
         }
         .append_on_drop(ServiceMetrics::sink())
     }
@@ -69,7 +71,7 @@ fn main() {
     request.status = "SUCCESS";
 
     /*
-    {"_aws":{"CloudWatchMetrics":[{"Namespace":"MyApp","Dimensions":[["Region","Status","Operation"],["Region","Operation"]],"Metrics":[{"Name":"NumberOfDucks"},{"Name":"HighStorageResolution","StorageResolution":1}]}],"Timestamp":1753189090887},"NumberOfDucks":10,"NoMetric":1,"HighStorageResolution":1,"Region":"us-east-1","Operation":"CountDucks","Status":"SUCCESS"}
+    {"_aws":{"CloudWatchMetrics":[{"Namespace":"MyApp","Dimensions":[["Region","Status","Operation"],["Region","Operation"]],"Metrics":[{"Name":"NumberOfDucks"},{"Name":"HighStorageResolution","StorageResolution":1}]}],"Timestamp":1753189090887},"NumberOfDucks":10,"NoMetric":1,"HighStorageResolution":1,"ActivePlugins":["auth","logging"],"Region":"us-east-1","Operation":"CountDucks","Status":"SUCCESS"}
     */
 }
 

--- a/metrique/examples/json.rs
+++ b/metrique/examples/json.rs
@@ -18,6 +18,7 @@ struct RequestMetrics {
     operation: &'static str,
     status: &'static str,
     number_of_ducks: usize,
+    active_plugins: Vec<String>,
 }
 
 impl RequestMetrics {
@@ -27,6 +28,7 @@ impl RequestMetrics {
             operation,
             status: "INCOMPLETE",
             number_of_ducks: 0,
+            active_plugins: vec!["auth".into(), "logging".into()],
         }
         .append_on_drop(ServiceMetrics::sink())
     }
@@ -56,6 +58,6 @@ fn main() {
     request.status = "SUCCESS";
 
     /*
-    {"timestamp":<millis>,"metrics":{"number_of_ducks":{"value":10}},"properties":{"region":"us-east-1","operation":"CountDucks","status":"SUCCESS"}}
+    {"timestamp":<millis>,"metrics":{"number_of_ducks":{"value":10}},"properties":{"region":"us-east-1","operation":"CountDucks","status":"SUCCESS","active_plugins":["auth","logging"]}}
     */
 }

--- a/metrique/tests/emf.rs
+++ b/metrique/tests/emf.rs
@@ -100,3 +100,34 @@ async fn test_dimensions_merged_with_global_queue() {
         ]
     );
 }
+
+#[metrics(rename_all = "PascalCase")]
+struct VecMetrics {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+    plugins: Vec<String>,
+    request_count: usize,
+}
+
+#[test]
+fn test_vec_property_emits_json_array_in_emf() {
+    let mut emf = Emf::all_validations("App".to_string(), vec![vec![]]);
+    let mut output = vec![];
+
+    emf.format(
+        &RootEntry::new(
+            VecMetrics {
+                timestamp: UNIX_EPOCH,
+                plugins: vec!["auth".into(), "cache".into()],
+                request_count: 5,
+            }
+            .close(),
+        ),
+        &mut output,
+    )
+    .unwrap();
+
+    let json: Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["Plugins"], serde_json::json!(["auth", "cache"]));
+    assert_eq!(json["RequestCount"], 5);
+}

--- a/metrique/tests/kitchen-sink.rs
+++ b/metrique/tests/kitchen-sink.rs
@@ -426,7 +426,7 @@ fn vec_property_comma_joins_in_default_format() {
     .append_on_drop(vec_sink.clone());
     let entries = vec_sink.drain();
     let entry = test_util::to_test_entry(&entries[0]);
-    assert_eq!(entry.values["Plugins"], "auth, logging, cache");
+    assert_eq!(entry.values["Plugins"], "auth,logging,cache");
     assert_eq!(entry.metrics["Count"], 42);
 }
 
@@ -458,5 +458,5 @@ fn vec_with_none_elements_skips_them_in_default_format() {
     .append_on_drop(vec_sink.clone());
     let entries = vec_sink.drain();
     let entry = test_util::to_test_entry(&entries[0]);
-    assert_eq!(entry.values["Tags"], "a, c");
+    assert_eq!(entry.values["Tags"], "a,c");
 }

--- a/metrique/tests/kitchen-sink.rs
+++ b/metrique/tests/kitchen-sink.rs
@@ -442,3 +442,21 @@ fn empty_vec_property_emits_empty_string() {
     let entry = test_util::to_test_entry(&entries[0]);
     assert_eq!(entry.values["Plugins"], "");
 }
+
+#[metrics(rename_all = "PascalCase")]
+#[derive(Default)]
+struct WithOptionalVecProperty {
+    tags: Vec<Option<String>>,
+}
+
+#[test]
+fn vec_with_none_elements_skips_them_in_default_format() {
+    let vec_sink = VecEntrySink::new();
+    WithOptionalVecProperty {
+        tags: vec![Some("a".into()), None, Some("c".into())],
+    }
+    .append_on_drop(vec_sink.clone());
+    let entries = vec_sink.drain();
+    let entry = test_util::to_test_entry(&entries[0]);
+    assert_eq!(entry.values["Tags"], "a, c");
+}

--- a/metrique/tests/kitchen-sink.rs
+++ b/metrique/tests/kitchen-sink.rs
@@ -408,3 +408,37 @@ fn multiple_sinks() {
     assert_eq!(inspector1.entries().len(), 2);
     assert_eq!(inspector2.entries().len(), 1);
 }
+
+#[metrics(rename_all = "PascalCase")]
+#[derive(Default)]
+struct WithVecProperty {
+    plugins: Vec<String>,
+    count: u32,
+}
+
+#[test]
+fn vec_property_comma_joins_in_default_format() {
+    let vec_sink = VecEntrySink::new();
+    WithVecProperty {
+        plugins: vec!["auth".into(), "logging".into(), "cache".into()],
+        count: 42,
+    }
+    .append_on_drop(vec_sink.clone());
+    let entries = vec_sink.drain();
+    let entry = test_util::to_test_entry(&entries[0]);
+    assert_eq!(entry.values["Plugins"], "auth, logging, cache");
+    assert_eq!(entry.metrics["Count"], 42);
+}
+
+#[test]
+fn empty_vec_property_emits_empty_string() {
+    let vec_sink = VecEntrySink::new();
+    WithVecProperty {
+        plugins: vec![],
+        count: 0,
+    }
+    .append_on_drop(vec_sink.clone());
+    let entries = vec_sink.drain();
+    let entry = test_util::to_test_entry(&entries[0]);
+    assert_eq!(entry.values["Plugins"], "");
+}


### PR DESCRIPTION
📬 *Issue #, if available:* #233

✍️ *Description of changes:*

Adds `Value` impl for `Vec<V: Value>` and `[V: Value]` so vector properties emit as native JSON arrays in EMF and comma-joined strings in other formats.

Adds a `values()` method to `ValueWriter` with a default comma-join implementation. EMF overrides it to write a JSON array. Elements that write nothing (e.g. `None` in a `Vec<Option<String>>`) are skipped in both paths. Also adds `CloseValue` for `Vec<V>` so it works with the `#[metrics]` derive macro.

Tested with new integration tests covering EMF array output, default comma-join behavior, empty vecs, and None-element skipping.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
