### PR TITLE
feat(value): support `Arc<str>` in metric structs

### DIFF
--- a/metrique-core/src/close_value_impls.rs
+++ b/metrique-core/src/close_value_impls.rs
@@ -92,6 +92,23 @@ impl CloseValue for Arc<String> {
 }
 
 #[diagnostic::do_not_recommend]
+impl CloseValue for &Arc<str> {
+    type Closed = Arc<str>;
+
+    fn close(self) -> Self::Closed {
+        self.clone()
+    }
+}
+
+impl CloseValue for Arc<str> {
+    type Closed = Arc<str>;
+
+    fn close(self) -> Self::Closed {
+        self
+    }
+}
+
+#[diagnostic::do_not_recommend]
 impl<'a, T: ToOwned + ?Sized> CloseValue for Cow<'a, T> {
     type Closed = Cow<'a, T>;
 
@@ -336,6 +353,18 @@ mod tests {
     fn close_arc() {
         let x = Arc::new(Closeable);
         assert_eq!(x.close(), 42);
+    }
+
+    #[test]
+    fn close_arc_str() {
+        let x: Arc<str> = Arc::from("hello");
+        assert_eq!(x.close(), Arc::from("hello"));
+    }
+
+    #[test]
+    fn close_arc_str_ref() {
+        let x: Arc<str> = Arc::from("hello");
+        assert_eq!((&x).close(), Arc::from("hello"));
     }
 
     #[test]

--- a/metrique-core/src/lib.rs
+++ b/metrique-core/src/lib.rs
@@ -100,7 +100,17 @@ pub use namestyle::{DynamicNameStyle, Identity, KebabCase, NameStyle, PascalCase
 ///         child: ChildMetrics,
 ///     }
 ///     ```
-/// 3. If you are fine with allocating, you could make your own string wrapper type.
+/// 3. Use `Arc<str>` instead of `String`.
+///     ```rust
+///     # use std::sync::Arc;
+///     # use metrique::unit_of_work::metrics;
+///     #[metrics(subfield)]
+///     struct ChildMetrics {
+///         field: Arc<str>,
+///     }
+///     ```
+/// 4. If you are fine with allocating, you could make your own string
+///    wrapper type.
 ///     ```rust
 ///     # use metrique::unit_of_work::metrics;
 ///     struct StringValue(String);

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -240,7 +240,7 @@ impl<T: Value> Value for Box<T> {
     }
 }
 
-impl<T: Value> Value for Arc<T> {
+impl<T: Value + ?Sized> Value for Arc<T> {
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)
     }
@@ -264,7 +264,7 @@ impl<T: MetricValue> MetricValue for Box<T> {
     type Unit = T::Unit;
 }
 
-impl<T: MetricValue> MetricValue for Arc<T> {
+impl<T: MetricValue + ?Sized> MetricValue for Arc<T> {
     type Unit = T::Unit;
 }
 

--- a/metrique/tests/kitchen-sink.rs
+++ b/metrique/tests/kitchen-sink.rs
@@ -46,6 +46,7 @@ struct Nested {
     c: Option<bool>,
 
     d: Arc<bool>,
+    d2: Option<Arc<str>>,
     e: Cow<'static, str>,
 
     #[metrics(format=ToString)]
@@ -190,6 +191,7 @@ fn flatten_flush_as_expected() {
     metric.entry.foo = 1;
     metric.optional_closed = Some(Nested {
         b: true,
+        d2: Some(Arc::from("arc_str_value")),
         sub: TestFlag::from(WithDimensions::new(MySubfield::default(), "Foo", "Bar")),
         nested_with_prefix: Prefix1 {
             inner: Prefix2 {
@@ -216,6 +218,7 @@ fn flatten_flush_as_expected() {
     );
     assert_eq!(entry.metrics["F"].test_flag, true);
     assert_eq!(entry.values["G"], "false");
+    assert_eq!(entry.values["D2"], "arc_str_value");
 
     assert_eq!(entry.metrics["NestedMetric"], 2);
     assert_eq!(entry.metrics["NestedValValue"], 3);


### PR DESCRIPTION
📬 *Issue #, if available:*

None that I'm aware of.

✍️ *Description of changes:*

Adds support for using `Arc<str>` in metric structs. `Arc<str>` is useful as a lightweight, cheaply-cloneable string dimension value that avoids the double indirection of `Arc<String>`.

Previously, `Arc<String>` worked but `Arc<str>` did not. The generic `Arc<T>` impls for `Value`, `MetricValue`, and `ObjectValue` all required `T: Sized`, and the generic `CloseValue` for `Arc<T>` where `T: CloseValueRef` path can't cover `str` due to HRTB lifetime constraints.

Changes:

  - Relaxed `T: Sized` bounds to `T: ?Sized` on `Value` for `Arc<T>` and `MetricValue` for `Arc<T>` in `metrique-writer-core`
  - Added explicit `CloseValue` impls for `Arc<str>` and `&Arc<str>` (mirroring the existing `Arc<String>` impls)
  - Added `Arc<str>` as a recommended option in the `CloseValue` trait documentation for the subfield string-field problem
  - Added unit tests and an integration test exercising `Option<Arc<str>>` through the full derive-macro → write path



🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
