### PR TITLE
refactor: use workspace dependencies for inter-crate deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,22 @@ members = [
 ]
 
 [workspace.dependencies]
+# Internal subcrates
+metrique = { version = "0.1", path = "metrique", default-features = false }
+metrique-aggregation = { version = "0.1", path = "metrique-aggregation" }
+metrique-core = { version = "0.1", path = "metrique-core" }
+metrique-macro = { version = "0.1", path = "metrique-macro" }
+metrique-metricsrs = { version = "0.1", path = "metrique-metricsrs" }
+metrique-service-metrics = { version = "0.1", path = "metrique-service-metrics" }
+metrique-timesource = { version = "0.1", path = "metrique-timesource" }
+metrique-util = { version = "0.1", path = "metrique-util" }
+metrique-writer = { version = "0.1", path = "metrique-writer", default-features = false }
+metrique-writer-core = { version = "0.1", path = "metrique-writer-core", default-features = false }
+metrique-writer-format-emf = { version = "0.1", path = "metrique-writer-format-emf" }
+metrique-writer-format-json = { version = "0.1", path = "metrique-writer-format-json" }
+metrique-writer-macro = { version = "0.1", path = "metrique-writer-macro" }
+
+# External dependencies
 ahash = "0.8.6"
 anyhow = "1.0.98"
 assert-json-diff = "2"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-core"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "itertools",
  "metrique-writer-core",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "ahash",
  "crossbeam-queue",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-core"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "derive-where",
  "itertools",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-emf"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "bit-set",
  "dtoa",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-json"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dtoa",
  "itoa",

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -9,20 +9,20 @@ repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
 [dependencies]
