### PR TITLE
feat: add metrique-writer-cloudwatch crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -133,10 +133,326 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd362783681b15d136480ad555a099e82ecd8e2d10a841e14dfd0078d67fee3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c635c2dc792cb4a11ce1a4f392a925340d1bdf499289b5ec1ec6810954eb43f5"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-cloudwatchlogs"
+version = "1.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a000383f4c0260a6a76b1f2155f77e55a1dcc68a8e1ba51d7d992b308e43ab8"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa49f3c607b92daae0c078d48a4571f599f966dce3caee5f1ea55c4d9073f99"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52eec3db979d18cb807fc1070961cc51d87d069abe9ab57917769687368a8c6c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b9c7354a3b13c66f60fe4616d6d1969c9fd36b1b5333a5dfb3ee716b33c588"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630e67f2a31094ffa51b210ae030855cb8f3b7ee1329bdd8d085aaf61e8b97fc"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12fb0abf49ff0cab20fd31ac1215ed7ce0ea92286ba09e2854b42ba5cabe7525"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-protocol-test",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "h2 0.3.27",
+ "h2 0.4.14",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "indexmap",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb96aa208d62ee94104645f7b2ecaf77bf27edf161590b6224bfbac2832f979"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a46543fbc94621080b3cf553eb4cbbdc41dd9780a30c4756400f0139440a1d"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.63.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7090f3a3657e7c2c0331604d62baa20a9a9f765c3f4bf63ccf48ccba6b8b7240"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3df87c14f0127a0d77eb261c3bc45d5b4833e2a1f63583ebfb728e4852134ee"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49952c52f7eebb72ce2a754d3866cc0f87b97d2a46146b79f80f3a93fb2b3716"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3a26048eeab0ddeba4b4f9d51654c79af8c3b32357dc5f336cee85ab331c33"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d980627d2dd7bfc32a3c025685a033eeab8d365cc840c631ef59d1b8f428164"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bit-set"
@@ -160,6 +476,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,12 +531,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -198,6 +588,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -227,6 +644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,10 +671,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -282,6 +736,22 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -318,6 +788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +818,17 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -384,6 +871,12 @@ name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -471,6 +964,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -568,6 +1067,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +1107,25 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
@@ -596,12 +1135,23 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -622,12 +1172,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "histogram"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e05f6bebaf5e4ae9ffac23c348518ceda3775c3b5edabdd95c3c0abee0c040"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -642,12 +1218,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -658,8 +1245,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -668,6 +1255,36 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -679,9 +1296,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -691,12 +1308,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "hyper-util",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -713,14 +1361,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -867,6 +1515,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -941,6 +1591,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1242,6 +1902,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrique-writer-cloudwatch"
+version = "0.1.0"
+dependencies = [
+ "aws-sdk-cloudwatchlogs",
+ "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bon",
+ "http 1.4.0",
+ "metrique-writer",
+ "metrique-writer-core",
+ "metrique-writer-format-emf",
+ "tokio",
+ "tracing",
+ "tracing-test",
+]
+
+[[package]]
 name = "metrique-writer-core"
 version = "0.1.16"
 dependencies = [
@@ -1313,6 +1991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +2014,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1351,10 +2045,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1391,6 +2115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +2142,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.4.0",
  "opentelemetry",
  "reqwest",
 ]
@@ -1423,7 +2153,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http",
+ "http 1.4.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -1475,6 +2205,12 @@ checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "papaya"
@@ -1584,6 +2320,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -1712,7 +2458,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1794,10 +2540,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -1812,6 +2558,29 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -1866,6 +2635,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,10 +2716,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "seize"
@@ -1898,6 +2778,12 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
@@ -1935,6 +2821,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1949,6 +2836,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2002,6 +2900,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -2043,6 +2951,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2102,7 +3016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2218,6 +3132,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,7 +3158,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2256,6 +3185,26 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.40",
+ "tokio",
 ]
 
 [[package]]
@@ -2343,10 +3292,10 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -2410,8 +3359,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -2505,6 +3454,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,10 +3496,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2555,7 +3537,7 @@ version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2571,6 +3553,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "want"
@@ -2799,6 +3787,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -2984,6 +3981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,6 +4055,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "metrique-timesource",
     "metrique-util",
     "metrique-writer",
+    "metrique-writer-cloudwatch",
     "metrique-writer-core",
     "metrique-writer-format-emf",
     "metrique-writer-format-json",

--- a/metrique-writer-cloudwatch/Cargo.toml
+++ b/metrique-writer-cloudwatch/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "metrique-writer-cloudwatch"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.89"
+license = "Apache-2.0"
+description = "A metrique EntryIoStream backend that submits EMF metrics to CloudWatch Logs via PutLogEvents"
+readme = "README.md"
+repository = "https://github.com/awslabs/metrique"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+
+[dependencies]
+metrique-writer-core = { workspace = true }
+metrique-writer-format-emf = { workspace = true }
+aws-sdk-cloudwatchlogs = "1"
+aws-smithy-types = "1"
+tokio = { workspace = true, features = ["sync", "time", "rt"] }
+tracing = "0.1"
+bon = "3"
+
+[dev-dependencies]
+aws-smithy-http-client = { version = "1", features = ["test-util"] }
+aws-smithy-runtime-api = "1"
+http = "1"
+tokio = { workspace = true, features = ["full", "test-util"] }
+metrique-writer-core = { workspace = true, features = ["test-util"] }
+metrique-writer = { workspace = true }
+tracing-test = "0.2"

