### PR TITLE
Add SCREAMING_SNAKE_CASE support to metrique-macro NameStyle

### DIFF
--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -38,7 +38,9 @@ pub(crate) fn mixed_site_self() -> Ident {
 fn make_ns(ns: NameStyle, span: proc_macro2::Span) -> Ts2 {
     match ns {
         NameStyle::PascalCase => quote_spanned! {span=> NS::PascalCase },
-        NameStyle::SnakeCase => quote_spanned! {span=> NS::SnakeCase },
+        NameStyle::SnakeCase | NameStyle::ScreamingSnakeCase => {
+            quote_spanned! {span=> NS::SnakeCase }
+        }
         NameStyle::KebabCase => quote_spanned! {span=> NS::KebabCase },
         NameStyle::Preserve => quote_spanned! {span=> NS },
     }

--- a/metrique-macro/src/inflect.rs
+++ b/metrique-macro/src/inflect.rs
@@ -24,6 +24,8 @@ pub(crate) enum NameStyle {
     PascalCase,
     #[darling(rename = "snake_case")]
     SnakeCase,
+    #[darling(rename = "SCREAMING_SNAKE_CASE")]
+    ScreamingSnakeCase,
     #[darling(rename = "kebab-case")]
     KebabCase,
     #[default]
@@ -36,6 +38,7 @@ impl NameStyle {
         match self {
             NameStyle::PascalCase => name.to_pascal_case(),
             NameStyle::SnakeCase => name.to_snake_case(),
+            NameStyle::ScreamingSnakeCase => name.to_screaming_snake_case(),
             NameStyle::Preserve => name.to_string(),
             NameStyle::KebabCase => name.to_kebab_case(),
         }
@@ -47,6 +50,13 @@ impl NameStyle {
             NameStyle::PascalCase => name.to_pascal_case(),
             NameStyle::SnakeCase => {
                 let mut res = name.to_snake_case();
+                if !res.ends_with("_") {
+                    res.push('_');
+                }
+                res
+            }
+            NameStyle::ScreamingSnakeCase => {
+                let mut res = name.to_screaming_snake_case();
                 if !res.ends_with("_") {
                     res.push('_');
                 }
@@ -67,6 +77,7 @@ impl NameStyle {
         match self {
             NameStyle::PascalCase => "Pascal",
             NameStyle::SnakeCase => "Snake",
+            NameStyle::ScreamingSnakeCase => "ScreamingSnake",
             NameStyle::Preserve => "Preserve",
             NameStyle::KebabCase => "Kebab",
         }

--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -2033,4 +2033,22 @@ mod tests {
         let parsed_file = metrics_impl_string(input, quote!(metrics(value(string))));
         assert_snapshot!("debug_derive_passthrough_enum", parsed_file);
     }
+
+    #[test]
+    fn test_value_enum_screaming_snake_case() {
+        let input = quote! {
+            enum Operation {
+                ReadData,
+                WriteData,
+                #[metrics(name = "CUSTOM_NAME")]
+                Delete,
+            }
+        };
+
+        let parsed_file = metrics_impl_string(
+            input,
+            quote!(metrics(value(string), rename_all = "SCREAMING_SNAKE_CASE")),
+        );
+        assert_snapshot!("value_enum_screaming_snake_case", parsed_file);
+    }
 }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__value_enum_screaming_snake_case.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__value_enum_screaming_snake_case.snap
@@ -1,0 +1,95 @@
+---
+source: metrique-macro/src/lib.rs
+expression: parsed_file
+---
+enum Operation {
+    ReadData,
+    WriteData,
+    Delete,
+}
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub enum OperationValue {
+    #[deprecated(
+        note = "these fields will become private in a future release. To introspect an entry, use `metrique::writer::test_util::test_entry`"
+    )]
+    #[doc(hidden)]
+    ReadData,
+    #[deprecated(
+        note = "these fields will become private in a future release. To introspect an entry, use `metrique::writer::test_util::test_entry`"
+    )]
+    #[doc(hidden)]
+    WriteData,
+    #[deprecated(
+        note = "these fields will become private in a future release. To introspect an entry, use `metrique::writer::test_util::test_entry`"
+    )]
+    #[doc(hidden)]
+    Delete,
+}
+impl ::std::convert::From<&'_ OperationValue> for &'static str {
+    fn from(value: &OperationValue) -> Self {
+        #[allow(deprecated)]
+        match value {
+            OperationValue::ReadData => "READ_DATA",
+            OperationValue::WriteData => "WRITE_DATA",
+            OperationValue::Delete => "CUSTOM_NAME",
+        }
+    }
+}
+impl ::std::convert::From<OperationValue> for &'static str {
+    fn from(value: OperationValue) -> Self {
+        <&str as ::std::convert::From<&_>>::from(&value)
+    }
+}
+impl ::metrique::writer::core::SampleGroup for OperationValue {
+    fn as_sample_group(&self) -> ::std::borrow::Cow<'static, str> {
+        ::std::borrow::Cow::Borrowed(::std::convert::Into::<&str>::into(self))
+    }
+}
+impl ::metrique::writer::Value for OperationValue {
+    fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
+        writer.string(::std::convert::Into::<&str>::into(self));
+    }
+}
+impl metrique::CloseValue for &'_ Operation {
+    type Closed = OperationValue;
+    fn close(self) -> Self::Closed {
+        macro_rules! __metrique_self_expr {
+            () => {
+                self
+            };
+        }
+        #[allow(deprecated)]
+        match __metrique_self_expr!() {
+            Operation::ReadData => OperationValue::ReadData,
+            Operation::WriteData => OperationValue::WriteData,
+            Operation::Delete => OperationValue::Delete,
+        }
+    }
+}
+impl metrique::CloseValue for Operation {
+    type Closed = OperationValue;
+    fn close(self) -> Self::Closed {
+        <&Self>::close(&self)
+    }
+}
+impl ::std::convert::From<&'_ Operation> for &'static str {
+    fn from(value: &Operation) -> Self {
+        #[allow(deprecated)]
+        match value {
+            Operation::ReadData => "READ_DATA",
+            Operation::WriteData => "WRITE_DATA",
+            Operation::Delete => "CUSTOM_NAME",
+        }
+    }
+}
+impl ::std::convert::From<Operation> for &'static str {
+    fn from(value: Operation) -> Self {
+        <&str as ::std::convert::From<&_>>::from(&value)
+    }
+}
+impl ::metrique::writer::core::SampleGroup for Operation {
+    fn as_sample_group(&self) -> ::std::borrow::Cow<'static, str> {
+        ::std::borrow::Cow::Borrowed(::std::convert::Into::<&str>::into(self))
+    }
+}

