### PR TITLE
feat(macro): Add flags(...) macro attribute for per-field ForceFlag

### DIFF
--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -227,13 +227,27 @@ fn generate_field_writes(
                 let (extra, name) = make_inflect_metric_name(root_attrs, field);
                 let field_access = field_access(&field.ident);
                 let value = crate::value_impl::format_value(format, field_span, field_access);
+
+                let wrapped_value = if field.attrs.flags.is_empty() {
+                    quote! { #value }
+                } else {
+                    let flags = &field.attrs.flags;
+                    let mut expr = quote! { #value };
+                    for path in flags {
+                        expr = quote! {
+                            ::metrique::writer::value::ForceFlag::<_, #path>::from(#expr)
+                        };
+                    }
+                    quote! { &#expr }
+                };
+
                 quote_spanned! {field_span=>
                     ::metrique::writer::EntryWriter::value(#writer_ident,
                         {
                             #extra
                             ::metrique::concat::const_str_value::<#name>()
                         }
-                        , #value);
+                        , #wrapped_value);
                 }
             }
         };

--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -691,6 +691,29 @@ impl From<RawTag> for Tag {
     }
 }
 
+/// Wrapper for parsing `flags(Path1, Path2, ...)` as a single darling field.
+///
+/// Implements `FromMeta` by parsing the token stream directly via `parse_args_with`.
+/// This works around a darling limitation where custom `FromMeta` types are silently
+/// dropped when they appear alongside darling `Flag` fields (like `flatten`, `no_close`)
+/// in the same attribute struct.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FlagsList(pub(crate) Vec<syn::Path>);
+
+impl FromMeta for FlagsList {
+    fn from_meta(item: &syn::Meta) -> darling::Result<Self> {
+        match item {
+            syn::Meta::List(list) => {
+                let parsed: syn::punctuated::Punctuated<syn::Path, syn::Token![,]> = list
+                    .parse_args_with(syn::punctuated::Punctuated::parse_terminated)
+                    .map_err(|e| darling::Error::custom(e.to_string()).with_span(list))?;
+                Ok(FlagsList(parsed.into_iter().collect()))
+            }
+            _ => Err(darling::Error::custom("expected flags(Path, ...)").with_span(item)),
+        }
+    }
+}
+
 #[derive(Debug, Default, FromMeta)]
 struct RawRootAttributes {
     prefix: Option<SpannedKv<String>>,
@@ -878,6 +901,9 @@ struct RawMetricsFieldAttrs {
 
     #[darling(default)]
     exact_prefix: Option<SpannedKv<String>>,
+
+    #[darling(default)]
+    flags: FlagsList,
 }
 
 /// Wrapper type to allow recovering both the key and value span when parsing an attribute
@@ -1041,6 +1067,22 @@ impl RawMetricsFieldAttrs {
             }
         }
 
+        // flags(...) on flatten/flatten_entry/timestamp/ignore is not yet supported.
+        if !self.flags.0.is_empty()
+            && let Some((
+                MetricsFieldKind::Flatten { span, .. }
+                | MetricsFieldKind::FlattenEntry(span)
+                | MetricsFieldKind::Timestamp(span)
+                | MetricsFieldKind::Ignore(span),
+                _,
+            )) = &out
+        {
+            return Err(darling::Error::custom(
+                "flags(...) is not yet supported on flatten, flatten_entry, timestamp, or ignore fields.",
+            )
+            .with_span(span));
+        }
+
         Ok(MetricsFieldAttrs {
             close,
             kind: match out {
@@ -1052,6 +1094,7 @@ impl RawMetricsFieldAttrs {
                     format: format.cloned(),
                 },
             },
+            flags: self.flags.0,
         })
     }
 }
