### PR TITLE
fix(cloudwatch): use proper SdkError pattern matching for ResourceAlreadyExistsException

### DIFF
--- a/metrique-writer-cloudwatch/src/lib.rs
+++ b/metrique-writer-cloudwatch/src/lib.rs
@@ -69,6 +69,9 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use aws_sdk_cloudwatchlogs::Client as CloudWatchLogsClient;
+use aws_sdk_cloudwatchlogs::error::SdkError;
+use aws_sdk_cloudwatchlogs::operation::create_log_group::CreateLogGroupError;
+use aws_sdk_cloudwatchlogs::operation::create_log_stream::CreateLogStreamError;
 use aws_sdk_cloudwatchlogs::types::InputLogEvent;
 use bon::bon;
 use metrique_writer_core::format::Format;
@@ -515,13 +518,16 @@ async fn create_log_resources(
         .await
     {
         Ok(_) => debug!("Created log group: {log_group_name}"),
+        Err(SdkError::ServiceError(ref e))
+            if matches!(
+                e.err(),
+                CreateLogGroupError::ResourceAlreadyExistsException(_)
+            ) =>
+        {
+            debug!("Log group already exists: {log_group_name}");
+        }
         Err(e) => {
-            let msg = format!("{e}");
-            if msg.contains("ResourceAlreadyExistsException") {
-                debug!("Log group already exists: {log_group_name}");
-            } else {
-                warn!("Failed to create log group {log_group_name}: {e}");
-            }
+            warn!("Failed to create log group {log_group_name}: {e}");
         }
     }
 
@@ -533,13 +539,16 @@ async fn create_log_resources(
         .await
     {
         Ok(_) => debug!("Created log stream: {log_stream_name}"),
+        Err(SdkError::ServiceError(ref e))
+            if matches!(
+                e.err(),
+                CreateLogStreamError::ResourceAlreadyExistsException(_)
+            ) =>
+        {
+            debug!("Log stream already exists: {log_stream_name}");
+        }
         Err(e) => {
-            let msg = format!("{e}");
-            if msg.contains("ResourceAlreadyExistsException") {
-                debug!("Log stream already exists: {log_stream_name}");
-            } else {
-                warn!("Failed to create log stream {log_stream_name}: {e}");
-            }
+            warn!("Failed to create log stream {log_stream_name}: {e}");
         }
     }
 }


### PR DESCRIPTION
📬 *Issue #, if available:* Follow-up to #302

✍️ *Description of changes:*
The string-based check msg.contains("ResourceAlreadyExistsException") didn't match the actual SDK error format, causing spurious WARN logs on every startup when the log group/stream already exists.

Use SdkError::ServiceError pattern matching with the typed CreateLogGroupError::ResourceAlreadyExistsException / CreateLogStreamError::ResourceAlreadyExistsException variants instead. This correctly suppresses the expected "already exists" case to debug! level while still logging unexpected errors (e.g. AccessDenied) at warn!.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
