### PR TITLE
fix: inline rate_limit macro to simplify dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-otel"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "divan",
  "metrique",

--- a/metrique-otel/Cargo.toml
+++ b/metrique-otel/Cargo.toml
@@ -16,7 +16,6 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [dependencies]
 metrique-writer-core = { workspace = true }
-metrique-writer = { workspace = true, features = ["background-queue"] }
 metrique-aggregation = { workspace = true }
 metrique-core = { workspace = true }
 opentelemetry = "0.32"
@@ -37,6 +36,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 metrique = { workspace = true }
+metrique-writer = { workspace = true, features = ["background-queue"] }
 metrique-writer-format-emf = { workspace = true }
 opentelemetry_sdk = { version = "0.32", features = ["testing"] }
 tracing-subscriber = { workspace = true }

--- a/metrique-otel/src/flags.rs
+++ b/metrique-otel/src/flags.rs
@@ -32,7 +32,7 @@
 use std::any::Any;
 use std::time::Duration;
 
-use metrique_writer::rate_limit::rate_limited;
+use crate::rate_limit::rate_limited;
 use metrique_writer_core::value::{FlagConstructor, MetricFlags, MetricOptions};
 
 fn warn_conflict(kept: InstrumentKind, dropped: InstrumentKind) {

--- a/metrique-otel/src/lib.rs
+++ b/metrique-otel/src/lib.rs
@@ -110,12 +110,13 @@
 
 pub mod flags;
 mod metrics;
+pub(crate) mod rate_limit;
 mod translator;
 
 use std::sync::Arc;
 use std::time::Duration;
 
-use metrique_writer::rate_limit::rate_limited;
+use crate::rate_limit::rate_limited;
 use metrique_writer_core::sink::{AnyEntrySink, FlushWait};
 use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
 

--- a/metrique-otel/src/metrics.rs
+++ b/metrique-otel/src/metrics.rs
@@ -4,7 +4,7 @@
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
-use metrique_writer::rate_limit::rate_limited;
+use crate::rate_limit::rate_limited;
 use metrique_writer_core::{
     Observation, Unit,
     unit::{NegativeScale, PositiveScale},

--- a/metrique-otel/src/rate_limit.rs
+++ b/metrique-otel/src/rate_limit.rs
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-thread rate limiting for noisy log call sites.
+
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+#[doc(hidden)]
+pub fn time_since_arbitrary_epoch() -> Duration {
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    Instant::now().duration_since(*EPOCH.get_or_init(Instant::now))
+}
+
+macro_rules! rate_limited {
+    ($interval:expr, $call:expr) => {{
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT_CALL: AtomicU64 = AtomicU64::new(u64::MIN);
+        let interval: std::time::Duration = $interval;
+        assert!(
+            interval >= std::time::Duration::from_secs(1),
+            "only second-level granularity supported for rate limiting"
+        );
+
+        let time = $crate::rate_limit::time_since_arbitrary_epoch();
+        let next = NEXT_CALL.load(Ordering::Relaxed);
+        if next <= time.as_secs() {
+            let new_next = time
+                .checked_add(interval)
+                .unwrap_or(std::time::Duration::MAX)
+                .as_secs();
+            if NEXT_CALL
+                .compare_exchange(next, new_next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                $call;
+            }
+        }
+    }};
+}
+pub(crate) use rate_limited;


### PR DESCRIPTION
the rate_limit macro was preventing release metrique-otel, I just inlined it for now

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