@@ -1078,6 +1121,7 @@ fn validate_name_inner(name: &str) -> std::result::Result<(), &'static str> {
 struct MetricsFieldAttrs {
     close: bool,
     kind: MetricsFieldKind,
+    flags: Vec<syn::Path>,
 }
 
 pub(crate) struct MetricsField {

--- a/metrique-writer-core/src/value/force.rs
+++ b/metrique-writer-core/src/value/force.rs
@@ -53,8 +53,13 @@ pub trait FlagConstructor {
 
 /// Helper to force enable metric flags on a value
 ///
-/// This is intentionally "punned" to work with [Entry], [Value], and [EntryIoStream] to
-/// avoid duplication of the format-specific flag types like `HighStorageResolution`.
+/// The `#[metrics(flags(...))]` attribute provides an alternative syntax:
+/// ```ignore
+/// #[metrics(flags(HighStorageResolution))]
+/// latency: u64,
+/// ```
+// Intentionally "punned" to work with Entry, Value, and EntryIoStream to
+// avoid duplication of the format-specific flag types like HighStorageResolution.
 #[derive_where(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash; T)]
 pub struct ForceFlag<T, FLAGS: FlagConstructor>(T, PhantomData<FLAGS>);
 

--- a/metrique-writer-format-emf/src/lib.rs
+++ b/metrique-writer-format-emf/src/lib.rs
@@ -15,3 +15,16 @@ pub use emf::{
     HighStorageResolutionCtor, MetricDefinition, MetricDirective, NoMetric, NoMetricCtor,
     SampledEmf, StorageResolution,
 };
+
+/// Re-exports of `FlagConstructor` types for use in `#[metrics(flags(...))]` attributes.
+///
+/// ```ignore
+/// use metrique::emf::flags::HighStorageResolution;
+///
+/// #[metrics(flags(HighStorageResolution))]
+/// event_count: u64,
+/// ```
+pub mod flags {
+    pub use super::HighStorageResolutionCtor as HighStorageResolution;
+    pub use super::NoMetricCtor as NoMetric;
+}

--- a/metrique/docs/emf.md
+++ b/metrique/docs/emf.md
@@ -290,7 +290,7 @@ struct RequestMetrics {
 }
 ```
 
-This is useful for numeric context values that you want available in CloudWatch Logs Insights queries but don't need as aggregated CloudWatch metrics.
+This is useful for numeric context values that you want available in CloudWatch Logs Insights or Contributor Insights queries but don't need as CloudWatch metrics.
 
 ## Platform Specific Guidance
 

--- a/metrique/docs/emf.md
+++ b/metrique/docs/emf.md
@@ -251,6 +251,47 @@ Your choice of destination will depend on your platform and performance needs. S
 
 **Important Note**: In all cases, you do not (and should not) use a nonblocking writer like [`tracing_appender::non_blocking`] when configuring `metrique`. There is _already_ a background sink. By using a non-blocking writer, you're adding a second level of indirection that is both unnecessary and will consume more memory during failure.
 
+## High-Resolution Metrics
+
+By default, CloudWatch metrics have a 60-second storage resolution. To store at 1-second resolution, apply the `HighStorageResolution` flag:
+
+```rust
+use metrique::unit_of_work::metrics;
+use metrique::emf::flags::HighStorageResolution;
+
+#[metrics(
+    rename_all = "PascalCase",
+    emf::dimension_sets = [["Operation"]],
+)]
+struct LatencySensitiveMetrics {
+    operation: String,
+    #[metrics(flags(HighStorageResolution))]
+    latency_ms: u64,
+}
+```
+
+## Excluding Fields from CloudWatch Metrics (NoMetric)
+
+To emit a numeric value as a JSON property without creating a CloudWatch metric, apply the `NoMetric` flag:
+
+```rust
+use metrique::unit_of_work::metrics;
+use metrique::emf::flags::NoMetric;
+
+#[metrics(
+    rename_all = "PascalCase",
+    emf::dimension_sets = [["Service"]],
+)]
+struct RequestMetrics {
+    service: String,
+    latency_ms: u64,
+    #[metrics(flags(NoMetric))]
+    request_size_bytes: u64, // appears in JSON but not as a CloudWatch metric
+}
+```
+
+This is useful for numeric context values that you want available in CloudWatch Logs Insights queries but don't need as aggregated CloudWatch metrics.
+
 ## Platform Specific Guidance
 
 ### Fargate / ECS

--- a/metrique/examples/emf.rs
+++ b/metrique/examples/emf.rs
@@ -4,7 +4,8 @@
 use std::time::SystemTime;
 
 use metrique::ServiceMetrics;
-use metrique::emf::{Emf, HighStorageResolution, NoMetric};
+use metrique::emf::Emf;
+use metrique::emf::flags::{HighStorageResolution, NoMetric};
 use metrique::unit_of_work::metrics;
 use metrique::writer::{
     AttachGlobalEntrySinkExt, Entry, EntryIoStreamExt, FormatExt, GlobalEntrySink,
@@ -24,8 +25,10 @@ struct RequestMetrics {
     operation: &'static str,
     status: &'static str,
     number_of_ducks: usize,
-    no_metric: NoMetric<usize>,
-    high_storage_resolution: HighStorageResolution<usize>,
+    #[metrics(flags(NoMetric))]
+    no_metric: usize,
+    #[metrics(flags(HighStorageResolution))]
+    high_storage_resolution: usize,
     active_plugins: Vec<String>,
 }
 
@@ -36,8 +39,8 @@ impl RequestMetrics {
             operation,
             status: "INCOMPLETE",
             number_of_ducks: 0,
-            no_metric: (0).into(),
-            high_storage_resolution: (0).into(),
+            no_metric: 0,
+            high_storage_resolution: 0,
             active_plugins: vec!["auth".into(), "logging".into()],
         }
         .append_on_drop(ServiceMetrics::sink())
@@ -66,8 +69,8 @@ fn main() {
     );
     let mut request = RequestMetrics::init("CountDucks");
     request.number_of_ducks += 10;
-    *request.no_metric += 1;
-    *request.high_storage_resolution += 1;
+    request.no_metric += 1;
+    request.high_storage_resolution += 1;
     request.status = "SUCCESS";
 
     /*

--- a/metrique/src/emf.rs
+++ b/metrique/src/emf.rs
@@ -13,6 +13,10 @@ pub use metrique_writer_format_emf::{
     MetricDefinition, MetricDirective, NoMetric, NoMetricCtor, SampledEmf, StorageResolution,
 };
 
+/// Re-exports of `FlagConstructor` types for use in `#[metrics(flags(...))]` attributes.
+#[cfg(feature = "emf")]
+pub use metrique_writer_format_emf::flags;
+
 /// Add EMF Entry-specific dimensions
 ///
 /// Generally, you will not use this directly. Instead, use the `#[metrics(emf::dimension_sets)]` attribute. See the