--- a/metrique-writer-cloudwatch/README.md
+++ b/metrique-writer-cloudwatch/README.md
@@ -1,0 +1,39 @@
+A `metrique` [EntryIoStream] backend that submits metrics directly to
+[Amazon CloudWatch Logs][cw-logs] via `PutLogEvents` using the
+[Embedded Metric Format (EMF)][emf-docs].
+
+This provides a direct path to CloudWatch Metrics without requiring the
+[CloudWatch Agent][cw-agent] or any log routing infrastructure.
+
+For more details, read the docs for [CwLogsStream].
+
+## Setup
+
+```rust,ignore
+use metrique_writer_cloudwatch::CwLogsStream;
+use metrique::ServiceMetrics;
+use metrique::writer::{AttachGlobalEntrySinkExt, GlobalEntrySink};
+
+let sdk_config = aws_config::load_from_env().await;
+let client = aws_sdk_cloudwatchlogs::Client::new(&sdk_config);
+
+let (stream, handle) = CwLogsStream::builder()
+    .client(client)
+    .log_group_name("/my-app/metrics".to_string())
+    .log_stream_name("host-1".to_string())
+    .namespace("MyApp".to_string())
+    .build();
+
+let _attach = ServiceMetrics::attach_to_stream(stream);
+
+// Metrics emitted via ServiceMetrics are now published to CloudWatch.
+
+// On shutdown:
+handle.shutdown().await;
+```
+
+[cw-logs]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html
+[cw-agent]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html
+[emf-docs]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+[EntryIoStream]: https://docs.rs/metrique-writer-core/latest/metrique_writer_core/stream/trait.EntryIoStream.html
+[CwLogsStream]: https://docs.rs/metrique-writer-cloudwatch/latest/metrique_writer_cloudwatch/struct.CwLogsStream.html

