### PR TITLE
Fix audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/metrique-aggregation/src/histogram.rs
+++ b/metrique-aggregation/src/histogram.rs
@@ -187,11 +187,9 @@ impl<T, S: AggregationStrategy> Histogram<T, S> {
                     match obs {
                         Observation::Unsigned(v) => self.0.record(v as f64),
                         Observation::Floating(v) => self.0.record(v),
-                        Observation::Repeated { total, occurrences } => {
-                            if occurrences > 0 {
-                                let avg = total / occurrences as f64;
-                                self.0.record_many(avg, occurrences);
-                            }
+                        Observation::Repeated { total, occurrences } if occurrences > 0 => {
+                            let avg = total / occurrences as f64;
+                            self.0.record_many(avg, occurrences);
                         }
                         _ => {}
                     }
@@ -271,11 +269,9 @@ impl<T, S: SharedAggregationStrategy> SharedHistogram<T, S> {
                     match obs {
                         Observation::Unsigned(v) => self.0.record(v as f64),
                         Observation::Floating(v) => self.0.record(v),
-                        Observation::Repeated { total, occurrences } => {
-                            if occurrences > 0 {
-                                let avg = total / occurrences as f64;
-                                self.0.record_many(avg, occurrences);
-                            }
+                        Observation::Repeated { total, occurrences } if occurrences > 0 => {
+                            let avg = total / occurrences as f64;
+                            self.0.record_many(avg, occurrences);
                         }
                         _ => {}
                     }
@@ -540,12 +536,10 @@ where
     fn insert(accum: &mut Self::Aggregated, value: HistogramClosed<T>) {
         for obs in value.observations {
             match obs {
-                Observation::Repeated { total, occurrences } => {
-                    if occurrences > 0 {
-                        accum
-                            .strategy
-                            .record_many(total / occurrences as f64, occurrences);
-                    }
+                Observation::Repeated { total, occurrences } if occurrences > 0 => {
+                    accum
+                        .strategy
+                        .record_many(total / occurrences as f64, occurrences);
                 }
                 Observation::Unsigned(v) => accum.strategy.record(v as f64),
                 Observation::Floating(v) => accum.strategy.record(v),

--- a/metrique/src/local.rs
+++ b/metrique/src/local.rs
@@ -309,9 +309,7 @@ impl ValueWriter for FieldValueWriter<'_> {
                     value: v,
                     weight: 1,
                 }),
-                Observation::Repeated { total, occurrences }
-                    if occurrences > 0 =>
-                {
+                Observation::Repeated { total, occurrences } if occurrences > 0 => {
                     // Repeated observations represent `occurrences` samples that sum
                     // to `total`. We store the average with the full weight so
                     // percentile computation accounts for the count without

--- a/metrique/src/local.rs
+++ b/metrique/src/local.rs
@@ -309,17 +309,17 @@ impl ValueWriter for FieldValueWriter<'_> {
                     value: v,
                     weight: 1,
                 }),
-                Observation::Repeated { total, occurrences } => {
-                    if occurrences > 0 {
-                        // Repeated observations represent `occurrences` samples that sum
-                        // to `total`. We store the average with the full weight so
-                        // percentile computation accounts for the count without
-                        // allocating one entry per occurrence.
-                        observations.push(WeightedObservation {
-                            value: total / occurrences as f64,
-                            weight: occurrences,
-                        });
-                    }
+                Observation::Repeated { total, occurrences }
+                    if occurrences > 0 =>
+                {
+                    // Repeated observations represent `occurrences` samples that sum
+                    // to `total`. We store the average with the full weight so
+                    // percentile computation accounts for the count without
+                    // allocating one entry per occurrence.
+                    observations.push(WeightedObservation {
+                        value: total / occurrences as f64,
+                        weight: occurrences,
+                    });
                 }
                 // Observation is #[non_exhaustive]; unknown variants are intentionally
                 // skipped — this is a best-effort debug format, not a lossless serializer.


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

The `security_audit` CI job is failing on two fronts: a `rand` unsoundness advisory (RUSTSEC-2026-0097) and a GitHub API permissions error preventing the check run from being created.

This updates `rand` from 0.9.2 to 0.9.4 to resolve the advisory, and adds `checks: write` / `contents: read` permissions to the audit workflow so `rustsec/audit-check` can post its results as a GitHub Check Run.

#### Testing

`cargo audit` passes cleanly after the lockfile update.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