--- a/metrique/tests/flags.rs
+++ b/metrique/tests/flags.rs
@@ -1,0 +1,277 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use metrique::emf::Emf;
+use metrique::writer::{format::Format, value::ForceFlag};
+use metrique::{CloseValue, RootEntry, unit_of_work::metrics};
+use serde_json::Value;
+
+// --- EMF: HighStorageResolution on individual field ---
+
+#[metrics(
+    rename_all = "PascalCase",
+    emf::dimension_sets = [["Operation"]],
+)]
+struct HighResField {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+    operation: String,
+    #[metrics(flags(metrique::emf::flags::HighStorageResolution))]
+    event_count: u64,
+    normal_count: u64,
+}
+
+#[test]
+fn flags_high_res_on_individual_field() {
+    let m = HighResField {
+        timestamp: UNIX_EPOCH,
+        operation: "test".into(),
+        event_count: 42,
+        normal_count: 7,
+    };
+    let closed = CloseValue::close(m);
+    let entry = RootEntry::new(closed);
+
+    let mut emf = Emf::all_validations("Test".to_string(), vec![vec!["Operation".to_string()]]);
+    let mut output = vec![];
+    emf.format(&entry, &mut output).unwrap();
+    let json: Value = serde_json::from_slice(&output).unwrap();
+
+    let metrics = json["_aws"]["CloudWatchMetrics"][0]["Metrics"]
+        .as_array()
+        .unwrap();
+
+    let event_metric = metrics.iter().find(|m| m["Name"] == "EventCount").unwrap();
+    assert_eq!(event_metric["StorageResolution"], 1);
+
+    let normal_metric = metrics.iter().find(|m| m["Name"] == "NormalCount").unwrap();
+    assert!(
+        normal_metric.get("StorageResolution").is_none()
+            || normal_metric["StorageResolution"] == 60
+    );
+}
+
+// --- EMF: NoMetric flag ---
+
+#[metrics(
+    rename_all = "PascalCase",
+    emf::dimension_sets = [["Operation"]],
+)]
+struct NoMetricField {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+    operation: String,
+    #[metrics(flags(metrique::emf::flags::NoMetric))]
+    debug_value: u64,
+    normal_count: u64,
+}
+
+#[test]
+fn flags_no_metric_excludes_from_metrics_array() {
+    let m = NoMetricField {
+        timestamp: UNIX_EPOCH,
+        operation: "test".into(),
+        debug_value: 99,
+        normal_count: 5,
+    };
+    let closed = CloseValue::close(m);
+    let entry = RootEntry::new(closed);
+
+    let mut emf = Emf::all_validations("Test".to_string(), vec![vec!["Operation".to_string()]]);
+    let mut output = vec![];
+    emf.format(&entry, &mut output).unwrap();
+    let json: Value = serde_json::from_slice(&output).unwrap();
+
+    assert_eq!(json["DebugValue"], 99);
+    let metrics = json["_aws"]["CloudWatchMetrics"][0]["Metrics"]
+        .as_array()
+        .unwrap();
+    assert!(!metrics.iter().any(|m| m["Name"] == "DebugValue"));
+    assert!(metrics.iter().any(|m| m["Name"] == "NormalCount"));
+}
+
+// --- EMF: Multiple flags on one field ---
+
+#[metrics(
+    rename_all = "PascalCase",
+    emf::dimension_sets = [["Operation"]],
+)]
+struct MultiFlagField {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+    operation: String,
+    #[metrics(flags(
+        metrique::emf::flags::HighStorageResolution,
+        metrique::emf::flags::NoMetric
+    ))]
+    debug_value: u64,
+    normal_count: u64,
+}
+
+#[test]
+fn flags_multiple_on_single_field() {
+    let m = MultiFlagField {
+        timestamp: UNIX_EPOCH,
+        operation: "test".into(),
+        debug_value: 99,
+        normal_count: 5,
+    };
+    let closed = CloseValue::close(m);
+    let entry = RootEntry::new(closed);
+
+    let mut emf = Emf::all_validations("Test".to_string(), vec![vec!["Operation".to_string()]]);
+    let mut output = vec![];
+    emf.format(&entry, &mut output).unwrap();
+    let json: Value = serde_json::from_slice(&output).unwrap();
+
+    assert_eq!(json["DebugValue"], 99);
+    let metrics = json["_aws"]["CloudWatchMetrics"][0]["Metrics"]
+        .as_array()
+        .unwrap();
+    assert!(!metrics.iter().any(|m| m["Name"] == "DebugValue"));
+}
+
+// --- EMF: Enum variant with flags ---
+
+#[metrics(
+    rename_all = "PascalCase",
+    emf::dimension_sets = [["Op"]],
+)]
+enum EnumFlags {
+    Fast {
+        #[metrics(timestamp)]
+        ts: SystemTime,
+        op: String,
+        #[metrics(flags(metrique::emf::flags::HighStorageResolution))]
+        latency: u64,
+    },
+    Slow {
+        #[metrics(timestamp)]
+        ts: SystemTime,
+        op: String,
+        latency: u64,
+    },
+}
+
+#[test]
+fn flags_enum_variant() {
+    let fast = EnumFlags::Fast {
+        ts: UNIX_EPOCH,
+        op: "read".into(),
+        latency: 5,
+    };
+    let closed = CloseValue::close(fast);
+    let entry = RootEntry::new(closed);
+
+    let mut emf = Emf::all_validations("Test".to_string(), vec![vec!["Op".to_string()]]);
+    let mut output = vec![];
+    emf.format(&entry, &mut output).unwrap();
+    let json: Value = serde_json::from_slice(&output).unwrap();
+
+    let metrics = json["_aws"]["CloudWatchMetrics"][0]["Metrics"]
+        .as_array()
+        .unwrap();
+    let latency_metric = metrics.iter().find(|m| m["Name"] == "Latency").unwrap();
+    assert_eq!(latency_metric["StorageResolution"], 1);
+
+    // Slow variant: no flag on latency
+    let slow = EnumFlags::Slow {
+        ts: UNIX_EPOCH,
+        op: "write".into(),
+        latency: 100,
+    };
+    let closed = CloseValue::close(slow);
+    let entry = RootEntry::new(closed);
+
+    let mut output2 = vec![];
+    emf.format(&entry, &mut output2).unwrap();
+    let json2: Value = serde_json::from_slice(&output2).unwrap();
+
+    let metrics2 = json2["_aws"]["CloudWatchMetrics"][0]["Metrics"]
+        .as_array()
+        .unwrap();
+    let latency_metric2 = metrics2.iter().find(|m| m["Name"] == "Latency").unwrap();
+    assert!(
+        latency_metric2.get("StorageResolution").is_none()
+            || latency_metric2["StorageResolution"] == 60
+    );
+}
+
+// --- Generic FlagConstructor (not EMF-specific) ---
+
+#[derive(Debug)]
+struct CustomFlagOpt;
+impl metrique::writer::value::MetricOptions for CustomFlagOpt {}
+
+struct CustomFlagCtor;
+impl metrique::writer::value::FlagConstructor for CustomFlagCtor {
+    fn construct() -> metrique::writer::MetricFlags<'static> {
+        metrique::writer::MetricFlags::upcast(&CustomFlagOpt)
+    }
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct CustomFlagMetrics {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+    #[metrics(flags(CustomFlagCtor))]
+    flagged_value: u64,
+    normal_value: u64,
+}
+
+#[test]
+fn flags_generic_flag_constructor() {
+    let m = CustomFlagMetrics {
+        timestamp: UNIX_EPOCH,
+        flagged_value: 123,
+        normal_value: 456,
+    };
+    let closed = CloseValue::close(m);
+    let entry = RootEntry::new(closed);
+
+    // Unrecognized flags are ignored by EMF, but the write path still works
+    let mut emf = Emf::all_validations("Test".to_string(), vec![vec![]]);
+    let mut output = vec![];
+    emf.format(&entry, &mut output).unwrap();
+    let json: Value = serde_json::from_slice(&output).unwrap();
+
+    assert_eq!(json["FlaggedValue"], 123);
+    assert_eq!(json["NormalValue"], 456);
+}
+
+// --- ForceFlag<T, Ctor> type wrapper still works (backwards compat) ---
+
+#[metrics(
+    rename_all = "PascalCase",
+    emf::dimension_sets = [["Operation"]],
+)]
+struct DirectForceFlagUsage {
+    #[metrics(timestamp)]
+    timestamp: SystemTime,
+    operation: String,
+    high_res: ForceFlag<u64, metrique::emf::HighStorageResolutionCtor>,
+}
+
+#[test]
+fn force_flag_type_wrapper_still_works() {
+    let m = DirectForceFlagUsage {
+        timestamp: UNIX_EPOCH,
+        operation: "test".into(),
+        high_res: 42.into(),
+    };
+    let closed = CloseValue::close(m);
+    let entry = RootEntry::new(closed);
+
+    let mut emf = Emf::all_validations("Test".to_string(), vec![vec!["Operation".to_string()]]);
+    let mut output = vec![];
+    emf.format(&entry, &mut output).unwrap();
+    let json: Value = serde_json::from_slice(&output).unwrap();
+
+    let metrics = json["_aws"]["CloudWatchMetrics"][0]["Metrics"]
+        .as_array()
+        .unwrap();
+    let hr_metric = metrics.iter().find(|m| m["Name"] == "HighRes").unwrap();
+    assert_eq!(hr_metric["StorageResolution"], 1);
+}