-metrique = { path = "../metrique", version = "0.1" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.21" }
-metrique-core = { path = "../metrique-core", version = "0.1.19" }
-metrique-macro = { path = "../metrique-macro", version = "0.1.15" }
+metrique = { workspace = true, features = ["service-metrics"] }
+metrique-writer = { workspace = true, features = ["background-queue", "tracing-subscriber-03", "metrics-rs-024"] }
+metrique-core = { workspace = true }
+metrique-macro = { workspace = true }
 smallvec.workspace = true
 histogram.workspace = true
 ordered-float.workspace = true
-metrique-writer-core = { version = "0.1.15", path = "../metrique-writer-core" }
+metrique-writer-core = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
-metrique-timesource = { version = "0.1.9", path = "../metrique-timesource", features = ["test-util"] }
+metrique-timesource = { workspace = true, features = ["test-util"] }
 hashbrown.workspace = true
 
 [dev-dependencies]
-metrique = { path = "../metrique", features = ["test-util", "emf", "local-format"] }
+metrique = { workspace = true, features = ["test-util", "emf", "local-format"] }
 divan = "0.1"
 insta = { workspace = true }
 serde_json = { workspace = true }

--- a/metrique-core/Cargo.toml
+++ b/metrique-core/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
 [dependencies]
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.15" }
+metrique-writer-core = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 
 [dev-dependencies]
-metrique = { path = "../metrique" }
-metrique-writer = { path = "../metrique-writer" }
+metrique = { workspace = true, features = ["service-metrics"] }
+metrique-writer = { workspace = true, features = ["background-queue", "tracing-subscriber-03", "metrics-rs-024"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -21,8 +21,8 @@ darling = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 prettyplease = { workspace = true }
-metrique = { path = "../metrique", features = ["test-util"] }
-metrique-aggregation = { path = "../metrique-aggregation" }
+metrique = { workspace = true, features = ["test-util"] }
+metrique-aggregation = { workspace = true }
 assert2 = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/metrique-metricsrs/Cargo.toml
+++ b/metrique-metricsrs/Cargo.toml
@@ -21,9 +21,9 @@ histogram = { workspace = true }
 pin-project = { workspace = true }
 metrics_024 = { workspace = true, optional = true }
 metrics-util_020 = { workspace = true, optional = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.15", default-features = false }
-metrique-writer = { path = "../metrique-writer", version = "0.1.21", default-features = false }
-metrique-timesource = { path = "../metrique-timesource", version = "0.1.9" }
+metrique-writer-core = { workspace = true }
+metrique-writer = { workspace = true }
+metrique-timesource = { workspace = true }
 futures = { workspace = true, default-features = false, features = ["executor"] }
 tokio = { workspace = true, default-features = false, features = [
     "sync", "time"
@@ -35,15 +35,15 @@ tracing-appender = { workspace = true, optional = true }
 
 [dev-dependencies]
 tracing-appender = { workspace = true }
-metrique = { path = "../metrique", features = ["service-metrics"] }
-metrique-timesource = { path = "../metrique-timesource", features = [
+metrique = { workspace = true, features = ["service-metrics"] }
+metrique-timesource = { workspace = true, features = [
     "custom-timesource",
     "tokio",
     "test-util",
 ] }
-metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
-metrique-writer-core = { path = "../metrique-writer-core", features = ["private-test-util"] }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf" }
+metrique-writer = { workspace = true, features = ["test-util"] }
+metrique-writer-core = { workspace = true, features = ["private-test-util"] }
+metrique-writer-format-emf = { workspace = true }
 metrique-metricsrs = { path = ".", features = ["metrics-rs-024", "test-util"] }
 tokio = { workspace = true, features = ["macros", "test-util"] }
 rand = { workspace = true }

--- a/metrique-service-metrics/Cargo.toml
+++ b/metrique-service-metrics/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
 [dependencies]
-metrique-writer = { path = "../metrique-writer", version = "0.1.21" }
+metrique-writer = { workspace = true, features = ["background-queue", "tracing-subscriber-03", "metrics-rs-024"] }
 
 [dev-dependencies]
 
-metrique = { path = "../metrique" }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf" }
+metrique = { workspace = true, features = ["service-metrics"] }
+metrique-writer-format-emf = { workspace = true }
 
 tracing-appender = { workspace = true }
 

--- a/metrique-util/Cargo.toml
+++ b/metrique-util/Cargo.toml
@@ -22,8 +22,8 @@ tokio-metrics-bridge = [
 ]
 
 [dependencies]
-metrique-core = { path = "../metrique-core", version = "0.1.19" }
-metrique = { path = "../metrique", version = "0.1.24", optional = true, default-features = false }
+metrique-core = { workspace = true }
+metrique = { workspace = true, optional = true }
 arc-swap = { version = "1", optional = true }
 tokio = { workspace = true, optional = true, features = ["time", "rt"] }
 tokio-metrics = { version = "0.5.0", optional = true, features = ["rt", "metrique-integration"] }
@@ -31,9 +31,9 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert2 = { workspace = true }
-metrique = { path = "../metrique", features = ["emf", "test-util"] }
-metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
-metrique-writer-core = { path = "../metrique-writer-core", features = ["test-util"] }
+metrique = { workspace = true, features = ["emf", "test-util"] }
+metrique-writer = { workspace = true, features = ["test-util"] }
+metrique-writer-core = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 rstest = { workspace = true }
 metrique-util = { path = ".", features = ["state"] }

--- a/metrique-writer-core/Cargo.toml
+++ b/metrique-writer-core/Cargo.toml
@@ -18,11 +18,11 @@ tokio = { workspace = true, optional = true, features = ["rt"] }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }
-metrique = { path = "../metrique", features = [] }
-metrique-writer = { path = "../metrique-writer", features = ["tracing-subscriber-03", "test-util"] }
+metrique = { workspace = true, features = [] }
+metrique-writer = { workspace = true, features = ["tracing-subscriber-03", "test-util"] }
 metrique-writer-core = { path = ".", features = ["test-util"] }
 tracing-appender = { workspace = true }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf" }
+metrique-writer-format-emf = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/metrique-writer-format-emf/Cargo.toml
+++ b/metrique-writer-format-emf/Cargo.toml
@@ -19,22 +19,22 @@ rand = { workspace = true }
 hashbrown = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.15" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.21" }
+metrique-writer-core = { workspace = true, features = ["serde"] }
+metrique-writer = { workspace = true, features = ["background-queue", "tracing-subscriber-03", "metrics-rs-024"] }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }
 assert_approx_eq = { workspace = true }
 rand_chacha = { workspace = true }
 rstest = { workspace = true }
-metrique-metricsrs = { path = "../metrique-metricsrs", features = ["metrics-rs-024"] }
-metrique-timesource = { path = "../metrique-timesource", features = [
+metrique-metricsrs = { workspace = true, features = ["metrics-rs-024"] }
+metrique-timesource = { workspace = true, features = [
     "custom-timesource",
     "tokio",
     "test-util",
 ] }
-metrique-writer-core = { path = "../metrique-writer-core", features = ["private-test-util"] }
-metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
+metrique-writer-core = { workspace = true, features = ["private-test-util"] }
+metrique-writer = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["macros", "test-util"] }
 metrics_024 = { workspace = true }
 

--- a/metrique-writer-format-json/Cargo.toml
+++ b/metrique-writer-format-json/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 itoa = { workspace = true }
 dtoa = { workspace = true }
 rand = { workspace = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.15" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.21" }
+metrique-writer-core = { workspace = true, features = ["serde"] }
+metrique-writer = { workspace = true, features = ["background-queue", "tracing-subscriber-03", "metrics-rs-024"] }
 
 [dev-dependencies]
-metrique-writer-core = { path = "../metrique-writer-core", features = ["private-test-util"] }
-metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
+metrique-writer-core = { workspace = true, features = ["private-test-util"] }
+metrique-writer = { workspace = true, features = ["test-util"] }
 rand_chacha = { workspace = true }
 serde_json = { workspace = true }
 

--- a/metrique-writer/Cargo.toml
+++ b/metrique-writer/Cargo.toml
@@ -26,22 +26,22 @@ tokio = { workspace = true, optional = true, default-features = false, features 
 tracing = { workspace = true, optional = true }
 metrics_024 = { workspace = true, optional = true }
 metrics-util_020 = { workspace = true, optional = true }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.15" }
-metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.8" }
-metrique-core = { path = "../metrique-core", version = "0.1.19" }
+metrique-writer-core = { workspace = true, features = ["serde"] }
+metrique-writer-macro = { workspace = true }
+metrique-core = { workspace = true }
 ordered-float = { workspace = true, optional = true }
 
 [dev-dependencies]
 enum-map = { workspace = true }
 strum_macros = { workspace = true }
-metrique-writer-core = { path = "../metrique-writer-core", features = [
+metrique-writer-core = { workspace = true, features = [
     "private-test-util",
     "test-util",
 ] }
-metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf" }
-metrique-metricsrs = { path = "../metrique-metricsrs" }
-metrique = { path = "../metrique" }
+metrique-writer = { path = ".", features = ["test-util"] }
+metrique-writer-format-emf = { workspace = true }
+metrique-metricsrs = { workspace = true }
+metrique = { workspace = true, features = ["service-metrics"] }
 metrics-util_020 = { workspace = true, features = ["debugging"] }
 futures = { workspace = true, features = ["executor"] }
 tokio = { workspace = true, features = ["macros", "test-util"] }

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -29,16 +29,16 @@ metrics_rs_024 = ["metrics-rs-024"]
 
 [dependencies]
 tokio = { workspace = true, features = ["sync"] }
-metrique-writer-core = { path = "../metrique-writer-core", version = "0.1.15" }
-metrique-macro = { path = "../metrique-macro", version = "0.1.15" }
-metrique-core = { path = "../metrique-core", version = "0.1.19" }
-metrique-writer = { path = "../metrique-writer", version = "0.1.21" }
-metrique-metricsrs = { path = "../metrique-metricsrs", version = "0.1.22", optional = true }
-metrique-service-metrics = { path = "../metrique-service-metrics", version = "0.1.20", optional = true }
-metrique-timesource = { path = "../metrique-timesource", version = "0.1.9" }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf", version = "0.1.20", optional = true }
-metrique-writer-format-json = { path = "../metrique-writer-format-json", version = "0.1.3", optional = true }
-metrique-writer-macro = { path = "../metrique-writer-macro", version = "0.1.8" }
+metrique-writer-core = { workspace = true, features = ["serde"] }
+metrique-macro = { workspace = true }
+metrique-core = { workspace = true }
+metrique-writer = { workspace = true, features = ["background-queue", "tracing-subscriber-03", "metrics-rs-024"] }
+metrique-metricsrs = { workspace = true, optional = true }
+metrique-service-metrics = { workspace = true, optional = true }
+metrique-timesource = { workspace = true }
+metrique-writer-format-emf = { workspace = true, optional = true }
+metrique-writer-format-json = { workspace = true, optional = true }
+metrique-writer-macro = { workspace = true }
 tracing-appender = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 ryu = { workspace = true }
@@ -51,23 +51,23 @@ assert2 = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
-metrique-writer = { path = "../metrique-writer", features = ["test-util"] }
-metrique-timesource = { path = "../metrique-timesource", features = [
+metrique-writer = { workspace = true, features = ["test-util"] }
+metrique-timesource = { workspace = true, features = [
     "custom-timesource",
     "tokio",
     "test-util",
 ] }
-metrique-writer-core = { path = "../metrique-writer-core", features = [
+metrique-writer-core = { workspace = true, features = [
     "private-test-util",
     "test-util",
 ] }
-metrique-writer-format-emf = { path = "../metrique-writer-format-emf", features = [] }
+metrique-writer-format-emf = { workspace = true, features = [] }
 tracing = { workspace = true }
 tokio-util = { workspace = true, features = ["rt"] }
 trybuild = { workspace = true }
 rustversion = { workspace = true }
 metrique = { path = ".", features = ["emf", "test-util", "local-format"] }
-metrique-util = { path = "../metrique-util", features = ["state", "tokio-metrics-bridge"] }
+metrique-util = { workspace = true, features = ["state", "tokio-metrics-bridge"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/metrique/tests/cargo-toml-format.rs
+++ b/metrique/tests/cargo-toml-format.rs
@@ -35,18 +35,21 @@ fn test_cargo_toml_format(
                         toml_path.display()
                     )
                 });
-                assert!(
-                    dep_table.contains_key("path"),
-                    "metrique dependency '{}' in {} must have 'path' property to use crate from property",
-                    name,
-                    toml_path.display()
-                );
-                assert!(
-                    dep_table.contains_key("version"),
-                    "metrique dependency '{}' in {} must have a 'version' property to allow publishing",
-                    name,
-                    toml_path.display()
-                );
+                // workspace = true inherits path and version from [workspace.dependencies]
+                if !dep_table.contains_key("workspace") {
+                    assert!(
+                        dep_table.contains_key("path"),
+                        "metrique dependency '{}' in {} must have 'path' or 'workspace' property",
+                        name,
+                        toml_path.display()
+                    );
+                    assert!(
+                        dep_table.contains_key("version"),
+                        "metrique dependency '{}' in {} must have a 'version' or 'workspace' property to allow publishing",
+                        name,
+                        toml_path.display()
+                    );
+                }
             }
         }
     }
@@ -61,18 +64,21 @@ fn test_cargo_toml_format(
                         toml_path.display()
                     )
                 });
-                assert!(
-                    dep_table.contains_key("path"),
-                    "metrique dependency '{}' in {} must have 'path' property to use crate from property",
-                    name,
-                    toml_path.display()
-                );
-                assert!(
-                    !dep_table.contains_key("version"),
-                    "metrique dependency '{}' in {} must not use the 'version' property to prevent chicken-and-egg problems",
-                    name,
-                    toml_path.display()
-                );
+                // workspace = true inherits path from [workspace.dependencies]
+                if !dep_table.contains_key("workspace") {
+                    assert!(
+                        dep_table.contains_key("path"),
+                        "metrique dependency '{}' in {} must have 'path' or 'workspace' property",
+                        name,
+                        toml_path.display()
+                    );
+                    assert!(
+                        !dep_table.contains_key("version"),
+                        "metrique dependency '{}' in {} must not use the 'version' property to prevent chicken-and-egg problems",
+                        name,
+                        toml_path.display()
+                    );
+                }
             }
         }
     }

--- a/scripts/check-docsrs.sh
+++ b/scripts/check-docsrs.sh
@@ -72,6 +72,17 @@ check_package() {
         # Patch the extracted Cargo.toml so workspace siblings resolve locally.
         generate_patch_entries "$pkg_name" >> "$pkg_dir/Cargo.toml"
 
+        # Redirect the workspace dependency for this package to the packaged
+        # copy so siblings with `workspace = true` deps resolve there instead
+        # of the workspace path (avoids lockfile collisions).
+        local abs_pkg_dir
+        abs_pkg_dir=$(realpath "$pkg_dir")
+        cp Cargo.toml Cargo.toml.bak
+        sed -i "s|^\(${pkg_name} = {.*version.*path = \"\)[^\"]*|\1${abs_pkg_dir}|" Cargo.toml
+        # Remove from workspace members so Cargo doesn't discover the original
+        # alongside the redirected workspace dep.
+        sed -i "/\"${pkg_name}\",/d" Cargo.toml
+
         # Restore doc-scrape-examples = true that cargo package strips.
         local source_toml
         source_toml=$(cargo metadata --no-deps --format-version 1 | \
@@ -79,6 +90,9 @@ check_package() {
         restore_doc_scrape_examples "$source_toml" "$pkg_dir/Cargo.toml"
 
         (cd "$pkg_dir" && cargo +nightly docs-rs --target "$TARGET")
+
+        # Restore workspace Cargo.toml.
+        mv Cargo.toml.bak Cargo.toml
         return
     fi
 


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

Cutting over to workspace-wide local crate version management, rather than explicit path + version blocks inside crates.

I left root at `0.x` to avoid needing to change it every minor version bump.

The `check_docs.rs` support was pretty gnarly because `workspace = true` essentially resolves to workspace patches - but then, our docs.rs. packaged copies have different paths. Previously, the sibling paths were directly embedded in the packaged bundles, so we didn't have this problem.

We fixed it by modifying the `workspace.dependencies` to point to the packaged copy instead.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
