### PR TITLE
chore: release metrique 0.1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25](https://github.com/awslabs/metrique/compare/metrique-v0.1.24...metrique-v0.1.25) - 2026-04-20
+
+### Added
+
+- `pending_sink` in `metrique-util` (feature: `pending-sink`): deferred sink attachment with bounded buffering. ([#275](https://github.com/awslabs/metrique/pull/275))
+  - Emit metrics immediately during startup while the real sink initializes asynchronously.
+  - Entries buffer in a lock-free ring buffer; oldest dropped when full.
+  - `resolver.resolve(real_sink)` drains the buffer and switches to direct forwarding.
+
+  ```rust
+  use metrique_util::pending_sink;
+
+  // Create a pending sink that buffers up to 1024 entries.
+  let (sink, resolver) = pending_sink::new(1024);
+
+  // Attach immediately so metrics start buffering during startup.
+  let _handle = ServiceMetrics::attach((sink, ()));
+
+  // Later, once the real sink is ready (after async init, credential
+  // exchange, etc.):
+  resolver.resolve(real_sink);
+  // Buffered entries drain into the real sink; future appends go direct.
+  ```
+
+### Other
+
+- Fix audit ([#276](https://github.com/awslabs/metrique/pull/276))
+- reframe terminology to lead with "wide events" ([#273](https://github.com/awslabs/metrique/pull/273))
+- use workspace dependencies for inter-crate deps ([#271](https://github.com/awslabs/metrique/pull/271))
+
 ## [0.1.24](https://github.com/awslabs/metrique/compare/metrique-v0.1.23...metrique-v0.1.24) - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "assert2",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-aggregation"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "assert2",
  "divan",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-core"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "itertools",
  "metrique",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-macro"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "Inflector",
  "assert2",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-metricsrs"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "derive-where",
  "futures",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-service-metrics"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "metrique",
  "metrique-writer",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-util"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "arc-swap",
  "assert2",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "ahash",
  "assert-json-diff",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-core"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "assert-json-diff",
  "derive-where",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-emf"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "assert-json-diff",
  "assert_approx_eq",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-json"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "dtoa",
  "itoa",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-macro"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-aggregation"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 rust-version = "1.89" # build.yml
 license = "Apache-2.0"

--- a/metrique-core/Cargo.toml
+++ b/metrique-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-core"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-macro"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-metricsrs/Cargo.toml
+++ b/metrique-metricsrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-metricsrs"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-service-metrics/Cargo.toml
+++ b/metrique-service-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-service-metrics"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-util/Cargo.toml
+++ b/metrique-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-util"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-writer-core/Cargo.toml
+++ b/metrique-writer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-core"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-writer-format-emf/Cargo.toml
+++ b/metrique-writer-format-emf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-format-emf"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-writer-format-json/Cargo.toml
+++ b/metrique-writer-format-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-format-json"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.89"
 license = "Apache-2.0"

--- a/metrique-writer-macro/Cargo.toml
+++ b/metrique-writer-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-macro"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique-writer/Cargo.toml
+++ b/metrique-writer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 rust-version = "1.89" # See build.yml for why this MSRV
 license = "Apache-2.0"

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 license = "Apache-2.0"
 description = "Library for generating wide event metrics"


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

### Summary

Release metrique 0.1.25 (and subcrate bumps).

The main addition is `pending_sink` in `metrique-util` (feature: `pending-sink`), which enables deferred sink attachment with bounded entry buffering. This lets applications attach a global sink and start emitting metrics immediately during startup, even when the real sink requires async initialization. Entries buffer in a lock-free ring buffer until `resolver.resolve(real_sink)` drains them and switches to direct forwarding.

Also includes: a security audit fix (rand advisory + CI permissions), documentation reframing to lead with "wide events" terminology, and a refactor to workspace dependencies for inter-crate deps.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