--- a/metrique/tests/ui/fail/bad_flags.rs
+++ b/metrique/tests/ui/fail/bad_flags.rs
@@ -1,0 +1,44 @@
+use metrique::unit_of_work::metrics;
+
+struct FakeFlagCtor;
+impl metrique::writer::value::FlagConstructor for FakeFlagCtor {
+    fn construct() -> metrique::writer::MetricFlags<'static> {
+        todo!()
+    }
+}
+
+#[metrics]
+struct FlagsOnFlatten {
+    #[metrics(flatten, flags(FakeFlagCtor))]
+    inner: Inner,
+}
+
+#[metrics(subfield)]
+struct Inner {
+    x: u64,
+}
+
+#[metrics]
+struct FlagsOnFlattenEntry {
+    #[metrics(flatten_entry, flags(FakeFlagCtor))]
+    inner: FlatEntry,
+}
+
+#[derive(metrique::writer::Entry)]
+struct FlatEntry {
+    x: u64,
+}
+
+#[metrics]
+struct FlagsOnIgnore {
+    #[metrics(ignore, flags(FakeFlagCtor))]
+    ignored: u64,
+}
+
+#[metrics]
+struct FlagsOnTimestamp {
+    #[metrics(timestamp, flags(FakeFlagCtor))]
+    ts: std::time::SystemTime,
+}
+
+fn main() {}