--- a/metrique/tests/value_enum_screaming_snake_case.rs
+++ b/metrique/tests/value_enum_screaming_snake_case.rs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests that `rename_all = "SCREAMING_SNAKE_CASE"` works on value(string) enums
+//! and that the enum can be used as a field inside a metrics struct.
+
+use metrique::writer::test_util;
+use metrique::{CloseValue, RootEntry, unit_of_work::metrics};
+
+#[metrics(value(string), rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Debug, Clone, Copy)]
+pub enum Operation {
+    ReadData,
+    WriteData,
+    #[metrics(name = "CUSTOM_OP")]
+    CustomOperation,
+}
+
+#[metrics]
+struct RequestMetrics {
+    operation: Operation,
+    latency: u64,
+}
+
+#[test]
+fn value_enum_screaming_snake_case_renames_correctly() {
+    // Multi-word variants get SCREAMING_SNAKE_CASE
+    assert_eq!(<&str>::from(&Operation::ReadData), "READ_DATA");
+    assert_eq!(<&str>::from(&Operation::WriteData), "WRITE_DATA");
+    // Explicit name override takes precedence
+    assert_eq!(<&str>::from(&Operation::CustomOperation), "CUSTOM_OP");
+}
+
+#[test]
+fn value_enum_screaming_snake_case_works_in_struct() {
+    let metrics = RequestMetrics {
+        operation: Operation::ReadData,
+        latency: 42,
+    };
+    let entry = test_util::to_test_entry(RootEntry::new(metrics.close()));
+
+    assert_eq!(entry.values["operation"], "READ_DATA");
+    assert_eq!(entry.metrics["latency"], 42);
+}
+
+#[test]
+fn value_enum_screaming_snake_case_with_override_in_struct() {
+    let metrics = RequestMetrics {
+        operation: Operation::CustomOperation,
+        latency: 100,
+    };
+    let entry = test_util::to_test_entry(RootEntry::new(metrics.close()));
+
+    assert_eq!(entry.values["operation"], "CUSTOM_OP");
+    assert_eq!(entry.metrics["latency"], 100);
+}


### PR DESCRIPTION
## Summary

Fixes #328

The `metrique-writer-macro` crate supports `SCREAMING_SNAKE_CASE` in its `NameStyle` enum, but `metrique-macro` did not. This caused `#[metrics(value(string), rename_all = "SCREAMING_SNAKE_CASE")]` to silently fail — darling couldn't parse the attribute, so the macro recovered with a default `RootEntry` mode instead of `ValueString`, generating an `*Entry` type (missing `impl Value`) instead of the correct `*Value` type.

## Changes

- Add `ScreamingSnakeCase` variant to `metrique-macro/src/inflect.rs` `NameStyle` enum with `apply()`, `apply_prefix()`, and `to_word()` implementations
- Handle new variant in `entry_impl.rs` `make_ns()` (maps to `NS::SnakeCase` as closest runtime equivalent)
- Add snapshot test for the macro codegen
- Add integration test verifying value enums compile and rename correctly when used as fields inside a metrics struct

## Note

For entry enums/structs, `ScreamingSnakeCase` maps to the runtime `NS::SnakeCase` type since there's no `ScreamingSnakeCase` type in `metrique-core`. Full runtime type-level support would require a new type there — left for a follow-up if needed.

## Test plan

- [x] New snapshot test `test_value_enum_screaming_snake_case` passes
- [x] New integration test `value_enum_screaming_snake_case.rs` verifies:
  - Multi-word variants renamed correctly (`ReadData` → `"READ_DATA"`)
  - Explicit `#[metrics(name = "...")]` overrides still work
  - Value enum usable as a field inside another `#[metrics]` struct
- [x] All existing tests continue to pass