--- a/metrique-writer-cloudwatch/src/lib.rs
+++ b/metrique-writer-cloudwatch/src/lib.rs
@@ -1,0 +1,1075 @@
+//! CloudWatch Logs `PutLogEvents` (EMF) backend for metrique.
+//!
+//! This crate provides [`CwLogsStream`], an [`EntryIoStream`] implementation that serializes
+//! metric entries as EMF JSON and submits them directly to CloudWatch Logs via `PutLogEvents`.
+//!
+//! # Architecture
+//!
+//! ```text
+//! App threads → BackgroundQueue (metrique) → std thread calls CwLogsStream::next(&entry)
+//!   → EMF serialize (reuses metrique-writer-format-emf)
+//!   → batch until size/count limit hit: try_send(batch) over tokio mpsc
+//!   → single tokio task: recv batch → client.put_log_events (async HTTP)
+//! ```
+//!
+//! # Backpressure
+//!
+//! When the submission channel is full (CloudWatch Logs is slow or down), batches are
+//! dropped at submission time with a rate-limited warning. Drops are reported through
+//! [`CwLogsStreamEvent::BatchDropped`]. Once the channel drains, normal submission resumes.
+//!
+//! # Shutdown
+//!
+//! [`CwLogsStream::builder()`] returns `(CwLogsStream, CwLogsStreamHandle)`. Call
+//! [`CwLogsStreamHandle::shutdown()`] to await drain of in-flight batches.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! # async fn example() {
+//! use metrique_writer_cloudwatch::{CwLogsStream, CwLogsStreamConfig};
+//! use metrique_writer_core::EntryIoStream;
+//!
+//! let sdk_config = aws_config::load_from_env().await;
+//! let client = aws_sdk_cloudwatchlogs::Client::new(&sdk_config);
+//!
+//! let (stream, handle) = CwLogsStream::builder()
+//!     .client(client)
+//!     .log_group_name("/my-app/metrics".to_string())
+//!     .log_stream_name("host-1".to_string())
+//!     .namespace("MyApp".to_string())
+//!     .default_dimensions(vec![vec![]])
+//!     .build();
+//!
+//! // Pass `stream` to metrique's BackgroundQueue or ServiceMetrics::attach_to_stream()
+//! // ...
+//!
+//! // Graceful shutdown:
+//! handle.shutdown().await;
+//! # }
+//! ```
+
+use std::future::Future;
+use std::io;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use aws_sdk_cloudwatchlogs::Client as CloudWatchLogsClient;
+use aws_sdk_cloudwatchlogs::types::InputLogEvent;
+use bon::bon;
+use metrique_writer_core::format::Format;
+use metrique_writer_core::{Entry, EntryIoStream, IoStreamError};
+use metrique_writer_format_emf::Emf;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+/// Maximum payload size for a single PutLogEvents request (1 MB).
+const MAX_BATCH_BYTES: usize = 1_048_576;
+/// Maximum size of a single log event message (1 MB).
+const MAX_EVENT_BYTES: usize = 1_048_576;
+/// Overhead per log event (timestamp + framing).
+const EVENT_OVERHEAD_BYTES: usize = 26;
+/// Maximum number of log events per PutLogEvents request.
+const MAX_BATCH_EVENTS: usize = 10_000;
+
+/// Configuration for [`CwLogsStream`].
+#[derive(Debug, Clone, bon::Builder)]
+pub struct CwLogsStreamConfig {
+    /// Capacity of the tokio mpsc channel between the collection thread and the
+    /// submission task. Default: 5.
+    #[builder(default = NonZeroUsize::new(5).unwrap())]
+    pub channel_capacity: NonZeroUsize,
+
+    /// Whether to auto-create the log group and stream if they don't exist. Default: true.
+    #[builder(default = true)]
+    pub auto_create: bool,
+}
+
+impl Default for CwLogsStreamConfig {
+    fn default() -> Self {
+        Self {
+            channel_capacity: NonZeroUsize::new(5).unwrap(),
+            auto_create: true,
+        }
+    }
+}
+
+/// Events emitted by [`CwLogsStream`] for observability.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CwLogsStreamEvent {
+    /// A batch was dropped due to backpressure (submission channel full).
+    #[non_exhaustive]
+    BatchDropped {
+        /// Number of events in the dropped batch.
+        event_count: usize,
+    },
+    /// A PutLogEvents submission failed.
+    #[non_exhaustive]
+    SubmissionFailed,
+    /// An entry was dropped because the stream is shut down.
+    #[non_exhaustive]
+    EntryDroppedAfterShutdown,
+    /// The EMF formatter produced invalid UTF-8 (indicates a bug in the formatter).
+    #[non_exhaustive]
+    InvalidUtf8,
+    /// A single event exceeded the per-event size limit (1 MB) and was dropped.
+    #[non_exhaustive]
+    EventOversized,
+}
+
+/// Observer for [`CwLogsStreamEvent`]s. Implement this to collect internal metrics.
+pub trait CwLogsStreamObserver: Send + Sync + std::fmt::Debug + 'static {
+    /// Called when an event occurs.
+    fn observe(&self, event: &CwLogsStreamEvent);
+}
+
+/// Default no-op observer.
+#[derive(Debug, Default)]
+pub struct NoOpObserver;
+impl CwLogsStreamObserver for NoOpObserver {
+    fn observe(&self, _event: &CwLogsStreamEvent) {}
+}
+
+/// Type alias for a task spawner function.
+// TODO: Consider upstreaming to metrique-writer-core as a shared utility for async EntryIoStream backends.
+pub type TaskSpawnerFn =
+    Box<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) -> JoinHandle<()> + Send + Sync + 'static>;
+
+/// A wrapper around a task spawner function.
+///
+/// Use [`TaskSpawner::tokio()`] for the default tokio spawner, or provide a custom
+/// one (e.g. `dial9::spawn`) via [`TaskSpawner::new()`].
+pub struct TaskSpawner(TaskSpawnerFn);
+
+impl std::fmt::Debug for TaskSpawner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TaskSpawner").finish_non_exhaustive()
+    }
+}
+
+impl TaskSpawner {
+    /// Create a new TaskSpawner with a custom spawn function.
+    pub fn new<F>(f: F) -> Self
+    where
+        F: Fn(Pin<Box<dyn Future<Output = ()> + Send>>) -> JoinHandle<()> + Send + Sync + 'static,
+    {
+        Self(Box::new(f))
+    }
+
+    /// Spawn a task.
+    pub fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) -> JoinHandle<()> {
+        (self.0)(future)
+    }
+
+    /// Create a task spawner that uses `tokio::spawn`.
+    pub fn tokio() -> Self {
+        Self::new(|future| tokio::spawn(future))
+    }
+}
+
+/// An [`EntryIoStream`] that serializes entries as EMF JSON and submits them
+/// to CloudWatch Logs via `PutLogEvents` in a background tokio task.
+pub struct CwLogsStream {
+    emf: Emf,
+    log_group_name: String,
+    log_stream_name: String,
+    batch: Vec<InputLogEvent>,
+    batch_bytes: usize,
+    tx: Option<mpsc::Sender<WorkerCommand>>,
+    observer: Arc<dyn CwLogsStreamObserver>,
+    submit_task: Option<JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for CwLogsStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CwLogsStream")
+            .field("log_group_name", &self.log_group_name)
+            .field("log_stream_name", &self.log_stream_name)
+            .field("batch_len", &self.batch.len())
+            .field("batch_bytes", &self.batch_bytes)
+            .field("shutdown", &self.tx.is_none())
+            .finish()
+    }
+}
+
+enum WorkerCommand {
+    PutLogEvents(Vec<InputLogEvent>),
+    Shutdown(oneshot::Sender<()>),
+}
+
+/// Handle for async shutdown of [`CwLogsStream`].
+///
+/// Call [`shutdown()`](Self::shutdown) to wait until all in-flight PutLogEvents
+/// batches finish. If the stream has already been dropped, `shutdown()` returns
+/// immediately (the worker drains buffered payloads on its own when the channel
+/// closes).
+///
+// TODO: this stinks, ideally we can register our entry io stream as wanting to know about
+// async flushes, in BackgroundQueue's async flush impl. That way we don't have to vend
+// a separate channel.
+#[derive(Debug)]
+pub struct CwLogsStreamHandle(Option<oneshot::Sender<oneshot::Sender<()>>>);
+
+impl CwLogsStreamHandle {
+    /// Async flush of remaining PutLogEvents batches. The submit loop drains
+    /// remaining payloads, then signals completion.
+    ///
+    /// After this returns, the stream detects the closed channel on the
+    /// next `enqueue_batch` and becomes inert.
+    pub async fn shutdown(self) {
+        let Some(shutdown_tx) = self.0 else { return };
+        let (tx, rx) = oneshot::channel();
+        if shutdown_tx.send(tx).is_ok() {
+            if rx.await.is_err() {
+                tracing::warn!("CwLogsStream closed while waiting on shutdown response");
+            }
+        } else {
+            tracing::warn!("CwLogsStream already shut down when shutdown() was called");
+        }
+    }
+}
+
+#[bon]
+impl CwLogsStream {
+    /// Create a new [`CwLogsStream`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if using the default tokio spawner outside of a tokio runtime context.
+    /// Provide a custom [`TaskSpawner`] to avoid this.
+    #[builder]
+    pub fn new(
+        client: CloudWatchLogsClient,
+        log_group_name: String,
+        log_stream_name: String,
+        namespace: String,
+        #[builder(default = vec![vec![]])] default_dimensions: Vec<Vec<String>>,
+        #[builder(default)] config: CwLogsStreamConfig,
+        task_spawner: Option<TaskSpawner>,
+        observer: Option<Box<dyn CwLogsStreamObserver>>,
+    ) -> (Self, CwLogsStreamHandle) {
+        let (tx, rx) = mpsc::channel(config.channel_capacity.get());
+        let observer: Arc<dyn CwLogsStreamObserver> =
+            Arc::from(observer.unwrap_or_else(|| Box::new(NoOpObserver)));
+        let spawner = task_spawner.unwrap_or_else(TaskSpawner::tokio);
+
+        let submit_task = spawner.spawn(Box::pin(submit_loop(
+            rx,
+            client.clone(),
+            log_group_name.clone(),
+            log_stream_name.clone(),
+            config.auto_create,
+            observer.clone(),
+        )));
+
+        // Shutdown relay: when the handle sends a shutdown signal, forward it to the worker.
+        // TODO: this stinks, ideally we can register our entry io stream as wanting to know about
+        // async flushes, in BackgroundQueue's async flush impl. That way we don't have to vend
+        // a separate channel. We also want the worker to flush all in-flight batches during
+        // attach handle drop / explicit shutdown automatically.
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let weak_tx = tx.downgrade();
+        spawner.spawn(Box::pin(async move {
+            if let Ok(response_tx) = shutdown_rx.await {
+                if let Some(sender) = weak_tx.upgrade() {
+                    let _ = sender.send(WorkerCommand::Shutdown(response_tx)).await;
+                } else {
+                    let _ = response_tx.send(());
+                }
+            }
+        }));
+
+        let handle = CwLogsStreamHandle(Some(shutdown_tx));
+        let emf = Emf::builder(namespace, default_dimensions).build();
+
+        (
+            Self {
+                emf,
+                log_group_name,
+                log_stream_name,
+                batch: Vec::new(),
+                batch_bytes: 0,
+                tx: Some(tx),
+                observer,
+                submit_task: Some(submit_task),
+            },
+            handle,
+        )
+    }
+
+    fn enqueue_batch(&mut self) {
+        let Some(tx) = self.tx.as_ref() else { return };
+        let batch = std::mem::take(&mut self.batch);
+        let count = batch.len();
+        self.batch_bytes = 0;
+
+        match tx.try_send(WorkerCommand::PutLogEvents(batch)) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                // TODO: drop oldest batch instead of newest for consistency with BackgroundQueue.
+                self.observer
+                    .observe(&CwLogsStreamEvent::BatchDropped { event_count: count });
+                warn!("CloudWatch Logs submission channel full, dropping batch of {count} events");
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                // TODO: clean up shutdown signaling when upstreaming to metrique —
+                // ideally BackgroundQueue would notify the stream directly.
+                self.tx.take();
+            }
+        }
+    }
+
+    fn batch_would_exceed_limits(&self, event_bytes: usize) -> bool {
+        self.batch.len() >= MAX_BATCH_EVENTS
+            || self.batch_bytes + event_bytes + EVENT_OVERHEAD_BYTES > MAX_BATCH_BYTES
+    }
+}
+
+impl Drop for CwLogsStream {
+    fn drop(&mut self) {
+        if !self.batch.is_empty() {
+            self.enqueue_batch();
+        }
+        if self.submit_task.is_some() && self.tx.is_some() {
+            tracing::warn!(
+                "CwLogsStream dropped without calling shutdown() — \
+                 in-flight batches will drain in the background but \
+                 completion cannot be awaited"
+            );
+        }
+        self.tx.take();
+        self.submit_task.take();
+    }
+}
+
+impl EntryIoStream for CwLogsStream {
+    fn next(&mut self, entry: &impl Entry) -> Result<(), IoStreamError> {
+        if self.tx.is_none() {
+            warn!("CwLogsStream::next() called after shutdown, entry dropped");
+            self.observer
+                .observe(&CwLogsStreamEvent::EntryDroppedAfterShutdown);
+            return Ok(());
+        }
+
+        // Serialize the entry to EMF JSON. The formatter may produce multiple
+        // newline-separated JSON objects (one per dimension set).
+        let mut buf = Vec::with_capacity(1024);
+        self.emf.format(entry, &mut buf)?;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        let output = match String::from_utf8(buf) {
+            Ok(s) => s,
+            Err(_) => {
+                warn!("CwLogsStream: EMF formatter produced invalid UTF-8, dropping entry");
+                self.observer.observe(&CwLogsStreamEvent::InvalidUtf8);
+                return Ok(());
+            }
+        };
+
+        // Each line is a separate EMF JSON record → separate log event.
+        for line in output.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            let event_bytes = line.len();
+
+            // Skip events that exceed the per-event size limit (1 MB).
+            if event_bytes > MAX_EVENT_BYTES {
+                warn!(
+                    "CwLogsStream: skipping oversized event ({event_bytes} bytes, limit {MAX_EVENT_BYTES})"
+                );
+                self.observer.observe(&CwLogsStreamEvent::EventOversized);
+                continue;
+            }
+
+            if !self.batch.is_empty() && self.batch_would_exceed_limits(event_bytes) {
+                self.enqueue_batch();
+            }
+
+            if let Ok(event) = InputLogEvent::builder()
+                .message(line)
+                .timestamp(now)
+                .build()
+            {
+                self.batch_bytes += event_bytes + EVENT_OVERHEAD_BYTES;
+                self.batch.push(event);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if !self.batch.is_empty() {
+            self.enqueue_batch();
+        }
+        Ok(())
+    }
+}
+
+async fn submit_loop(
+    mut rx: mpsc::Receiver<WorkerCommand>,
+    client: CloudWatchLogsClient,
+    log_group_name: String,
+    log_stream_name: String,
+    auto_create: bool,
+    observer: Arc<dyn CwLogsStreamObserver>,
+) {
+    if auto_create {
+        create_log_resources(&client, &log_group_name, &log_stream_name).await;
+    }
+
+    while let Some(command) = rx.recv().await {
+        match command {
+            WorkerCommand::PutLogEvents(events) => {
+                submit_batch(
+                    &client,
+                    &log_group_name,
+                    &log_stream_name,
+                    events,
+                    &observer,
+                )
+                .await;
+            }
+            WorkerCommand::Shutdown(response_tx) => {
+                // Drain remaining batches.
+                rx.close();
+                while let Some(cmd) = rx.recv().await {
+                    if let WorkerCommand::PutLogEvents(events) = cmd {
+                        submit_batch(
+                            &client,
+                            &log_group_name,
+                            &log_stream_name,
+                            events,
+                            &observer,
+                        )
+                        .await;
+                    }
+                }
+                let _ = response_tx.send(());
+                break;
+            }
+        }
+    }
+}
+
+async fn submit_batch(
+    client: &CloudWatchLogsClient,
+    log_group_name: &str,
+    log_stream_name: &str,
+    events: Vec<InputLogEvent>,
+    observer: &Arc<dyn CwLogsStreamObserver>,
+) {
+    let result = client
+        .put_log_events()
+        .log_group_name(log_group_name)
+        .log_stream_name(log_stream_name)
+        .set_log_events(Some(events))
+        .send()
+        .await;
+
+    match result {
+        Err(e) => {
+            warn!("CloudWatch Logs PutLogEvents failed: {e}");
+            observer.observe(&CwLogsStreamEvent::SubmissionFailed);
+        }
+        Ok(output) => {
+            if let Some(rejected) = output.rejected_log_events_info() {
+                warn!("CloudWatch Logs rejected events: {rejected:?}");
+            }
+        }
+    }
+}
+
+// Best-effort creation — ignore "already exists" errors.
+async fn create_log_resources(
+    client: &CloudWatchLogsClient,
+    log_group_name: &str,
+    log_stream_name: &str,
+) {
+    match client
+        .create_log_group()
+        .log_group_name(log_group_name)
+        .send()
+        .await
+    {
+        Ok(_) => debug!("Created log group: {log_group_name}"),
+        Err(e) => {
+            let msg = format!("{e}");
+            if msg.contains("ResourceAlreadyExistsException") {
+                debug!("Log group already exists: {log_group_name}");
+            } else {
+                warn!("Failed to create log group {log_group_name}: {e}");
+            }
+        }
+    }
+
+    match client
+        .create_log_stream()
+        .log_group_name(log_group_name)
+        .log_stream_name(log_stream_name)
+        .send()
+        .await
+    {
+        Ok(_) => debug!("Created log stream: {log_stream_name}"),
+        Err(e) => {
+            let msg = format!("{e}");
+            if msg.contains("ResourceAlreadyExistsException") {
+                debug!("Log stream already exists: {log_stream_name}");
+            } else {
+                warn!("Failed to create log stream {log_stream_name}: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_cloudwatchlogs::config::{BehaviorVersion, Credentials, Region};
+    use aws_smithy_http_client::test_util::infallible_client_fn;
+    use aws_smithy_runtime_api::client::http::{
+        HttpClient, HttpConnector, HttpConnectorFuture, HttpConnectorSettings, SharedHttpConnector,
+    };
+    use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+    use aws_smithy_runtime_api::shared::IntoShared;
+    use aws_smithy_types::body::SdkBody;
+    use metrique_writer::sink::BackgroundQueueBuilder;
+    use metrique_writer_core::{AnyEntrySink, EntryWriter};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tracing_test::traced_test;
+
+    fn success_response() -> http::Response<SdkBody> {
+        http::Response::builder()
+            .status(200)
+            .body(SdkBody::from("{}"))
+            .unwrap()
+    }
+
+    fn error_response() -> http::Response<SdkBody> {
+        http::Response::builder()
+            .status(503)
+            .body(SdkBody::from("Service Unavailable"))
+            .unwrap()
+    }
+
+    fn test_client_success() -> CloudWatchLogsClient {
+        test_client(infallible_client_fn(|_req| success_response()))
+    }
+
+    fn test_client_failing() -> CloudWatchLogsClient {
+        test_client(infallible_client_fn(|_req| error_response()))
+    }
+
+    fn test_client(http_client: impl HttpClient + 'static) -> CloudWatchLogsClient {
+        let config = aws_sdk_cloudwatchlogs::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("us-east-1"))
+            .credentials_provider(Credentials::new("test", "test", None, None, "test"))
+            .http_client(http_client)
+            .build();
+        CloudWatchLogsClient::from_conf(config)
+    }
+
+    #[derive(Debug, Clone)]
+    struct DelayedConnector {
+        latency: Duration,
+        calls: Arc<AtomicU64>,
+        status: u16,
+    }
+
+    impl DelayedConnector {
+        fn new(latency: Duration, status: u16) -> (Self, Arc<AtomicU64>) {
+            let calls = Arc::new(AtomicU64::new(0));
+            (
+                Self {
+                    latency,
+                    calls: calls.clone(),
+                    status,
+                },
+                calls,
+            )
+        }
+    }
+
+    impl HttpConnector for DelayedConnector {
+        fn call(&self, _req: aws_smithy_runtime_api::http::Request) -> HttpConnectorFuture {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            let latency = self.latency;
+            let status = self.status;
+            HttpConnectorFuture::new(async move {
+                tokio::time::sleep(latency).await;
+                Ok(aws_smithy_runtime_api::http::Response::new(
+                    status.try_into().unwrap(),
+                    SdkBody::from("{}"),
+                ))
+            })
+        }
+    }
+
+    impl HttpClient for DelayedConnector {
+        fn http_connector(
+            &self,
+            _settings: &HttpConnectorSettings,
+            _components: &RuntimeComponents,
+        ) -> SharedHttpConnector {
+            self.clone().into_shared()
+        }
+    }
+
+    struct TestEntry(u64);
+
+    impl Entry for TestEntry {
+        fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+            writer.value("test_value", &self.0);
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestMetrics {
+        dropped: AtomicUsize,
+        failures: AtomicUsize,
+    }
+
+    impl TestMetrics {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                dropped: AtomicUsize::new(0),
+                failures: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    impl CwLogsStreamObserver for TestMetrics {
+        fn observe(&self, event: &CwLogsStreamEvent) {
+            match event {
+                CwLogsStreamEvent::BatchDropped { event_count } => {
+                    self.dropped.fetch_add(*event_count, Ordering::Relaxed);
+                }
+                CwLogsStreamEvent::SubmissionFailed => {
+                    self.failures.fetch_add(1, Ordering::Relaxed);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    impl CwLogsStreamObserver for Arc<TestMetrics> {
+        fn observe(&self, event: &CwLogsStreamEvent) {
+            (**self).observe(event);
+        }
+    }
+    fn default_config() -> CwLogsStreamConfig {
+        CwLogsStreamConfig {
+            channel_capacity: NonZeroUsize::new(4).unwrap(),
+            auto_create: false,
+        }
+    }
+
+    fn default_stream() -> (CwLogsStream, CwLogsStreamHandle) {
+        default_stream_with(test_client_success(), default_config(), None)
+    }
+
+    fn default_stream_with(
+        client: CloudWatchLogsClient,
+        config: CwLogsStreamConfig,
+        observer: Option<Box<dyn CwLogsStreamObserver>>,
+    ) -> (CwLogsStream, CwLogsStreamHandle) {
+        let builder = CwLogsStream::builder()
+            .client(client)
+            .log_group_name("g".to_string())
+            .log_stream_name("s".to_string())
+            .namespace("Ns".to_string())
+            .config(config);
+        match observer {
+            Some(reporter) => builder.observer(reporter).build(),
+            None => builder.build(),
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_triggers_send() {
+        let (mut stream, handle) = default_stream();
+
+        // Add one entry to measure its serialized size (use value 0 throughout
+        // so all entries are identical size).
+        stream.next(&TestEntry(0)).unwrap();
+        let entry_size = stream.batch_bytes;
+        let entries_per_batch = MAX_BATCH_BYTES / entry_size;
+
+        // Reset.
+        stream.flush().unwrap();
+
+        // Fill to the batch capacity (doesn't trigger yet due to integer rounding).
+        for _ in 0..entries_per_batch {
+            stream.next(&TestEntry(0)).unwrap();
+        }
+        assert_eq!(stream.batch.len(), entries_per_batch);
+
+        // One more entry crosses the byte limit, triggering auto-flush.
+        stream.next(&TestEntry(0)).unwrap();
+        assert_eq!(stream.batch.len(), 1);
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn flush_sends_partial_batch() {
+        let (mut stream, handle) = default_stream();
+
+        stream.next(&TestEntry(1)).unwrap();
+        assert!(!stream.batch.is_empty());
+
+        stream.flush().unwrap();
+        assert!(stream.batch.is_empty());
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn backpressure_drops_and_reports() {
+        let metrics = TestMetrics::new();
+
+        // Channel capacity 1, batch size 1 — easy to fill.
+        let (mut stream, handle) = default_stream_with(
+            test_client_success(),
+            CwLogsStreamConfig {
+                channel_capacity: NonZeroUsize::new(1).unwrap(),
+                auto_create: false,
+            },
+            Some(Box::new(metrics.clone()) as Box<dyn CwLogsStreamObserver>),
+        );
+
+        // On current_thread runtime, the submit loop can't drain the channel
+        // until we yield. So the channel fills after the first flush and
+        // subsequent flushes are dropped.
+        for i in 0..50 {
+            stream.next(&TestEntry(i)).unwrap();
+            // Flushing after each entry simulates a batch size of 1 for test simplicity.
+            stream.flush().unwrap();
+        }
+
+        handle.shutdown().await;
+
+        // First flush fills the channel, remaining 49 are dropped.
+        assert_eq!(metrics.dropped.load(Ordering::Relaxed), 49);
+    }
+
+    #[tokio::test]
+    async fn empty_flush_is_noop() {
+        let (mut stream, handle) = default_stream();
+
+        stream.flush().unwrap();
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn drop_without_shutdown() {
+        // Dropping the stream without calling handle.shutdown() should not panic.
+        let (mut stream, _handle) = default_stream();
+
+        stream.next(&TestEntry(1)).unwrap();
+        drop(stream);
+        // handle is also dropped without shutdown — no panic.
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn drop_without_shutdown_warns_with_pending_entries() {
+        let (mut stream, _handle) = default_stream();
+
+        stream.next(&TestEntry(1)).unwrap();
+        assert!(stream.submit_task.is_some());
+        drop(stream);
+
+        assert!(logs_contain(
+            "CwLogsStream dropped without calling shutdown()"
+        ));
+    }
+
+    #[tokio::test]
+    async fn drop_handle_without_shutdown() {
+        // Dropping the handle without calling shutdown is fine — stream keeps working
+        // until it is dropped.
+        let (mut stream, handle) = default_stream();
+
+        drop(handle);
+
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+        // stream dropped without graceful shutdown — Drop aborts task.
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_pending_batches() {
+        let (connector, calls) = DelayedConnector::new(Duration::from_millis(50), 200);
+        let client = test_client(connector);
+        let (mut stream, handle) = default_stream_with(client, default_config(), None);
+
+        // Enqueue 3 batches.
+        for batch in 0..3 {
+            stream.next(&TestEntry(batch)).unwrap();
+            stream.flush().unwrap();
+        }
+
+        // Shutdown waits for all 3 to be submitted.
+        handle.shutdown().await;
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn submit_loop_reports_failure() {
+        let metrics = TestMetrics::new();
+
+        let (mut stream, handle) = default_stream_with(
+            test_client_failing(),
+            default_config(),
+            Some(Box::new(metrics.clone()) as Box<dyn CwLogsStreamObserver>),
+        );
+
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+        handle.shutdown().await;
+
+        assert_eq!(metrics.failures.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn next_after_channel_close_is_noop() {
+        let (mut stream, handle) = default_stream_with(
+            test_client_success(),
+            CwLogsStreamConfig {
+                channel_capacity: NonZeroUsize::new(1).unwrap(),
+                auto_create: false,
+            },
+            None,
+        );
+
+        // Shutdown closes the channel from the worker side.
+        handle.shutdown().await;
+
+        // Next entry after shutdown should be a no-op (channel closed detected on flush).
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+
+        // Subsequent entries take the early-return path (tx is None).
+        stream.next(&TestEntry(2)).unwrap();
+        assert!(stream.tx.is_none());
+        assert!(logs_contain("called after shutdown, entry dropped"));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn shutdown_after_drop_still_drains() {
+        let (connector, calls) = DelayedConnector::new(Duration::from_millis(100), 200);
+        let (mut stream, handle) =
+            default_stream_with(test_client(connector), default_config(), None);
+
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+        stream.next(&TestEntry(2)).unwrap();
+        stream.flush().unwrap();
+
+        // Yield so the submit loop picks up the first batch (now in-flight for 100ms).
+        tokio::task::yield_now().await;
+
+        // Drop the stream while the first batch is still in-flight and the
+        // second is queued. This simulates BackgroundQueue dropping the stream.
+        assert!(calls.load(Ordering::Relaxed) <= 1);
+        drop(stream);
+
+        // Shutdown returns immediately (WeakSender can't upgrade after stream
+        // drop), but the worker still drains buffered payloads.
+        handle.shutdown().await;
+
+        // Wait for worker to finish.
+        for _ in 0..50 {
+            if calls.load(Ordering::Relaxed) == 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(calls.load(Ordering::Relaxed) == 2);
+
+        assert!(logs_contain(
+            "CwLogsStream dropped without calling shutdown()"
+        ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_entries_enqueued_during_drain() {
+        let metrics = TestMetrics::new();
+        // Slow connector: each batch takes 50ms, giving us a window to try
+        // sending more entries after shutdown begins.
+        let (connector, calls) = DelayedConnector::new(Duration::from_millis(50), 200);
+        let (mut stream, handle) = default_stream_with(
+            test_client(connector),
+            default_config(),
+            Some(Box::new(metrics.clone()) as Box<dyn CwLogsStreamObserver>),
+        );
+
+        // Enqueue a batch before shutdown.
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+
+        // Shutdown closes the receiver — drain processes queued batches but
+        // rejects anything new.
+        handle.shutdown().await;
+
+        // After shutdown, the channel is closed. Enqueuing should be a no-op.
+        stream.next(&TestEntry(2)).unwrap();
+        stream.flush().unwrap();
+
+        // Only the pre-shutdown batch was submitted.
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        // Post-shutdown entries are silently discarded, not counted as backpressure drops.
+        assert_eq!(metrics.dropped.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_entries_queued_while_batch_in_flight() {
+        // Slow connector: first batch takes 50ms. While it's in-flight,
+        // we enqueue a second batch, then trigger shutdown. Both should drain.
+        let (connector, calls) = DelayedConnector::new(Duration::from_millis(50), 200);
+        let (mut stream, handle) =
+            default_stream_with(test_client(connector), default_config(), None);
+
+        // First batch — starts a 50ms in-flight submission.
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+        // Yield so the submit loop picks up the first batch.
+        tokio::task::yield_now().await;
+
+        // Second batch — queued while first is in-flight.
+        stream.next(&TestEntry(2)).unwrap();
+        stream.flush().unwrap();
+
+        // Shutdown should drain both: the in-flight one finishes, then the
+        // queued one is processed during the drain loop.
+        handle.shutdown().await;
+
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn shutdown_drain_reports_submission_failures() {
+        let metrics = TestMetrics::new();
+        let (connector, _calls) = DelayedConnector::new(Duration::from_millis(10), 503);
+        let client = test_client(connector);
+        let (mut stream, handle) = default_stream_with(
+            client,
+            default_config(),
+            Some(Box::new(metrics.clone()) as Box<dyn CwLogsStreamObserver>),
+        );
+
+        // Enqueue 2 batches, then shutdown — both fail during drain.
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+        stream.next(&TestEntry(2)).unwrap();
+        stream.flush().unwrap();
+        handle.shutdown().await;
+
+        assert_eq!(metrics.failures.load(Ordering::Relaxed), 2);
+        assert!(logs_contain("CloudWatch Logs PutLogEvents failed"));
+    }
+
+    #[tokio::test]
+    async fn auto_create_log_resources() {
+        let (connector, calls) = DelayedConnector::new(Duration::from_millis(1), 200);
+        let client = test_client(connector);
+        let (mut stream, handle) = default_stream_with(
+            client,
+            CwLogsStreamConfig {
+                channel_capacity: NonZeroUsize::new(4).unwrap(),
+                auto_create: true,
+            },
+            None,
+        );
+
+        // Give the submit loop time to run CreateLogGroup + CreateLogStream.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // At least 2 calls for create_log_group + create_log_stream.
+        assert!(calls.load(Ordering::Relaxed) >= 2);
+
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+        handle.shutdown().await;
+
+        // 2 create calls + 1 PutLogEvents.
+        assert!(calls.load(Ordering::Relaxed) == 3);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn rejected_log_events_are_logged() {
+        let config = aws_sdk_cloudwatchlogs::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("us-east-1"))
+            .credentials_provider(Credentials::new("test", "test", None, None, "test"))
+            .http_client(infallible_client_fn(|_req| {
+                let body = r#"{"rejectedLogEventsInfo":{"tooOldLogEventEndIndex":2}}"#;
+                http::Response::builder()
+                    .status(200)
+                    .body(SdkBody::from(body))
+                    .unwrap()
+            }))
+            .build();
+        let client = CloudWatchLogsClient::from_conf(config);
+
+        let (mut stream, handle) = default_stream_with(client, default_config(), None);
+
+        stream.next(&TestEntry(1)).unwrap();
+        stream.flush().unwrap();
+        handle.shutdown().await;
+
+        assert!(logs_contain("CloudWatch Logs rejected events"));
+    }
+
+    #[tokio::test]
+    async fn background_queue_drains_after_handle_drop() {
+        // 50ms per batch — batches are provably still in-flight when BQ handle drops.
+        let (connector, calls) = DelayedConnector::new(Duration::from_millis(50), 200);
+
+        let (stream, _cw_handle) =
+            default_stream_with(test_client(connector), default_config(), None);
+
+        let (queue, bg_handle) = BackgroundQueueBuilder::new().build_boxed(stream);
+
+        // Emit entries via BackgroundQueue → CwLogsStream → submit task.
+        for i in 0..4u64 {
+            queue.append_any(TestEntry(i));
+        }
+
+        // Drop queue + BG handle — flushes BQ, drops the stream.
+        // CW submit task keeps running in the background.
+        drop(queue);
+        drop(bg_handle);
+
+        // Not all batches have completed yet — work is still in-flight.
+        // Not a race: on current_thread runtime, the submit task can't poll
+        // until we yield. Payloads are in the channel but unprocessed.
+        assert!(calls.load(Ordering::Relaxed) == 0);
+
+        // Wait for the worker to finish draining.
+        // sleep().await yields to the executor so the submit task can progress.
+        for _ in 0..50 {
+            if calls.load(Ordering::Relaxed) >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(calls.load(Ordering::Relaxed) == 1);
+    }
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,6 +12,7 @@ changelog_include = [
     "metrique-timesource",
     "metrique-util",
     "metrique-writer",
+    "metrique-writer-cloudwatch",
     "metrique-writer-core",
     "metrique-writer-format-emf",
     "metrique-writer-format-json",


### PR DESCRIPTION
📬 *Issue #, if available:* #226

✍️ *Description of changes:* CloudWatch Logs PutLogEvents (EMF) EntryIoStream backend for metrique.

Implements EntryIoStream using a channel-based async architecture: sync next() → EMF serialize → batch → try_send over bounded mpsc → spawned tokio task calls PutLogEvents asynchronously.

Features:
- Respects CW Logs limits (1MB payload, 10k events per request)
- Backpressure: drops batch when channel full, reports via CwLogsSelfMetrics
- Graceful shutdown via CwLogsStreamHandle::shutdown().await
- Auto-creates log group/stream on startup (configurable)
- Logs rejected events from PutLogEvents response
- Builder API via bon

🔏 *By submitting this pull request*

- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