--- a/metrique/tests/ui/fail/bad_flags.stderr
+++ b/metrique/tests/ui/fail/bad_flags.stderr
@@ -1,0 +1,23 @@
+error: flags(...) is not yet supported on flatten, flatten_entry, timestamp, or ignore fields.
+  --> tests/ui/fail/bad_flags.rs:12:15
+   |
+12 |     #[metrics(flatten, flags(FakeFlagCtor))]
+   |               ^^^^^^^
+
+error: flags(...) is not yet supported on flatten, flatten_entry, timestamp, or ignore fields.
+  --> tests/ui/fail/bad_flags.rs:23:15
+   |
+23 |     #[metrics(flatten_entry, flags(FakeFlagCtor))]
+   |               ^^^^^^^^^^^^^
+
+error: flags(...) is not yet supported on flatten, flatten_entry, timestamp, or ignore fields.
+  --> tests/ui/fail/bad_flags.rs:34:15
+   |
+34 |     #[metrics(ignore, flags(FakeFlagCtor))]
+   |               ^^^^^^
+
+error: flags(...) is not yet supported on flatten, flatten_entry, timestamp, or ignore fields.
+  --> tests/ui/fail/bad_flags.rs:40:15
+   |
+40 |     #[metrics(timestamp, flags(FakeFlagCtor))]
+   |               ^^^^^^^^^


