### PR TITLE
feat(util): add StateRef for non-Clone types in State

### DIFF
--- a/metrique-util/src/lib.rs
+++ b/metrique-util/src/lib.rs
@@ -8,7 +8,7 @@
 #[cfg(feature = "state")]
 mod state;
 #[cfg(feature = "state")]
-pub use state::{LatestRef, State};
+pub use state::{LatestRef, State, StateRef};
 
 #[cfg(feature = "tokio-metrics-bridge")]
 mod dynamic_inflection;

--- a/metrique-util/src/state.rs
+++ b/metrique-util/src/state.rs
@@ -6,7 +6,72 @@
 
 use std::sync::{Arc, OnceLock};
 
-use metrique_core::CloseValue;
+use metrique_core::{CloseValue, CloseValueRef};
+
+/// Shared core for [`State`] and [`StateRef`].
+struct StateInner<T> {
+    swap: Arc<arc_swap::ArcSwap<T>>,
+    snap: OnceLock<Arc<T>>,
+}
+
+impl<T> StateInner<T> {
+    fn new(val: T) -> Self {
+        Self {
+            swap: Arc::new(arc_swap::ArcSwap::from_pointee(val)),
+            snap: OnceLock::new(),
+        }
+    }
+
+    fn store(&self, val: Arc<T>) {
+        self.swap.store(val);
+    }
+
+    fn snapshot(&self) -> Arc<T> {
+        self.snap.get_or_init(|| self.swap.load_full()).clone()
+    }
+
+    fn latest(&self) -> LatestRef<T> {
+        LatestRef(self.swap.load())
+    }
+}
+
+impl<T> Clone for StateInner<T> {
+    fn clone(&self) -> Self {
+        Self {
+            swap: self.swap.clone(),
+            snap: OnceLock::new(),
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> StateInner<T> {
+    fn debug_fmt(&self, f: &mut std::fmt::Formatter<'_>, name: &str) -> std::fmt::Result {
+        let mut d = f.debug_struct(name);
+        d.field("current", &*self.swap.load());
+        if let Some(snap) = self.snap.get() {
+            d.field("snapshot", snap);
+        }
+        d.finish()
+    }
+}
+
+/// A cheap, short-lived reference returned by [`State::latest`] and
+/// [`StateRef::latest`].
+///
+/// Always reads the latest value (bypasses the snapshot). This means
+/// that the guarded value might differ from metrics emitted by its related
+/// [`State`] or [`StateRef`].
+///
+/// Derefs to `T` without cloning. Not `Send`; for cross-task use, call
+/// [`snapshot`](State::snapshot) instead.
+pub struct LatestRef<T>(arc_swap::Guard<Arc<T>>);
+
+impl<T> std::ops::Deref for LatestRef<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
 
 /// An atomically swappable shared value where each cloned handle captures a
 /// snapshot on first read.
@@ -16,6 +81,11 @@ use metrique_core::CloseValue;
 /// current value and emit metrics reflecting what they saw. `State`
 /// ensures the value captured for metrics matches the value used during
 /// processing, even if a background task swaps in a new value mid-request.
+///
+/// `State` requires `T: Clone` so it can extract the value from the
+/// internal `Arc` for closing. If your `T` is not `Clone` but implements
+/// [`CloseValueRef`] (i.e. both `CloseValue for T` and `CloseValue for &T`),
+/// use [`StateRef`] instead.
 ///
 /// # Usage
 ///
@@ -84,35 +154,12 @@ use metrique_core::CloseValue;
 /// let next_request = shared.clone();
 /// assert_eq!(*next_request.snapshot(), "v2");
 /// ```
-pub struct State<T> {
-    swap: Arc<arc_swap::ArcSwap<T>>,
-    snap: OnceLock<Arc<T>>,
-}
-
-/// A cheap, short-lived reference returned by [`State::latest`].
-///
-/// Always reads the latest value (bypasses the snapshot). This means
-/// that the guarded value might differ from metrics emitted by its related
-/// [`State`].
-///
-/// Derefs to `T` without cloning. Not `Send`; for cross-task use, call
-/// [`snapshot`](State::snapshot) instead.
-pub struct LatestRef<T>(arc_swap::Guard<Arc<T>>);
-
-impl<T> std::ops::Deref for LatestRef<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}
+pub struct State<T>(StateInner<T>);
 
 impl<T> State<T> {
     /// Create a new `State` from an initial value.
     pub fn new(val: T) -> Self {
-        Self {
-            swap: Arc::new(arc_swap::ArcSwap::from_pointee(val)),
-            snap: OnceLock::new(),
-        }
+        Self(StateInner::new(val))
     }
 
     /// Atomically replace the shared value.
@@ -122,7 +169,7 @@ impl<T> State<T> {
     /// captured one. A handle that has already called `snapshot` is
     /// unaffected; its captured value is immutable.
     pub fn store(&self, val: Arc<T>) {
-        self.swap.store(val);
+        self.0.store(val);
     }
 
     /// Capture and return a snapshot of the current value.
@@ -130,7 +177,7 @@ impl<T> State<T> {
     /// The first call captures the value; subsequent calls return the
     /// same `Arc<T>`.
     pub fn snapshot(&self) -> Arc<T> {
-        self.snap.get_or_init(|| self.swap.load_full()).clone()
+        self.0.snapshot()
     }
 
     /// Get a cheap guard for the latest shared value, bypassing the snapshot.
@@ -142,7 +189,7 @@ impl<T> State<T> {
     ///
     /// Returns a [`LatestRef`] that derefs to `T`.
     pub fn latest(&self) -> LatestRef<T> {
-        LatestRef(self.swap.load())
+        self.0.latest()
     }
 }
 
@@ -150,21 +197,13 @@ impl<T> Clone for State<T> {
     /// Clone produces a fresh handle to the same shared value, without a
     /// captured snapshot.
     fn clone(&self) -> Self {
-        Self {
-            swap: self.swap.clone(),
-            snap: OnceLock::new(),
-        }
+        Self(self.0.clone())
     }
 }
 
 impl<T: std::fmt::Debug> std::fmt::Debug for State<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("State");
-        d.field("current", &*self.swap.load());
-        if let Some(snap) = self.snap.get() {
-            d.field("snapshot", snap);
-        }
-        d.finish()
+        self.0.debug_fmt(f, "State")
     }
 }
 
@@ -192,13 +231,108 @@ where
     }
 }
 
+/// Like [`State`], but closes by reference instead of cloning.
+///
+/// Use this when `T` is not `Clone` but implements [`CloseValueRef`]
+/// (i.e. both `CloseValue for T` and `CloseValue for &T`). This is
+/// common for `#[metrics(subfield)]` structs containing non-Clone fields
+/// like [`OnceLock`](std::sync::OnceLock).
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use std::sync::OnceLock;
+///
+/// #[metrics(subfield)]
+/// struct Environment {
+///     feature_flag: bool,
+///     // Populated later; emits None if still empty at close time.
+///     resolved_region: OnceLock<&'static str>,
+/// }
+///
+/// #[metrics(rename_all = "PascalCase")]
+/// struct RequestMetrics {
+///     #[metrics(flatten)]
+///     env: StateRef<Environment>,
+/// }
+/// ```
+///
+/// See [`State`] for full documentation on snapshot semantics.
+pub struct StateRef<T>(StateInner<T>);
+
+impl<T> StateRef<T> {
+    /// Create a new `StateRef` from an initial value.
+    pub fn new(val: T) -> Self {
+        Self(StateInner::new(val))
+    }
+
+    /// Atomically replace the shared value. Existing snapshots are unaffected.
+    ///
+    /// See [`State::store`] for details.
+    pub fn store(&self, val: Arc<T>) {
+        self.0.store(val);
+    }
+
+    /// Capture and return a snapshot of the current value.
+    /// The first call pins the snapshot; subsequent calls return the same `Arc<T>`.
+    ///
+    /// See [`State::snapshot`] for details.
+    pub fn snapshot(&self) -> Arc<T> {
+        self.0.snapshot()
+    }
+
+    /// Get a cheap guard for the latest shared value, bypassing the snapshot.
+    /// The returned value may differ from what metrics will emit on close.
+    ///
+    /// See [`State::latest`] for details.
+    pub fn latest(&self) -> LatestRef<T> {
+        self.0.latest()
+    }
+}
+
+impl<T> Clone for StateRef<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for StateRef<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.debug_fmt(f, "StateRef")
+    }
+}
+
+#[diagnostic::do_not_recommend]
+impl<T> CloseValue for StateRef<T>
+where
+    T: CloseValueRef,
+{
+    type Closed = T::Closed;
+
+    fn close(self) -> Self::Closed {
+        self.snapshot().close()
+    }
+}
+
+#[diagnostic::do_not_recommend]
+impl<T> CloseValue for &'_ StateRef<T>
+where
+    T: CloseValueRef,
+{
+    type Closed = T::Closed;
+
+    fn close(self) -> Self::Closed {
+        self.snapshot().close()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use metrique_core::CloseValue;
 
-    use super::State;
+    use super::{State, StateRef};
 
     #[derive(Clone, Debug)]
     struct Closeable;
@@ -226,7 +360,6 @@ mod tests {
         let x = State::new(42u64);
         assert_eq!(*x.snapshot(), 42);
         x.store(Arc::new(100));
-        // Still returns the captured value.
         assert_eq!(*x.snapshot(), 42);
     }
 
@@ -242,9 +375,7 @@ mod tests {
         let x = State::new(42u64);
         x.snapshot();
         x.store(Arc::new(100));
-        // Snapshot is unchanged.
         assert_eq!(*x.snapshot(), 42);
-        // But a fresh clone sees the new value.
         assert_eq!(*x.clone().snapshot(), 100);
     }
 
@@ -258,14 +389,13 @@ mod tests {
     #[test]
     fn clone_gets_fresh_snapshot() {
         let x = State::new(42u64);
-        x.snapshot(); // capture 42
+        x.snapshot();
 
         let writer = x.clone();
         writer.store(Arc::new(100));
 
         let reader = x.clone();
         assert_eq!(*reader.snapshot(), 100);
-        // Original still has 42.
         assert_eq!(*x.snapshot(), 42);
     }
 
@@ -292,5 +422,43 @@ mod tests {
         x.snapshot();
         let dbg = format!("{:?}", x);
         assert!(dbg.contains("snapshot"));
+    }
+
+    #[derive(Debug)]
+    struct NotClone(u64);
+    impl CloseValue for NotClone {
+        type Closed = u64;
+        fn close(self) -> u64 {
+            self.0
+        }
+    }
+    impl CloseValue for &'_ NotClone {
+        type Closed = u64;
+        fn close(self) -> u64 {
+            self.0
+        }
+    }
+
+    #[test]
+    fn state_ref_close_owned() {
+        let x = StateRef::new(NotClone(99));
+        assert_eq!(x.close(), 99);
+    }
+
+    #[test]
+    fn state_ref_close_ref() {
+        let x = StateRef::new(NotClone(99));
+        assert_eq!((&x).close(), 99);
+    }
+
+    #[test]
+    fn state_ref_snapshot() {
+        let x = StateRef::new(NotClone(1));
+        assert_eq!(x.snapshot().0, 1);
+        x.store(Arc::new(NotClone(2)));
+        // Snapshot is pinned.
+        assert_eq!(x.snapshot().0, 1);
+        // Fresh clone sees new value.
+        assert_eq!(x.clone().snapshot().0, 2);
     }
 }

--- a/metrique-util/tests/state.rs
+++ b/metrique-util/tests/state.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use metrique::unit_of_work::metrics;
 use metrique::writer::sink::VecEntrySink;
 use metrique::writer::test_util;
-use metrique_util::State;
+use metrique_util::{State, StateRef};
 
 #[derive(Clone, Debug, Default)]
 #[metrics(subfield)]
@@ -242,4 +242,83 @@ async fn state_spawned_tasks_across_config_reload() {
     let e3 = test_util::to_test_entry(&entries[2]);
     assert_eq!(e3.values["Operation"], "DeleteItem");
     assert_eq!(e3.metrics["FeatureXyzEnabled"], 1);
+}
+
+/// StateRef<T> works with non-Clone types containing OnceLock for progressive population.
+/// This is the motivating use case for issue #263.
+#[test]
+fn state_ref_with_oncelock_progressive_population() {
+    use std::sync::OnceLock;
+
+    #[metrics(subfield)]
+    struct Environment {
+        feature_flag: bool,
+        resolved_region: OnceLock<&'static str>,
+    }
+
+    #[metrics(rename_all = "PascalCase")]
+    struct Metrics {
+        operation: &'static str,
+        #[metrics(flatten)]
+        env: StateRef<Environment>,
+    }
+
+    let vec_sink = VecEntrySink::new();
+
+    let state = StateRef::new(Environment {
+        feature_flag: true,
+        resolved_region: OnceLock::new(),
+    });
+
+    // Simulate background work progressively populating the OnceLock
+    // through the shared Arc.
+    state.snapshot().resolved_region.set("us-east-1").unwrap();
+
+    let metrics = Metrics {
+        operation: "GetItem",
+        env: state,
+    }
+    .append_on_drop(vec_sink.clone());
+    drop(metrics);
+
+    let entries = vec_sink.drain();
+    assert_eq!(entries.len(), 1);
+    let entry = test_util::to_test_entry(&entries[0]);
+    assert_eq!(entry.values["Operation"], "GetItem");
+    assert_eq!(entry.metrics["FeatureFlag"], 1);
+    assert_eq!(entry.values["ResolvedRegion"], "us-east-1");
+}
+
+/// OnceLock fields left unset at emission time close as None (omitted from output).
+#[test]
+fn state_ref_unset_oncelock_emits_none() {
+    use std::sync::OnceLock;
+
+    #[metrics(subfield)]
+    struct Environment {
+        resolved_region: OnceLock<&'static str>,
+    }
+
+    #[metrics(rename_all = "PascalCase")]
+    struct Metrics {
+        #[metrics(flatten)]
+        env: StateRef<Environment>,
+    }
+
+    let vec_sink = VecEntrySink::new();
+
+    let metrics = Metrics {
+        env: StateRef::new(Environment {
+            resolved_region: OnceLock::new(),
+        }),
+    }
+    .append_on_drop(vec_sink.clone());
+    drop(metrics);
+
+    let entries = vec_sink.drain();
+    assert_eq!(entries.len(), 1);
+    let entry = test_util::to_test_entry(&entries[0]);
+    // Unset OnceLock should not appear in the emitted entry.
+    assert!(!entry.values.contains_key("ResolvedRegion"));
+    assert!(!entry.metrics.contains_key("ResolvedRegion"));
 }

--- a/metrique/examples/global-state.rs
+++ b/metrique/examples/global-state.rs
@@ -7,7 +7,7 @@
 //! routing config, in-flight counters) that should appear on every
 //! metric record for correlation during debugging.
 //!
-//! This example shows two approaches:
+//! This example shows three approaches:
 //!
 //! 1. **Borrowed (`&'static`)**: `Counter` and `OnceLock<State<T>>`
 //!    live in statics. Cheap, no `Arc` overhead, but not injectable
@@ -18,6 +18,11 @@
 //!    that is cloned into each request's metrics. Cloning shares the
 //!    underlying `Counter` (via `Arc`) and gives each request a fresh
 //!    `State` snapshot slot. More flexible, easy to inject in tests.
+//!
+//! 3. **Progressive population**: [`StateRef`](metrique_util::StateRef)
+//!    wraps a struct containing `OnceLock` fields that start empty and
+//!    are filled during request processing. Fields still empty at
+//!    emission time close as `None`.
 //!
 //! Both patterns flatten shared state into the per-request metric, so
 //! every emitted record includes the current counter value, config
@@ -40,7 +45,7 @@ use metrique::{
     unit_of_work::metrics,
     writer::{AttachGlobalEntrySinkExt, FormatExt, GlobalEntrySink},
 };
-use metrique_util::State;
+use metrique_util::{State, StateRef};
 
 // ---------------------------------------------------------------------------
 // Borrowed (static) state
@@ -115,6 +120,27 @@ impl AppState {
 }
 
 // ---------------------------------------------------------------------------
+// Progressive population with OnceLock in State
+// ---------------------------------------------------------------------------
+
+// OnceLock fields start empty and are filled during request processing.
+// Fields still empty at emission time close as None.
+#[metrics(subfield)]
+struct RequestEnvironment {
+    resolved_endpoint: OnceLock<&'static str>,
+    cache_hit: OnceLock<bool>,
+}
+
+impl RequestEnvironment {
+    fn new() -> Self {
+        Self {
+            resolved_endpoint: OnceLock::new(),
+            cache_hit: OnceLock::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Per-request metrics
 // ---------------------------------------------------------------------------
 
@@ -125,6 +151,8 @@ struct RequestMetrics {
     static_state: BorrowedState,
     #[metrics(flatten)]
     app_state: AppState,
+    #[metrics(flatten)]
+    request_env: StateRef<RequestEnvironment>,
 }
 
 impl RequestMetrics {
@@ -133,6 +161,7 @@ impl RequestMetrics {
             throttled: false,
             static_state: BorrowedState::new(),
             app_state: state.clone(),
+            request_env: StateRef::new(RequestEnvironment::new()),
         }
         .append_on_drop(ServiceMetrics::sink())
     }
@@ -161,10 +190,11 @@ async fn main() {
     //
     // Requests 1 and 2 see the default config (NoThrottle, feature off).
     // Request 3 starts after the 1s refresh, sees the new config (Throttle, feature on).
+    // All requests populate ResolvedEndpoint and CacheHit via OnceLock.
     //
-    // {"Throttled":0,"InFlight":1,"ActiveRequests":0,"FeatureXyzEnabled":0,"NodeGroup":"us-east-1a","ThrottlePolicy":"NoThrottle", ...}
-    // {"Throttled":0,"InFlight":0,"ActiveRequests":0,"FeatureXyzEnabled":0,"NodeGroup":"us-east-1a","ThrottlePolicy":"NoThrottle", ...}
-    // {"Throttled":1,"InFlight":0,"ActiveRequests":0,"FeatureXyzEnabled":1,"NodeGroup":"us-east-1a","ThrottlePolicy":"Throttle", ...}
+    // {"Throttled":0,"InFlight":1,"ActiveRequests":0,"FeatureXyzEnabled":0,"ThrottlePolicy":"NoThrottle","ResolvedEndpoint":"us-east-1","CacheHit":0, ...}
+    // {"Throttled":0,"InFlight":0,"ActiveRequests":0,"FeatureXyzEnabled":0,"ThrottlePolicy":"NoThrottle","ResolvedEndpoint":"us-east-1","CacheHit":0, ...}
+    // {"Throttled":1,"InFlight":0,"ActiveRequests":0,"FeatureXyzEnabled":1,"ThrottlePolicy":"Throttle","ResolvedEndpoint":"us-east-1","CacheHit":0, ...}
 }
 
 async fn handle_request(state: &AppState) {
@@ -177,12 +207,19 @@ async fn handle_request(state: &AppState) {
         metrics.throttled = true;
     }
 
+    // Progressively populate OnceLock fields as information becomes
+    // available. Fields not set by emission time close as None.
+    let env = metrics.request_env.snapshot();
+    env.resolved_endpoint.set("us-east-1").ok();
+
     let _guard = IN_FLIGHT.increment_scoped();
-    do_some_work().await;
+    let cached = do_some_work().await;
+    env.cache_hit.set(cached).ok();
 }
 
-async fn do_some_work() {
+async fn do_some_work() -> bool {
     tokio::time::sleep(Duration::from_millis(1500)).await;
+    false // simulate a cache miss
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
📬 *Issue #, if available:*

#263 

✍️ *Description of changes:*


`State<T>` requires `T: Clone` for its `CloseValue` impls because it extracts the value from an internal `Arc` via `Arc::unwrap_or_clone`. This prevents using `State` with structs containing non-Clone fields like `OnceLock`, which are useful for progressive population (fields that start empty and are filled during request processing).

Rather than changing `State`'s bounds (which would break existing uses like `State<String>`, since `&String` intentionally doesn't implement `CloseValue`), this adds a new `StateRef<T>` type that requires `T: CloseValueRef` instead of `T: Clone + CloseValue`. `StateRef` closes by reference through the `Arc`, so no cloning is needed.

Both types share the same snapshot semantics via an internal `StateInner` struct. The choice between them is simple: use `State` when `T` is `Clone`, use `StateRef` when `T` implements `CloseValue` for both owned and borrowed (e.g. `#[metrics(subfield)]` structs containing `OnceLock` fields).

The global-state example is updated to demonstrate progressive population with `OnceLock` fields in a `StateRef`-wrapped struct.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