### PR DESCRIPTION
📬 *Issue #, if available:*

Closes: #30 
Closes: #14

✍️ *Description of changes:*

Minimal subset of #289 to get tags working for OTel.

Adds `#[metrics(flags(...))]` field attribute support to the `#[metrics]` macro. This provides an alternative to wrapping field types in `ForceFlag<T, Ctor>`:

```rust
use metrique::emf::flags::{HighStorageResolution, NoMetric};

#[metrics(emf::dimension_sets = [["Op"]], rename_all = "PascalCase")]
struct Metrics {
    op: String,
    #[metrics(flags(HighStorageResolution))]
    latency: u64,
    #[metrics(flags(NoMetric))]
    debug_count: u64,
}
```

The macro wraps the field value in `ForceFlag` at write time during codegen. Multiple flags can be specified on a single field: `flags(A, B)`.

Also adds `emf::flags` module re-exports (`HighStorageResolution`, `NoMetric`) providing ergonomic names for the `FlagConstructor` types.

**Deferred to keep scope minimal:**
- Container-level `default_flags(...)` (apply a flag to all fields in a struct)
- `flags(...)` on `flatten`/`flatten_entry` fields (requires `InflectableEntry` impl for `ForceFlag`)
- `InflectableEntry` blanket impl for `ForceFlag` (needed for the above)

I think these probably belong in this API, but Otel doesn't need them, so will keep this PR small.

### Testing

Integration tests covering: HighStorageResolution on individual field, NoMetric exclusion from metrics array, multiple flags on a single field, enum variant flags, a user-defined generic `FlagConstructor`, and backwards-compat verification that `ForceFlag<T, Ctor>` type wrappers still work. All tests validate actual EMF JSON output. Compile-fail UI tests for flags on flatten, flatten_entry, timestamp, and ignore fields.


🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
