### PR TITLE
[metrique-writer-core + metrique-macro] Resolve FieldShape and Unit from Value trait

### DIFF
--- a/.github/actions/rust-build/action.yml
+++ b/.github/actions/rust-build/action.yml
@@ -23,11 +23,11 @@ runs:
           if [ "${{ inputs.toolchain }}" != stable ]; then
               rm -fv Cargo.lock
           fi
-          cargo build --verbose ${{ inputs.flags }}
+          RUSTFLAGS="--cfg tokio_unstable" cargo build --verbose ${{ inputs.flags }}
     - name: Run tests
       shell: bash
       run: |
-          cargo test --verbose ${{ inputs.flags }}
+          RUSTFLAGS="--cfg tokio_unstable" cargo test --verbose ${{ inputs.flags }}
           if [ "${{ inputs.toolchain }}" == nightly -a "${{ inputs.flags }}" == "--all-features" ]; then
               # docs use unstable features, run them on nightly
               # pass --no-deps. When *rendering* docs, is better to not use `--no-deps`,
@@ -37,5 +37,5 @@ runs:
               #
               # It's better to keep `--no-deps` in CI, since it matches what rustdoc runs, and is
               # faster.
-              RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo doc --verbose --no-deps ${{ inputs.flags }}
+              RUSTFLAGS="--cfg tokio_unstable" RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo doc --verbose --no-deps ${{ inputs.flags }}
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run clippy check
         id: cargoClippy
         shell: bash
-        run: cargo clippy --workspace --all-features -- -D warnings
+        run: RUSTFLAGS="--cfg tokio_unstable" cargo clippy --workspace --all-features -- -D warnings
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,20 @@ jobs:
   # instead of naming every individual job. This job fails if any of its
   # dependencies failed or were cancelled; skipped jobs (e.g. docs-rs on release
   # branches) do not count as failures.
+  value-consts:
+    name: Value impl completeness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check all Value impls define SHAPE and UNIT
+        run: RUSTFLAGS="--cfg metrique_require_explicit_impls" cargo check --workspace --all-features
+
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, build, docs-rs, fuzz]
+    needs: [fmt, clippy, build, docs-rs, fuzz, value-consts]
     if: always()
     steps:
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Check all Value impls define SHAPE and UNIT
-        run: RUSTFLAGS="--cfg metrique_require_explicit_impls" cargo check --workspace --all-features
+        # metrique-util is excluded from the full check because tokio-metrics
+        # (pulled in by the tokio-metrics-bridge feature) has Value impls that
+        # don't yet provide SHAPE/UNIT. RUSTFLAGS propagates to all crates
+        # including dependencies, so we check metrique-util separately without
+        # that feature. Remove this workaround once tokio-metrics adds the consts.
+        run: |
+          RUSTFLAGS="--cfg metrique_require_explicit_impls --cfg tokio_unstable" \
+            cargo check --workspace --all-features \
+            --exclude metrique-util
+          RUSTFLAGS="--cfg metrique_require_explicit_impls --cfg tokio_unstable" \
+            cargo check -p metrique-util --features state,pending-sink,sysinfo-bridge
 
   ci-pass:
     name: CI Pass

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run stress test
-        run: cargo nextest run --all-features --stress-duration '${{ inputs.duration_minutes || '60' }}m'
+        run: RUSTFLAGS="--cfg tokio_unstable" cargo nextest run --all-features --stress-duration '${{ inputs.duration_minutes || '60' }}m'

--- a/docs/entry-descriptors.md
+++ b/docs/entry-descriptors.md
@@ -109,16 +109,40 @@ Accessor return types are conservative (borrows tied to the handle, not `&'stati
 `FieldShape` describes the closed/emitted shape, not the raw Rust field type. Examples:
 
 - `bool` / `u64` / `i32` / `f64` / `String` / `Vec<u8>` lower to the corresponding `Known(KnownShape::..)` variant.
-- `Timer` lowers to `Known(U64)`.
-- `Option<Duration>` lowers to `Optional(Known(U64))`.
+- `Timer` lowers to `Known(F64)` (Timer closes to Duration, which writes as a floating-point millisecond value).
+- `Option<Duration>` lowers to `Optional(Known(F64))`.
 - `Vec<String>` and `&[String]` lower to `List(Known(String))`.
 - `Vec<Option<String>>` lowers to `List(Optional(Known(String)))`.
 - `Flex<(String, u64)>` lowers to `Flex { key: String, value: Known(U64) }`.
-- `Flex<(String, Option<Duration>)>` lowers to `Flex { key: String, value: Optional(Known(U64)) }`.
+- `Flex<(String, Option<Duration>)>` lowers to `Flex { key: String, value: Optional(Known(F64)) }`.
 
-`#[metrics(value)]` newtypes lower to their wrapped scalar's shape when the wrapped type is macro-known. `#[metrics(value)] struct Percent(u8)` lowers to `Known(U8)`. Newtypes wrapping user `Value` types fall through to `Opaque`.
+### Resolution mechanism
 
-The macro recognises one layer of `Optional` inside `List` or `Flex.value`. Deeper combinations (`Vec<Vec<T>>`, `Vec<Flex<..>>`, `Flex<(String, Vec<T>)>`, `Option<Option<T>>`) lower to `FieldShape::Opaque`; the descriptor enum can represent arbitrary nesting, the macro's syntactic recognition is what is currently restricted.
+Shape resolution uses `Value::SHAPE`, a defaulted associated const on the `Value` trait:
+
+```rust,ignore
+pub trait Value {
+    const SHAPE: FieldShape<'static> = FieldShape::Opaque;
+    fn write(&self, writer: impl ValueWriter);
+}
+```
+
+The macro emits `<<FieldType as CloseValue>::Closed as Value>::SHAPE` for each field. The compiler resolves the full chain at const-eval time: the field type closes (via `CloseValue`) to a closed type, and that closed type's `Value::SHAPE` provides the shape.
+
+Generic wrappers compose naturally: `Option<T>` returns `Optional(&T::SHAPE)`, `Vec<T>` returns `List(&T::SHAPE)`, transparent wrappers like `ForceFlag<T, F>` and `Box<T>` forward `T::SHAPE` unchanged.
+
+Custom types that close to a known type (like `Timer` closing to `Duration`) automatically get the correct shape without any extra work. Custom `Value` types that don't override `SHAPE` get `Opaque` by default. To provide a shape for a custom `Value` impl, override the const:
+
+```rust,ignore
+impl Value for MyCustomValue {
+    const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::String);
+    fn write(&self, writer: impl ValueWriter) { /* ... */ }
+}
+```
+
+`#[metrics(value)]` newtypes lower to their wrapped scalar's shape when the wrapped type implements `Value` with a non-Opaque `SHAPE`. `#[metrics(value)] struct Percent(u8)` lowers to `Known(U8)`.
+
+Nesting composes arbitrarily through the trait system (`Option<Vec<Option<u64>>>` resolves correctly). There is no syntactic depth limit.
 
 Flattening an `Option<SubEntry>` into a parent entry propagates optionality to each flattened field. If `SubEntry { baz: Option<usize> }` is flattened through an `Option<SubEntry>`, the descriptor lists `baz: Optional(Known(U64))`. `Optional` wraps the emit-or-not decision; it is not re-stacked.
 

--- a/docs/entry-descriptors.md
+++ b/docs/entry-descriptors.md
@@ -1,7 +1,5 @@
 # Entry descriptors and field flags
 
-> **Status: partially implemented.** Field flags, descriptors, and flatten chaining are implemented. Field shapes are deferred (all Opaque).
-
 A small system on top of metrique's existing `Entry` / `Value` / `CloseValue` traits that lets sinks introspect the structure of macro-derived entries.
 
 Two pieces, both opt-in for sinks:
@@ -113,8 +111,6 @@ Accessor return types are conservative (borrows tied to the handle, not `&'stati
 - `Option<Duration>` lowers to `Optional(Known(F64))`.
 - `Vec<String>` and `&[String]` lower to `List(Known(String))`.
 - `Vec<Option<String>>` lowers to `List(Optional(Known(String)))`.
-- `Flex<(String, u64)>` lowers to `Flex { key: String, value: Known(U64) }`.
-- `Flex<(String, Option<Duration>)>` lowers to `Flex { key: String, value: Optional(Known(F64)) }`.
 
 ### Resolution mechanism
 
@@ -131,7 +127,7 @@ The macro emits `<<FieldType as CloseValue>::Closed as Value>::SHAPE` for each f
 
 Generic wrappers compose naturally: `Option<T>` returns `Optional(&T::SHAPE)`, `Vec<T>` returns `List(&T::SHAPE)`, transparent wrappers like `ForceFlag<T, F>` and `Box<T>` forward `T::SHAPE` unchanged.
 
-Custom types that close to a known type (like `Timer` closing to `Duration`) automatically get the correct shape without any extra work. Custom `Value` types that don't override `SHAPE` get `Opaque` by default. To provide a shape for a custom `Value` impl, override the const:
+Custom types that close to a known type (like `Timer` closing to `Duration`) get the correct shape without any extra work. Custom `Value` types that don't override `SHAPE` get `Opaque` by default. To provide a shape for a custom `Value` impl, override the const:
 
 ```rust,ignore
 impl Value for MyCustomValue {
@@ -142,7 +138,7 @@ impl Value for MyCustomValue {
 
 `#[metrics(value)]` newtypes lower to their wrapped scalar's shape when the wrapped type implements `Value` with a non-Opaque `SHAPE`. `#[metrics(value)] struct Percent(u8)` lowers to `Known(U8)`.
 
-Nesting composes arbitrarily through the trait system (`Option<Vec<Option<u64>>>` resolves correctly). There is no syntactic depth limit.
+Nesting composes arbitrarily through the trait system (`Option<Vec<Option<u64>>>` resolves correctly).
 
 Flattening an `Option<SubEntry>` into a parent entry propagates optionality to each flattened field. If `SubEntry { baz: Option<usize> }` is flattened through an `Option<SubEntry>`, the descriptor lists `baz: Optional(Known(U64))`. `Optional` wraps the emit-or-not decision; it is not re-stacked.
 
@@ -206,7 +202,7 @@ The metrique macro emits exactly one `EntryWriter::value(name, ..)` callback per
 
 Multi-element fields (`Vec<T>`, `Flex<(String, T)>`, and similar) still produce exactly one `value()` callback per `FieldDescriptor`. The multiplicity is handled inside the `Value` impl, which the adapter's `ValueWriter` observes through `ValueWriter::values()` (for `Vec<T>` / `[T]`) or similar dispatch methods. Descriptor-aware sinks that want typed encoding for these fields override the corresponding `ValueWriter` method; the default implementations collapse multi-element data into a single scalar (comma-joined string for `values()`), which is a valid but lossy fallback.
 
-The contract is guaranteed by construction for macro-derived entries (the macro emits both from the same iteration). A debug-mode check inside metrique's test harness validates correspondence; CI tests assert it on every release. Hand-written entries that ship a descriptor (a deferred feature) must uphold the same correspondence.
+The contract is guaranteed by construction for macro-derived entries (the macro emits both from the same iteration). Hand-written entries that ship a descriptor must uphold the same correspondence.
 
 ## Field flags
 
@@ -276,15 +272,15 @@ Flattened children manage their own flags independently. This matches the scopin
 
 Sinks decide how to surface units: a field-name suffix, a schema-level annotation, a separate metadata stream, whatever fits the wire format. Metrique reports units once, structurally, in the descriptor, so sinks do not have to infer them.
 
-## Flex and List
+Unit resolution follows the same pattern as shapes: `Value::UNIT` is a defaulted associated const (`Unit::None` by default). Types with inherent units override it (e.g. `Duration` provides `Unit::Second(Milli)`). The macro resolves `<<FieldType as CloseValue>::Closed as Value>::UNIT` for each field, converting `Unit::None` to `Option::None` in the descriptor. Explicit `#[metrics(unit = X)]` takes precedence over the type-resolved unit.
 
-`Flex<(String, T)>` lowers to `FieldShape::Flex { key: StringShape::String, value: .. }`.
+## Flex and List
 
 `Vec<T>` / `[T]` / `&[T]` lower to `FieldShape::List(..)`.
 
-One descriptor entry regardless of runtime cardinality. Sinks that understand `Flex` or `List` can register one schema field for the whole collection; sinks that do not can still fall back to per-element emission through `Entry::write`.
+One descriptor entry regardless of runtime cardinality. Sinks that understand `List` can register one schema field for the whole collection; sinks that do not can still fall back to per-element emission through `Entry::write`.
 
-The inner shape may be `Known(_)` or `Optional(Known(_))` in the initial release.
+`Flex<(String, T)>` fields are flattened entries, not regular value fields. They produce their own descriptor segment via `Entry::descriptors()` rather than appearing as a `FieldShape::Flex` on a parent field. The `FieldShape::Flex` variant exists for future use when Flex fields can self-describe their key/value shape.
 
 ## Interaction with existing `#[metrics(..)]` attributes
 
@@ -379,7 +375,6 @@ Short list of things explicitly left out of the initial design that fit the syst
 - **Typed source extraction.** See the appendix below. Would let sinks pull a typed structural snapshot (timestamp, task id, correlation id, ...) out of the closed entry before encoding fields. Deferred pending a concrete second consumer (OTEL, a richer dial9 integration).
 - **Hand-written `Entry` impls opting into descriptors** via a `DescribeEntry` trait users implement by hand; same mechanism macro-derived entries use internally. Would require promoting metrique's hidden macro-only constructors to a public surface.
 - **`FieldShape::Distribution(KnownShape)`** for distribution-typed fields (`Histogram<T>`, `SharedHistogram<T>`, and user types that emit many `Observation`s). Depends on a `DescribeValue` trait so value types can self-describe as distribution-shaped.
-- **Nested container recognition beyond one optional layer.** `Vec<Vec<T>>`, `Vec<Flex<..>>`, `Flex<(String, Vec<T>)>`, and double-optional all fall through to `Opaque` today; the descriptor enum accepts them, the macro's syntactic recognition just does not. Relaxing is an additive macro change.
 - **`#[metrics(entry_name = "...")]`** attribute for overriding the canonical entry name.
 - **`no_write` attribute** for fields that participate in close but not in `Entry::write`. Deferred until a concrete consumer needs it; the deferred source system is the likely trigger.
 - **Cross-process `DescriptorId` stability** via a content-hash accessor. Deferred until a consumer needs cross-process schema correlation.

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -8,6 +8,9 @@ description = "Library for aggregating metrique events"
 repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(metrique_require_explicit_impls)'] }
+
 [dependencies]
 metrique = { workspace = true, features = ["service-metrics"] }
 metrique-writer = { workspace = true, features = ["background-queue", "tracing-subscriber-03", "metrics-rs-024"] }

--- a/metrique-aggregation/src/histogram.rs
+++ b/metrique-aggregation/src/histogram.rs
@@ -308,6 +308,10 @@ impl<T> Value for HistogramClosed<T>
 where
     T: MetricValue,
 {
+    const SHAPE: metrique_writer_core::FieldShape<'static> =
+        metrique_writer_core::FieldShape::Known(metrique_writer_core::KnownShape::F64);
+    const UNIT: metrique_writer_core::Unit = <T::Unit as metrique_writer::unit::UnitTag>::UNIT;
+
     fn write(&self, writer: impl ValueWriter) {
         use metrique_writer::unit::UnitTag;
         writer.metric(

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true, features = ["full", "extra-traits"] }
+syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
 Inflector = { workspace = true }

--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -437,6 +437,10 @@ pub(crate) struct DescriptorFieldMeta {
     pub(crate) skipped_flags: Vec<Ts2>,
     /// Unit expression (None or Some(<Unit>::UNIT))
     pub(crate) unit_expr: Ts2,
+    /// The field's Rust type (used for shape resolution via Value::SHAPE)
+    pub(crate) field_type: syn::Type,
+    /// Whether this field goes through CloseValue (true) or is used directly as Value (false)
+    pub(crate) close: bool,
 }
 
 /// Build a `Descriptors` chain from a base expression and cfg-aware children.
@@ -529,6 +533,7 @@ pub(crate) fn generate_style_matched_descriptor(
             let flags_ident = format_ident!("__METRIQUE_{}_FLAGS_{}", ident_prefix, i);
             let skipped_ident = format_ident!("__METRIQUE_{}_SKIPPED_{}", ident_prefix, i);
             let unit_expr = &f.unit_expr;
+            let field_shape = shape_expr(f);
             quote! {
                 ::metrique::writer::core::FieldDescriptor::builder(#preserve)
                     .pascal(#pascal)
@@ -538,6 +543,7 @@ pub(crate) fn generate_style_matched_descriptor(
                     .flags(&#flags_ident)
                     .skipped_flags(&#skipped_ident)
                     .maybe_unit(#unit_expr)
+                    .shape(#field_shape)
                     .build()
             }
         })
@@ -556,6 +562,30 @@ pub(crate) fn generate_style_matched_descriptor(
             &#desc_ident
         }
     }
+}
+
+/// Generate the shape expression for a single field.
+fn shape_expr(f: &DescriptorFieldMeta) -> Ts2 {
+    let field_type = anonymize_lifetimes(&f.field_type);
+    if f.close {
+        quote! { <<#field_type as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE }
+    } else {
+        quote! { <#field_type as ::metrique::writer::core::Value>::SHAPE }
+    }
+}
+
+/// Replace all named lifetime parameters with `'_` so the type can be
+/// used inside a `static` initializer for shape resolution.
+fn anonymize_lifetimes(ty: &syn::Type) -> syn::Type {
+    struct Anonymizer;
+    impl syn::visit_mut::VisitMut for Anonymizer {
+        fn visit_lifetime_mut(&mut self, lt: &mut syn::Lifetime) {
+            *lt = syn::Lifetime::new("'_", lt.apostrophe);
+        }
+    }
+    let mut ty = ty.clone();
+    syn::visit_mut::VisitMut::visit_type_mut(&mut Anonymizer, &mut ty);
+    ty
 }
 
 pub(crate) fn generate_descriptor_impl(

--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -435,12 +435,15 @@ pub(crate) struct DescriptorFieldMeta {
     pub(crate) flags: Vec<Ts2>,
     /// Skipped flag token streams for this field (field-level skip overrides flatten-site defaults)
     pub(crate) skipped_flags: Vec<Ts2>,
-    /// Unit expression (None or Some(<Unit>::UNIT))
-    pub(crate) unit_expr: Ts2,
+    /// Explicit unit from `#[metrics(unit = X)]`. None means resolve from the type.
+    pub(crate) explicit_unit: Option<syn::Path>,
     /// The field's Rust type (used for shape resolution via Value::SHAPE)
     pub(crate) field_type: syn::Type,
     /// Whether this field goes through CloseValue (true) or is used directly as Value (false)
     pub(crate) close: bool,
+    /// Optional format path. When present and close is false, the raw type may not impl Value,
+    /// so shape/unit resolution falls back to Opaque/None.
+    pub(crate) format: Option<syn::Path>,
 }
 
 /// Build a `Descriptors` chain from a base expression and cfg-aware children.
@@ -532,7 +535,7 @@ pub(crate) fn generate_style_matched_descriptor(
             let screaming_snake = &f.names[metrique_core::Styles::SCREAMING_SNAKE.index as usize];
             let flags_ident = format_ident!("__METRIQUE_{}_FLAGS_{}", ident_prefix, i);
             let skipped_ident = format_ident!("__METRIQUE_{}_SKIPPED_{}", ident_prefix, i);
-            let unit_expr = &f.unit_expr;
+            let field_unit = unit_expr(f);
             let field_shape = shape_expr(f);
             quote! {
                 ::metrique::writer::core::FieldDescriptor::builder(#preserve)
@@ -542,7 +545,7 @@ pub(crate) fn generate_style_matched_descriptor(
                     .screaming_snake(#screaming_snake)
                     .flags(&#flags_ident)
                     .skipped_flags(&#skipped_ident)
-                    .maybe_unit(#unit_expr)
+                    .maybe_unit(#field_unit)
                     .shape(#field_shape)
                     .build()
             }
@@ -565,12 +568,36 @@ pub(crate) fn generate_style_matched_descriptor(
 }
 
 /// Generate the shape expression for a single field.
+/// Shape describes the field's type-level closed shape. Formatted fields fall back to Opaque
+/// because the raw/closed type may not impl Value (formatters handle the writing).
 fn shape_expr(f: &DescriptorFieldMeta) -> Ts2 {
+    if f.format.is_some() {
+        return quote! { ::metrique::writer::core::descriptor::FieldShape::Opaque };
+    }
     let field_type = anonymize_lifetimes(&f.field_type);
     if f.close {
         quote! { <<#field_type as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE }
     } else {
         quote! { <#field_type as ::metrique::writer::core::Value>::SHAPE }
+    }
+}
+
+/// Generate the unit expression for a single field.
+/// Explicit `#[metrics(unit = X)]` takes precedence. Otherwise, resolves from the type.
+fn unit_expr(f: &DescriptorFieldMeta) -> Ts2 {
+    if let Some(u) = &f.explicit_unit {
+        quote! { Some(<#u as ::metrique::writer::core::unit::UnitTag>::UNIT) }
+    } else if f.format.is_some() {
+        // Formatted fields: raw/closed type may not impl Value, can't resolve unit
+        quote! { Option::None }
+    } else {
+        let field_type = anonymize_lifetimes(&f.field_type);
+        let resolved = if f.close {
+            quote! { <<#field_type as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT }
+        } else {
+            quote! { <#field_type as ::metrique::writer::core::Value>::UNIT }
+        };
+        quote! { ::metrique::writer::core::Unit::to_option(#resolved) }
     }
 }
 

--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -576,6 +576,8 @@ fn shape_expr(f: &DescriptorFieldMeta) -> Ts2 {
 
 /// Replace all named lifetime parameters with `'_` so the type can be
 /// used inside a `static` initializer for shape resolution.
+/// Also rewrites explicit `'static` to `'_`, which is harmless since
+/// trait resolution infers the same lifetime regardless.
 fn anonymize_lifetimes(ty: &syn::Type) -> syn::Type {
     struct Anonymizer;
     impl syn::visit_mut::VisitMut for Anonymizer {

--- a/metrique-macro/src/entry_impl/enum_impl.rs
+++ b/metrique-macro/src/entry_impl/enum_impl.rs
@@ -68,7 +68,7 @@ pub(crate) fn generate_enum_entry_impl(
         }
     };
 
-    let descriptor = generate_enum_descriptor(entry_name, variants, root_attrs);
+    let descriptor = generate_enum_descriptor(entry_name, generics, variants, root_attrs);
     let descriptor_trait_impls = &descriptor.trait_impls;
     let descriptors_method = &descriptor.method;
 
@@ -366,6 +366,7 @@ fn collect_tuple_sample_group(
 /// Same pattern as sample_group: one variant per enum arm, unified via Iterator impl.
 fn generate_enum_descriptor(
     entry_name: &Ident,
+    _generics: &syn::Generics,
     variants: &[MetricsVariant],
     root_attrs: &RootAttributes,
 ) -> super::DescriptorOutput {
@@ -386,7 +387,7 @@ fn generate_enum_descriptor(
             let mut v_timestamp_expr = quote! { None };
             if let Some(tag) = &root_attrs.tag {
                 let names: [String; metrique_core::Styles::COUNT] = std::array::from_fn(|_| tag.field_name(root_attrs));
-                v_field_metas.push(DescriptorFieldMeta { names, flags: vec![], skipped_flags: vec![], unit_expr: quote! { None } });
+                v_field_metas.push(DescriptorFieldMeta { names, flags: vec![], skipped_flags: vec![], unit_expr: quote! { None }, field_type: syn::parse_quote!(&'static str), close: true });
             }
             if let Some(VariantData::Struct(fields)) = &variant.data {
                 for field in fields {
@@ -398,7 +399,7 @@ fn generate_enum_descriptor(
                                 Some(u) => quote! { Some(<#u as ::metrique::writer::core::unit::UnitTag>::UNIT) },
                                 None => quote! { None },
                             };
-                            v_field_metas.push(DescriptorFieldMeta { names, flags: resolved.flags, skipped_flags: resolved.skipped_flags, unit_expr });
+                            v_field_metas.push(DescriptorFieldMeta { names, flags: resolved.flags, skipped_flags: resolved.skipped_flags, unit_expr, field_type: field.ty.clone(), close: field.attrs.close });
                         }
                         MetricsFieldKind::Timestamp(_) => {
                             let ts_name = field.name.as_deref().unwrap_or("timestamp");

--- a/metrique-macro/src/entry_impl/enum_impl.rs
+++ b/metrique-macro/src/entry_impl/enum_impl.rs
@@ -386,20 +386,35 @@ fn generate_enum_descriptor(
             let mut v_field_metas: Vec<super::DescriptorFieldMeta> = Vec::new();
             let mut v_timestamp_expr = quote! { None };
             if let Some(tag) = &root_attrs.tag {
-                let names: [String; metrique_core::Styles::COUNT] = std::array::from_fn(|_| tag.field_name(root_attrs));
-                v_field_metas.push(DescriptorFieldMeta { names, flags: vec![], skipped_flags: vec![], unit_expr: quote! { None }, field_type: syn::parse_quote!(&'static str), close: true });
+                let names: [String; metrique_core::Styles::COUNT] =
+                    std::array::from_fn(|_| tag.field_name(root_attrs));
+                v_field_metas.push(DescriptorFieldMeta {
+                    names,
+                    flags: vec![],
+                    skipped_flags: vec![],
+                    explicit_unit: None,
+                    field_type: syn::parse_quote!(&'static str),
+                    close: true,
+                    format: None,
+                });
             }
             if let Some(VariantData::Struct(fields)) = &variant.data {
                 for field in fields {
                     match &field.attrs.kind {
-                        MetricsFieldKind::Field { unit, .. } => {
-                            let names: [String; metrique_core::Styles::COUNT] = std::array::from_fn(|i| metric_name(root_attrs, styles[i], field));
-                            let resolved = resolve_field_flags(&field.attrs.flags, &root_attrs.default_flags);
-                            let unit_expr = match unit {
-                                Some(u) => quote! { Some(<#u as ::metrique::writer::core::unit::UnitTag>::UNIT) },
-                                None => quote! { None },
-                            };
-                            v_field_metas.push(DescriptorFieldMeta { names, flags: resolved.flags, skipped_flags: resolved.skipped_flags, unit_expr, field_type: field.ty.clone(), close: field.attrs.close });
+                        MetricsFieldKind::Field { unit, format, .. } => {
+                            let names: [String; metrique_core::Styles::COUNT] =
+                                std::array::from_fn(|i| metric_name(root_attrs, styles[i], field));
+                            let resolved =
+                                resolve_field_flags(&field.attrs.flags, &root_attrs.default_flags);
+                            v_field_metas.push(DescriptorFieldMeta {
+                                names,
+                                flags: resolved.flags,
+                                skipped_flags: resolved.skipped_flags,
+                                explicit_unit: unit.clone(),
+                                field_type: field.ty.clone(),
+                                close: field.attrs.close,
+                                format: format.clone(),
+                            });
                         }
                         MetricsFieldKind::Timestamp(_) => {
                             let ts_name = field.name.as_deref().unwrap_or("timestamp");
@@ -431,7 +446,8 @@ fn generate_enum_descriptor(
                 )
             };
 
-            let (pattern, chain_expr) = build_variant_descriptor_arm(entry_name, variant, &base, &ns);
+            let (pattern, chain_expr) =
+                build_variant_descriptor_arm(entry_name, variant, &base, &ns);
             quote! { #pattern => #chain_expr }
         })
         .collect();

--- a/metrique-macro/src/entry_impl/struct_impl.rs
+++ b/metrique-macro/src/entry_impl/struct_impl.rs
@@ -122,23 +122,18 @@ fn generate_descriptor(
                     Some(::metrique::writer::core::TimestampDescriptor::new(#name))
                 };
             }
-            MetricsFieldKind::Field { unit, .. } => {
+            MetricsFieldKind::Field { unit, format, .. } => {
                 let names: [String; metrique_core::Styles::COUNT] =
                     std::array::from_fn(|i| metric_name(root_attrs, styles[i], field));
                 let resolved = resolve_field_flags(&field.attrs.flags, &root_attrs.default_flags);
-                let unit_expr = match unit {
-                    Some(u) => {
-                        quote! { Some(<#u as ::metrique::writer::core::unit::UnitTag>::UNIT) }
-                    }
-                    None => quote! { None },
-                };
                 field_metas.push(DescriptorFieldMeta {
                     names,
                     flags: resolved.flags,
                     skipped_flags: resolved.skipped_flags,
-                    unit_expr,
+                    explicit_unit: unit.clone(),
                     field_type: field.ty.clone(),
                     close: field.attrs.close,
+                    format: format.clone(),
                 });
             }
         }

--- a/metrique-macro/src/entry_impl/struct_impl.rs
+++ b/metrique-macro/src/entry_impl/struct_impl.rs
@@ -137,6 +137,8 @@ fn generate_descriptor(
                     flags: resolved.flags,
                     skipped_flags: resolved.skipped_flags,
                     unit_expr,
+                    field_type: field.ty.clone(),
+                    close: field.attrs.close,
                 });
             }
         }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_enum.snap
@@ -41,6 +41,9 @@ impl ::metrique::writer::core::SampleGroup for OperationValue {
     }
 }
 impl ::metrique::writer::Value for OperationValue {
+    const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> = ::metrique::writer::core::descriptor::FieldShape::Known(
+        ::metrique::writer::core::descriptor::KnownShape::String,
+    );
     fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
         writer.string(::std::convert::Into::<&str>::into(self));
     }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_struct.snap
@@ -32,7 +32,11 @@ const _: () = {
                         .screaming_snake("FIELD")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_struct.snap
@@ -33,6 +33,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
@@ -31,6 +31,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -318,6 +321,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                         ::metrique::writer::core::FieldDescriptor::builder(
                                                 "latency",
@@ -332,6 +338,9 @@ const _: () = {
                                                 Some(
                                                     <metrique::writer::unit::Millisecond as ::metrique::writer::core::unit::UnitTag>::UNIT,
                                                 ),
+                                            )
+                                            .shape(
+                                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
                                             .build(),
                                     ];
@@ -579,6 +588,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V0_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
@@ -30,7 +30,11 @@ const _: () = {
                         .screaming_snake("VALUE")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -320,7 +324,11 @@ const _: () = {
                                             .screaming_snake("COUNT")
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
@@ -587,7 +595,11 @@ const _: () = {
                                             .screaming_snake("BYTES")
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
@@ -30,7 +30,11 @@ const _: () = {
                         .screaming_snake("VALUE")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -316,7 +320,11 @@ const _: () = {
                                             .screaming_snake("operation")
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
@@ -328,7 +336,11 @@ const _: () = {
                                             .screaming_snake("BYTES")
                                             .flags(&__METRIQUE_V0_FLAGS_1)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_1)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
@@ -364,7 +376,11 @@ const _: () = {
                                                 .screaming_snake("operation")
                                                 .flags(&__METRIQUE_V1_FLAGS_0)
                                                 .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
-                                                .maybe_unit(None)
+                                                .maybe_unit(
+                                                    ::metrique::writer::core::Unit::to_option(
+                                                        <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                    ),
+                                                )
                                                 .shape(
                                                     <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                                 )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
@@ -31,6 +31,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -314,6 +317,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                         ::metrique::writer::core::FieldDescriptor::builder("bytes")
                                             .pascal("Bytes")
@@ -323,6 +329,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_1)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_1)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V0_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -356,6 +365,9 @@ const _: () = {
                                                 .flags(&__METRIQUE_V1_FLAGS_0)
                                                 .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
                                                 .maybe_unit(None)
+                                                .shape(
+                                                    <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                                )
                                                 .build(),
                                         ];
                                         static __METRIQUE_V1_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag_sample_group.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag_sample_group.snap
@@ -171,7 +171,11 @@ const _: () = {
                                             .screaming_snake("operation")
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
@@ -183,7 +187,11 @@ const _: () = {
                                             .screaming_snake("BYTES")
                                             .flags(&__METRIQUE_V0_FLAGS_1)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_1)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag_sample_group.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag_sample_group.snap
@@ -172,6 +172,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                         ::metrique::writer::core::FieldDescriptor::builder("bytes")
                                             .pascal("Bytes")
@@ -181,6 +184,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_1)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_1)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V0_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__enum_with_flags.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__enum_with_flags.snap
@@ -169,7 +169,11 @@ const _: () = {
                                             .screaming_snake("VALUE")
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
@@ -207,7 +211,11 @@ const _: () = {
                                             .screaming_snake("SKIPPED")
                                             .flags(&__METRIQUE_V1_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__enum_with_flags.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__enum_with_flags.snap
@@ -170,6 +170,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V0_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -205,6 +208,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V1_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V1_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__enum_with_timestamp_and_unit.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__enum_with_timestamp_and_unit.snap
@@ -194,6 +194,9 @@ const _: () = {
                                                     <Millisecond as ::metrique::writer::core::unit::UnitTag>::UNIT,
                                                 ),
                                             )
+                                            .shape(
+                                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V0_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -229,6 +232,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V1_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V1_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__enum_with_timestamp_and_unit.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__enum_with_timestamp_and_unit.snap
@@ -231,7 +231,11 @@ const _: () = {
                                             .screaming_snake("BYTES")
                                             .flags(&__METRIQUE_V1_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
@@ -38,7 +38,11 @@ const _: () = {
                         .screaming_snake("API@OPERATION")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -52,7 +56,11 @@ const _: () = {
                         .screaming_snake("API@NUMBER_OF_DUCKS")
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
@@ -39,6 +39,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder(
                             "API@number_of_ducks",
@@ -50,6 +53,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
                         .maybe_unit(None)
+                        .shape(
+                            <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
@@ -37,6 +37,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
@@ -36,7 +36,11 @@ const _: () = {
                         .screaming_snake("OPERATION")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
@@ -37,6 +37,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
@@ -36,7 +36,11 @@ const _: () = {
                         .screaming_snake("OPERATION")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_cow_lifetime.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_cow_lifetime.snap
@@ -39,6 +39,12 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<Cow<
+                                '_,
+                                str,
+                            > as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("b")
                         .pascal("B")
@@ -48,6 +54,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
                         .maybe_unit(None)
+                        .shape(
+                            <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_cow_lifetime.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_cow_lifetime.snap
@@ -38,7 +38,14 @@ const _: () = {
                         .screaming_snake("A")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<Cow<
+                                    '_,
+                                    str,
+                                > as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<Cow<
                                 '_,
@@ -53,7 +60,11 @@ const _: () = {
                         .screaming_snake("B")
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_lifetime.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_lifetime.snap
@@ -39,6 +39,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("b")
                         .pascal("B")
@@ -48,6 +51,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
                         .maybe_unit(None)
+                        .shape(
+                            <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_lifetime.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_lifetime.snap
@@ -38,7 +38,11 @@ const _: () = {
                         .screaming_snake("A")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -50,7 +54,11 @@ const _: () = {
                         .screaming_snake("B")
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
@@ -40,6 +40,9 @@ impl ::metrique::writer::core::SampleGroup for OperationValue {
     }
 }
 impl ::metrique::writer::Value for OperationValue {
+    const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> = ::metrique::writer::core::descriptor::FieldShape::Known(
+        ::metrique::writer::core::descriptor::KnownShape::String,
+    );
     fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
         writer.string(::std::convert::Into::<&str>::into(self));
     }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
@@ -124,7 +124,11 @@ const _: () = {
                         .screaming_snake("OPERATION")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -136,7 +140,11 @@ const _: () = {
                         .screaming_snake("REQUEST_ID")
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<String as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<String as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -637,7 +645,11 @@ const _: () = {
                                             .screaming_snake("OPERATION")
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
@@ -649,7 +661,11 @@ const _: () = {
                                             .screaming_snake("BYTES")
                                             .flags(&__METRIQUE_V0_FLAGS_1)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_1)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
@@ -687,7 +703,11 @@ const _: () = {
                                             .screaming_snake("OPERATION")
                                             .flags(&__METRIQUE_V1_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )
@@ -701,7 +721,11 @@ const _: () = {
                                             .screaming_snake("ERROR_CODE")
                                             .flags(&__METRIQUE_V1_FLAGS_1)
                                             .skipped_flags(&__METRIQUE_V1_SKIPPED_1)
-                                            .maybe_unit(None)
+                                            .maybe_unit(
+                                                ::metrique::writer::core::Unit::to_option(
+                                                    <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                                                ),
+                                            )
                                             .shape(
                                                 <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                                             )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
@@ -122,6 +122,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("request_id")
                         .pascal("RequestId")
@@ -131,6 +134,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
                         .maybe_unit(None)
+                        .shape(
+                            <<String as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -629,6 +635,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                         ::metrique::writer::core::FieldDescriptor::builder("bytes")
                                             .pascal("Bytes")
@@ -638,6 +647,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V0_FLAGS_1)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_1)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V0_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -673,6 +685,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V1_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<Operation as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                         ::metrique::writer::core::FieldDescriptor::builder(
                                                 "error_code",
@@ -684,6 +699,9 @@ const _: () = {
                                             .flags(&__METRIQUE_V1_FLAGS_1)
                                             .skipped_flags(&__METRIQUE_V1_SKIPPED_1)
                                             .maybe_unit(None)
+                                            .shape(
+                                                <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                                            )
                                             .build(),
                                     ];
                                     static __METRIQUE_V1_DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
@@ -38,7 +38,11 @@ const _: () = {
                         .screaming_snake("OPERATION")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -50,7 +54,11 @@ const _: () = {
                         .screaming_snake("NUMBER_OF_DUCKS")
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
@@ -39,6 +39,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("number_of_ducks")
                         .pascal("NumberOfDucks")
@@ -48,6 +51,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
                         .maybe_unit(None)
+                        .shape(
+                            <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_value_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_value_struct.snap
@@ -16,6 +16,7 @@ pub struct RequestValueValue {
     value: <&'static str as metrique::CloseValue>::Closed,
 }
 impl ::metrique::writer::Value for RequestValueValue {
+    const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> = <<&'static str as ::metrique::CloseValue>::Closed as ::metrique::writer::Value>::SHAPE;
     fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
         #[allow(deprecated)]
         {

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_enum.snap
@@ -33,6 +33,9 @@ impl ::metrique::writer::core::SampleGroup for FooValue {
     }
 }
 impl ::metrique::writer::Value for FooValue {
+    const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> = ::metrique::writer::core::descriptor::FieldShape::Known(
+        ::metrique::writer::core::descriptor::KnownShape::String,
+    );
     fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
         writer.string(::std::convert::Into::<&str>::into(self));
     }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
@@ -48,7 +48,11 @@ const _: () = {
                         .screaming_snake("OPERATION")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -60,7 +64,11 @@ const _: () = {
                         .screaming_snake("NUMBER_OF_DUCKS")
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
@@ -49,6 +49,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<&'_ str as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("number_of_ducks")
                         .pascal("NumberOfDucks")
@@ -58,6 +61,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
                         .maybe_unit(None)
+                        .shape(
+                            <<usize as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("latency")
                         .pascal("Latency")
@@ -70,6 +76,9 @@ const _: () = {
                             Some(
                                 <Millisecond as ::metrique::writer::core::unit::UnitTag>::UNIT,
                             ),
+                        )
+                        .shape(
+                            <<std::time::Duration as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
                         .build(),
                 ];

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_struct.snap
@@ -16,6 +16,7 @@ pub struct RequestValueValue {
     value: <u32 as metrique::CloseValue>::Closed,
 }
 impl ::metrique::writer::Value for RequestValueValue {
+    const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> = <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::Value>::SHAPE;
     fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
         #[allow(deprecated)]
         {

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_unnamed_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_unnamed_struct.snap
@@ -13,6 +13,7 @@ pub struct RequestValueValue(
     <u32 as metrique::CloseValue>::Closed,
 );
 impl ::metrique::writer::Value for RequestValueValue {
+    const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> = <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::Value>::SHAPE;
     fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
         #[allow(deprecated)]
         {

--- a/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_flags.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_flags.snap
@@ -53,7 +53,11 @@ const _: () = {
                         .screaming_snake("COUNT")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -65,7 +69,11 @@ const _: () = {
                         .screaming_snake("DEBUG")
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<String as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<String as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )
@@ -77,7 +85,11 @@ const _: () = {
                         .screaming_snake("SPECIAL")
                         .flags(&__METRIQUE__FLAGS_2)
                         .skipped_flags(&__METRIQUE__SKIPPED_2)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_flags.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_flags.snap
@@ -54,6 +54,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("debug")
                         .pascal("Debug")
@@ -63,6 +66,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
                         .maybe_unit(None)
+                        .shape(
+                            <<String as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("special")
                         .pascal("Special")
@@ -72,6 +78,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_2)
                         .skipped_flags(&__METRIQUE__SKIPPED_2)
                         .maybe_unit(None)
+                        .shape(
+                            <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_timestamp_and_unit.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_timestamp_and_unit.snap
@@ -51,6 +51,9 @@ const _: () = {
                                 <Millisecond as ::metrique::writer::core::unit::UnitTag>::UNIT,
                             ),
                         )
+                        .shape(
+                            <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                     ::metrique::writer::core::FieldDescriptor::builder("count")
                         .pascal("Count")
@@ -60,6 +63,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
                         .maybe_unit(None)
+                        .shape(
+                            <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_timestamp_and_unit.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_timestamp_and_unit.snap
@@ -62,7 +62,11 @@ const _: () = {
                         .screaming_snake("COUNT")
                         .flags(&__METRIQUE__FLAGS_1)
                         .skipped_flags(&__METRIQUE__SKIPPED_1)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<u64 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__subfield_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__subfield_struct.snap
@@ -31,6 +31,9 @@ const _: () = {
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
                         .maybe_unit(None)
+                        .shape(
+                            <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
+                        )
                         .build(),
                 ];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__subfield_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__subfield_struct.snap
@@ -30,7 +30,11 @@ const _: () = {
                         .screaming_snake("COUNTER")
                         .flags(&__METRIQUE__FLAGS_0)
                         .skipped_flags(&__METRIQUE__SKIPPED_0)
-                        .maybe_unit(None)
+                        .maybe_unit(
+                            ::metrique::writer::core::Unit::to_option(
+                                <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::UNIT,
+                            ),
+                        )
                         .shape(
                             <<u32 as ::metrique::CloseValue>::Closed as ::metrique::writer::core::Value>::SHAPE,
                         )

--- a/metrique-macro/src/snapshots/metrique_macro__tests__value_enum_screaming_snake_case.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__value_enum_screaming_snake_case.snap
@@ -47,6 +47,9 @@ impl ::metrique::writer::core::SampleGroup for OperationValue {
     }
 }
 impl ::metrique::writer::Value for OperationValue {
+    const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> = ::metrique::writer::core::descriptor::FieldShape::Known(
+        ::metrique::writer::core::descriptor::KnownShape::String,
+    );
     fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
         writer.string(::std::convert::Into::<&str>::into(self));
     }

--- a/metrique-macro/src/value_impl.rs
+++ b/metrique-macro/src/value_impl.rs
@@ -27,6 +27,11 @@ pub(crate) fn generate_value_impl_for_enum(
     Ok(quote!(
         #from_and_sample_group
         impl ::metrique::writer::Value for #value_name {
+            const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> =
+                ::metrique::writer::core::descriptor::FieldShape::Known(
+                    ::metrique::writer::core::descriptor::KnownShape::String,
+                );
+
             fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
                 writer.string(::std::convert::Into::<&str>::into(self));
             }
@@ -162,8 +167,18 @@ pub(crate) fn generate_value_impl_for_struct(
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let shape_const = non_ignore_field.map(|field| {
+        let field_ty = &field.ty;
+        quote! {
+            const SHAPE: ::metrique::writer::core::descriptor::FieldShape<'static> =
+                <<#field_ty as ::metrique::CloseValue>::Closed as ::metrique::writer::Value>::SHAPE;
+        }
+    });
+
     Ok(quote! {
         impl #impl_generics ::metrique::writer::Value for #value_name #ty_generics #where_clause {
+            #shape_const
+
             fn write(&self, writer: impl ::metrique::writer::ValueWriter) {
                 #[allow(deprecated)] {
                     #body

--- a/metrique-metricsrs/Cargo.toml
+++ b/metrique-metricsrs/Cargo.toml
@@ -8,6 +8,9 @@ description = "Library for wide event metrics - metrics.rs collector"
 repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(metrique_require_explicit_impls)'] }
+
 [features]
 default = ["background-queue"]
 metrics-rs-024 = [ "dep:metrics_024", "dep:metrics-util_020" ]

--- a/metrique-metricsrs/src/accumulator.rs
+++ b/metrique-metricsrs/src/accumulator.rs
@@ -262,6 +262,10 @@ impl<V: MetricsRsVersion + ?Sized> Entry for MetricAccumulatorEntry<V> {
         where
             T: IntoIterator<Item = Observation> + Clone,
         {
+            const SHAPE: metrique_writer_core::FieldShape<'static> =
+                metrique_writer_core::FieldShape::Known(metrique_writer_core::KnownShape::F64);
+            const UNIT: metrique_writer_core::Unit = metrique_writer_core::Unit::None;
+
             fn write(&self, writer: impl metrique_writer_core::ValueWriter) {
                 writer.metric(
                     self.value.clone(),
@@ -330,6 +334,10 @@ impl<V: MetricsRsVersion + ?Sized> Entry for MetricAccumulatorEntry<V> {
                 },
             );
         }
+    }
+
+    fn descriptors(&self) -> metrique_writer_core::Descriptors<'_> {
+        metrique_writer_core::Descriptors::Unavailable
     }
 }
 

--- a/metrique-util/Cargo.toml
+++ b/metrique-util/Cargo.toml
@@ -83,4 +83,5 @@ doc-scrape-examples = false
 all-features = true
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
+rustc-args = ["--cfg", "tokio_unstable"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -323,9 +323,39 @@ mod tests {
         check!(entry.metrics["workers_count"] == 1);
         check!(entry.metrics["elapsed"] > 0.0);
         check!(entry.metrics["total_park_count"] > 0);
+    }
 
-        #[cfg(tokio_unstable)]
-        check!(entry.metrics["poll_time_histogram"].num_observations() > 0);
+    #[cfg(tokio_unstable)]
+    #[test]
+    fn subscribe_appends_metrics_identity_histogram() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .enable_metrics_poll_count_histogram()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            metrique_writer::sink::global_entry_sink! { Sink }
+            let TestEntrySink { inspector, sink } = test_entry_sink();
+            let _handle = Sink::attach((sink, ()));
+
+            Sink::subscribe_tokio_runtime_metrics(
+                TokioRuntimeMetricsConfig::default().with_interval(Duration::from_millis(50)),
+            );
+
+            // Spawn work and wait so the runtime records poll times.
+            tokio::spawn(async {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            })
+            .await
+            .unwrap();
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            let entries = inspector.entries();
+            check!(!entries.is_empty());
+            let entry = entries.last().unwrap();
+            check!(entry.metrics["poll_time_histogram"].num_observations() > 0);
+        });
     }
 
     #[tokio::test(start_paused = true)]
@@ -349,9 +379,6 @@ mod tests {
         check!(entry.metrics["WorkersCount"] == 1);
         check!(entry.metrics["Elapsed"] > 0.0);
         check!(entry.metrics["TotalParkCount"] > 0);
-
-        #[cfg(tokio_unstable)]
-        check!(entry.metrics["PollTimeHistogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -375,9 +402,6 @@ mod tests {
         check!(entry.metrics["workers_count"] == 1);
         check!(entry.metrics["elapsed"] > 0.0);
         check!(entry.metrics["total_park_count"] > 0);
-
-        #[cfg(tokio_unstable)]
-        check!(entry.metrics["poll_time_histogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]
@@ -401,9 +425,6 @@ mod tests {
         check!(entry.metrics["workers-count"] == 1);
         check!(entry.metrics["elapsed"] > 0.0);
         check!(entry.metrics["total-park-count"] > 0);
-
-        #[cfg(tokio_unstable)]
-        check!(entry.metrics["poll-time-histogram"].num_observations() > 0);
     }
 
     #[tokio::test(start_paused = true)]

--- a/metrique-util/src/tokio_metrics_reporter.rs
+++ b/metrique-util/src/tokio_metrics_reporter.rs
@@ -325,39 +325,6 @@ mod tests {
         check!(entry.metrics["total_park_count"] > 0);
     }
 
-    #[cfg(tokio_unstable)]
-    #[test]
-    fn subscribe_appends_metrics_identity_histogram() {
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .enable_metrics_poll_count_histogram()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            metrique_writer::sink::global_entry_sink! { Sink }
-            let TestEntrySink { inspector, sink } = test_entry_sink();
-            let _handle = Sink::attach((sink, ()));
-
-            Sink::subscribe_tokio_runtime_metrics(
-                TokioRuntimeMetricsConfig::default().with_interval(Duration::from_millis(50)),
-            );
-
-            // Spawn work and wait so the runtime records poll times.
-            tokio::spawn(async {
-                std::thread::sleep(std::time::Duration::from_millis(1));
-            })
-            .await
-            .unwrap();
-            tokio::time::sleep(Duration::from_millis(200)).await;
-
-            let entries = inspector.entries();
-            check!(!entries.is_empty());
-            let entry = entries.last().unwrap();
-            check!(entry.metrics["poll_time_histogram"].num_observations() > 0);
-        });
-    }
-
     #[tokio::test(start_paused = true)]
     async fn subscribe_appends_metrics_pascal_case() {
         metrique_writer::sink::global_entry_sink! { Sink }

--- a/metrique-writer-core/Cargo.toml
+++ b/metrique-writer-core/Cargo.toml
@@ -8,6 +8,9 @@ description = "Library for wide event metrics - writer-side interface core trait
 repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(metrique_require_explicit_impls)'] }
+
 [dependencies]
 smallvec = { workspace = true, features = ["union", "const_generics", "const_new"] }
 itertools = { workspace = true, default-features = false }

--- a/metrique-writer-core/src/config.rs
+++ b/metrique-writer-core/src/config.rs
@@ -78,6 +78,10 @@ impl crate::Entry for MetriqueValidationError<'_> {
         writer.config(&const { AllowUnroutableEntries::new() });
         writer.value("MetriqueValidationError", self.message);
     }
+
+    fn descriptors(&self) -> crate::Descriptors<'_> {
+        crate::Descriptors::Unavailable
+    }
 }
 
 /// This struct is mostly useful for the EMF internal implementation

--- a/metrique-writer-core/src/descriptor.rs
+++ b/metrique-writer-core/src/descriptor.rs
@@ -451,13 +451,13 @@ pub enum KnownShape {
     U32,
     /// Unsigned 64-bit integer
     U64,
-    /// Signed 8-bit integer
+    /// Signed 8-bit integer.
     I8,
-    /// Signed 16-bit integer
+    /// Signed 16-bit integer.
     I16,
-    /// Signed 32-bit integer
+    /// Signed 32-bit integer.
     I32,
-    /// Signed 64-bit integer
+    /// Signed 64-bit integer.
     I64,
     /// 32-bit floating point
     F32,
@@ -465,7 +465,7 @@ pub enum KnownShape {
     F64,
     /// String
     String,
-    /// Byte slice
+    /// Byte slice.
     Bytes,
 }
 

--- a/metrique-writer-core/src/entry/boxed.rs
+++ b/metrique-writer-core/src/entry/boxed.rs
@@ -144,6 +144,9 @@ impl<V: Value + ?Sized> DynValue for ValueToDyn<'_, V> {
 }
 
 impl Value for ValueFromDyn<'_> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Opaque;
+    const UNIT: crate::Unit = crate::Unit::None;
+
     fn write(&self, writer: impl ValueWriter) {
         self.0.write(&mut ValueWriterToDyn(Some(writer)));
     }

--- a/metrique-writer-core/src/entry/map.rs
+++ b/metrique-writer-core/src/entry/map.rs
@@ -15,6 +15,10 @@ impl<K: AsRef<str>, V: Value, S> Entry for HashMap<K, V, S> {
             writer.value(k.as_ref(), v);
         }
     }
+
+    fn descriptors(&self) -> crate::Descriptors<'_> {
+        crate::Descriptors::Unavailable
+    }
 }
 
 impl<K: AsRef<str>, V: Value> Entry for BTreeMap<K, V> {
@@ -22,6 +26,10 @@ impl<K: AsRef<str>, V: Value> Entry for BTreeMap<K, V> {
         for (k, v) in self {
             writer.value(k.as_ref(), v);
         }
+    }
+
+    fn descriptors(&self) -> crate::Descriptors<'_> {
+        crate::Descriptors::Unavailable
     }
 }
 
@@ -32,5 +40,9 @@ impl<K: AsRef<str>, V: Value> Entry for [(K, V)] {
         for (k, v) in self {
             writer.value(k.as_ref(), v);
         }
+    }
+
+    fn descriptors(&self) -> crate::Descriptors<'_> {
+        crate::Descriptors::Unavailable
     }
 }

--- a/metrique-writer-core/src/entry/mod.rs
+++ b/metrique-writer-core/src/entry/mod.rs
@@ -190,9 +190,13 @@ pub trait Entry {
     /// Each descriptor covers a contiguous segment of the `Entry::write` output.
     /// Simple entries yield one descriptor. Composed entries (like aggregation results)
     /// yield multiple. Hand-written entries return an empty iterator by default.
+    #[cfg(not(metrique_require_explicit_impls))]
     fn descriptors(&self) -> Descriptors<'_> {
         Descriptors::Unavailable
     }
+    /// Returns descriptors for this entry in write order.
+    #[cfg(metrique_require_explicit_impls)]
+    fn descriptors(&self) -> Descriptors<'_>;
 
     /// Move the entry to the heap and rely on dynamic dispatch.
     ///

--- a/metrique-writer-core/src/test_stream.rs
+++ b/metrique-writer-core/src/test_stream.rs
@@ -120,6 +120,10 @@ impl Entry for TestEntry {
     fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
         writer.value("value", &self.0);
     }
+
+    fn descriptors(&self) -> crate::Descriptors<'_> {
+        crate::Descriptors::Unavailable
+    }
 }
 
 /// A helper struct that implements `io::Write` to write to an `Arc<Mutex<Vec<u8>>>`, to be

--- a/metrique-writer-core/src/unit.rs
+++ b/metrique-writer-core/src/unit.rs
@@ -522,6 +522,7 @@ where
     V::Unit: Convert<U>,
 {
     const SHAPE: crate::descriptor::FieldShape<'static> = V::SHAPE;
+    const UNIT: crate::Unit = U::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         struct Wrapper<W, From, To> {

--- a/metrique-writer-core/src/unit.rs
+++ b/metrique-writer-core/src/unit.rs
@@ -89,6 +89,14 @@ impl serde::Serialize for Unit {
 }
 
 impl Unit {
+    /// Converts to `Some(self)` unless unitless (`Unit::None`).
+    pub const fn to_option(self) -> Option<Unit> {
+        match self {
+            Unit::None => Option::None,
+            other => Option::Some(other),
+        }
+    }
+
     /// The public name defined by CloudWatch for the unit.
     pub const fn name(self) -> &'static str {
         macro_rules! positive_scale {

--- a/metrique-writer-core/src/unit.rs
+++ b/metrique-writer-core/src/unit.rs
@@ -513,6 +513,8 @@ impl<V: MetricValue, U: UnitTag> Value for WithUnit<V, U>
 where
     V::Unit: Convert<U>,
 {
+    const SHAPE: crate::descriptor::FieldShape<'static> = V::SHAPE;
+
     fn write(&self, writer: impl ValueWriter) {
         struct Wrapper<W, From, To> {
             writer: W,

--- a/metrique-writer-core/src/value/dimensions.rs
+++ b/metrique-writer-core/src/value/dimensions.rs
@@ -300,6 +300,9 @@ impl<'a, W: EntryWriter<'a>> EntryWriter<'a> for Wrapper<'_, W> {
 }
 
 impl<V: Value> Value for Wrapper<'_, V> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = V::SHAPE;
+    const UNIT: crate::Unit = V::UNIT;
+
     fn write(&self, writer: impl ValueWriter) {
         self.value.write(Wrapper {
             value: writer,
@@ -341,6 +344,7 @@ impl<W: ValueWriter> ValueWriter for Wrapper<'_, W> {
 
 impl<V: Value, const N: usize> Value for WithDimensions<V, N> {
     const SHAPE: crate::descriptor::FieldShape<'static> = V::SHAPE;
+    const UNIT: crate::Unit = V::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         self.value.write(Wrapper {
@@ -357,6 +361,10 @@ impl<V: MetricValue, const N: usize> MetricValue for WithDimensions<V, N> {
 impl<E: Entry, const N: usize> Entry for WithDimensions<E, N> {
     fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
         self.value.write(&mut self.entry_writer_wrapper(writer))
+    }
+
+    fn descriptors(&self) -> crate::Descriptors<'_> {
+        self.value.descriptors()
     }
 }
 

--- a/metrique-writer-core/src/value/dimensions.rs
+++ b/metrique-writer-core/src/value/dimensions.rs
@@ -340,6 +340,8 @@ impl<W: ValueWriter> ValueWriter for Wrapper<'_, W> {
 }
 
 impl<V: Value, const N: usize> Value for WithDimensions<V, N> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = V::SHAPE;
+
     fn write(&self, writer: impl ValueWriter) {
         self.value.write(Wrapper {
             value: writer,

--- a/metrique-writer-core/src/value/force.rs
+++ b/metrique-writer-core/src/value/force.rs
@@ -119,6 +119,8 @@ impl<T, FLAGS: FlagConstructor> ForceFlag<T, FLAGS> {
 }
 
 impl<T: Value, FLAGS: FlagConstructor> Value for ForceFlag<T, FLAGS> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+
     fn write(&self, writer: impl ValueWriter) {
         struct Wrapper<W, FLAGS: FlagConstructor>(W, PhantomData<FLAGS>);
 

--- a/metrique-writer-core/src/value/force.rs
+++ b/metrique-writer-core/src/value/force.rs
@@ -120,6 +120,7 @@ impl<T, FLAGS: FlagConstructor> ForceFlag<T, FLAGS> {
 
 impl<T: Value, FLAGS: FlagConstructor> Value for ForceFlag<T, FLAGS> {
     const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+    const UNIT: crate::Unit = T::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         struct Wrapper<W, FLAGS: FlagConstructor>(W, PhantomData<FLAGS>);

--- a/metrique-writer-core/src/value/formatter.rs
+++ b/metrique-writer-core/src/value/formatter.rs
@@ -77,9 +77,10 @@ impl Liftability for NotLifted {}
 pub trait ValueFormatter<V: ?Sized, L: Liftability = Lifted> {
     /// The shape of values produced by this formatter.
     ///
-    /// Defaults to [`FieldShape::Opaque`]. Override when the formatter always
+    /// Defaults to [`Opaque`](crate::descriptor::FieldShape::Opaque). Override when the formatter always
     /// produces a known wire shape (e.g. formatters that call `writer.string()`
-    /// should return `Known(String)`).
+    /// should return `Known(String)`, formatters that call `writer.metric()`
+    /// should return `Known(F64)` or the appropriate numeric shape).
     #[cfg(not(metrique_require_explicit_impls))]
     const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Opaque;
     /// The shape of values produced by this formatter.

--- a/metrique-writer-core/src/value/formatter.rs
+++ b/metrique-writer-core/src/value/formatter.rs
@@ -191,6 +191,7 @@ where
     VF: ValueFormatter<V, L>,
 {
     const SHAPE: crate::descriptor::FieldShape<'static> = <VF as ValueFormatter<V, L>>::SHAPE;
+    const UNIT: crate::Unit = crate::Unit::None;
 
     fn write(&self, writer: impl ValueWriter) {
         VF::format_value(writer, self.1);

--- a/metrique-writer-core/src/value/formatter.rs
+++ b/metrique-writer-core/src/value/formatter.rs
@@ -75,6 +75,13 @@ impl Liftability for NotLifted {}
 /// }
 /// ```
 pub trait ValueFormatter<V: ?Sized, L: Liftability = Lifted> {
+    /// The shape of values produced by this formatter.
+    ///
+    /// Defaults to [`FieldShape::Opaque`]. Override when the formatter always
+    /// produces a known wire shape (e.g. formatters that call `writer.string()`
+    /// should return `Known(String)`).
+    const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Opaque;
+
     /// Write `value` to `writer`
     fn format_value(writer: impl ValueWriter, value: &V);
 }
@@ -95,6 +102,9 @@ pub trait ValueFormatter<V: ?Sized, L: Liftability = Lifted> {
 pub struct ToString;
 
 impl<T: Display + ?Sized> ValueFormatter<T, NotLifted> for ToString {
+    const SHAPE: crate::descriptor::FieldShape<'static> =
+        crate::descriptor::FieldShape::Known(crate::descriptor::KnownShape::String);
+
     fn format_value(writer: impl ValueWriter, value: &T) {
         writer.string(&value.to_string());
     }
@@ -104,6 +114,8 @@ impl<V: ?Sized, F: ?Sized> ValueFormatter<&V> for F
 where
     F: ValueFormatter<V>,
 {
+    const SHAPE: crate::descriptor::FieldShape<'static> = <F as ValueFormatter<V>>::SHAPE;
+
     fn format_value(writer: impl ValueWriter, value: &&V) {
         <Self as ValueFormatter<V>>::format_value(writer, value)
     }
@@ -113,6 +125,10 @@ impl<V, F: ?Sized> ValueFormatter<Option<V>> for F
 where
     F: ValueFormatter<V>,
 {
+    const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Optional(
+        crate::descriptor::ShapeRef::new(&<F as ValueFormatter<V>>::SHAPE),
+    );
+
     fn format_value(writer: impl ValueWriter, value: &Option<V>) {
         if let Some(value) = value {
             <Self as ValueFormatter<V>>::format_value(writer, value)
@@ -124,6 +140,8 @@ impl<V: ?Sized, F: ?Sized> ValueFormatter<Box<V>> for F
 where
     F: ValueFormatter<V>,
 {
+    const SHAPE: crate::descriptor::FieldShape<'static> = <F as ValueFormatter<V>>::SHAPE;
+
     fn format_value(writer: impl ValueWriter, value: &Box<V>) {
         <Self as ValueFormatter<V>>::format_value(writer, value)
     }
@@ -133,6 +151,8 @@ impl<V: ?Sized, F: ?Sized> ValueFormatter<Arc<V>> for F
 where
     F: ValueFormatter<V>,
 {
+    const SHAPE: crate::descriptor::FieldShape<'static> = <F as ValueFormatter<V>>::SHAPE;
+
     fn format_value(writer: impl ValueWriter, value: &Arc<V>) {
         <Self as ValueFormatter<V>>::format_value(writer, value)
     }
@@ -142,6 +162,8 @@ impl<V: ToOwned + ?Sized, F: ?Sized> ValueFormatter<Cow<'_, V>> for F
 where
     F: ValueFormatter<V>,
 {
+    const SHAPE: crate::descriptor::FieldShape<'static> = <F as ValueFormatter<V>>::SHAPE;
+
     fn format_value(writer: impl ValueWriter, value: &Cow<V>) {
         <Self as ValueFormatter<V>>::format_value(writer, value)
     }
@@ -164,6 +186,8 @@ impl<V, VF, L: Liftability> super::Value for FormattedValue<'_, V, VF, L>
 where
     VF: ValueFormatter<V, L>,
 {
+    const SHAPE: crate::descriptor::FieldShape<'static> = <VF as ValueFormatter<V, L>>::SHAPE;
+
     fn write(&self, writer: impl ValueWriter) {
         VF::format_value(writer, self.1);
     }

--- a/metrique-writer-core/src/value/formatter.rs
+++ b/metrique-writer-core/src/value/formatter.rs
@@ -80,7 +80,11 @@ pub trait ValueFormatter<V: ?Sized, L: Liftability = Lifted> {
     /// Defaults to [`FieldShape::Opaque`]. Override when the formatter always
     /// produces a known wire shape (e.g. formatters that call `writer.string()`
     /// should return `Known(String)`).
+    #[cfg(not(metrique_require_explicit_impls))]
     const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Opaque;
+    /// The shape of values produced by this formatter.
+    #[cfg(metrique_require_explicit_impls)]
+    const SHAPE: crate::descriptor::FieldShape<'static>;
 
     /// Write `value` to `writer`
     fn format_value(writer: impl ValueWriter, value: &V);

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -39,6 +39,12 @@ use crate::{
     note = "If `{Self}` is a metric *entry*, flatten it using `#[metrics(flatten)]`"
 )]
 pub trait Value {
+    /// The statically-known shape of this value type for descriptor-aware sinks.
+    ///
+    /// Defaults to [`FieldShape::Opaque`] when not overridden. Sinks use this to
+    /// determine wire encoding without observing a live write.
+    const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Opaque;
+
     /// Write the value to the metric entry. This must never panic, but invalid values may trigger a validaiton panic on
     /// [`crate::EntrySink::append()`] for test sinks or a `tracing` event on production queues.
     fn write(&self, writer: impl ValueWriter);
@@ -221,12 +227,17 @@ pub trait MetricValue: Value {
 // Delegate Value impls for references and standard containers
 
 impl<T: Value + ?Sized> Value for &T {
+    const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)
     }
 }
 
 impl<T: Value> Value for Option<T> {
+    const SHAPE: crate::descriptor::FieldShape<'static> =
+        crate::descriptor::FieldShape::Optional(crate::descriptor::ShapeRef::new(&T::SHAPE));
+
     fn write(&self, writer: impl ValueWriter) {
         if let Some(data) = self.as_ref() {
             data.write(writer)
@@ -235,18 +246,24 @@ impl<T: Value> Value for Option<T> {
 }
 
 impl<T: Value> Value for Box<T> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)
     }
 }
 
 impl<T: Value + ?Sized> Value for Arc<T> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)
     }
 }
 
 impl<T: Value + ToOwned + ?Sized> Value for Cow<'_, T> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)
     }

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -45,6 +45,13 @@ pub trait Value {
     /// determine wire encoding without observing a live write.
     const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Opaque;
 
+    /// The unit this value type is reported in.
+    ///
+    /// Defaults to [`Unit::None`] (unitless). Types with inherent units (like
+    /// `Duration`, which reports in milliseconds) override this. Explicit
+    /// `#[metrics(unit = X)]` takes precedence.
+    const UNIT: crate::Unit = crate::Unit::None;
+
     /// Write the value to the metric entry. This must never panic, but invalid values may trigger a validaiton panic on
     /// [`crate::EntrySink::append()`] for test sinks or a `tracing` event on production queues.
     fn write(&self, writer: impl ValueWriter);

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -43,14 +43,22 @@ pub trait Value {
     ///
     /// Defaults to [`FieldShape::Opaque`] when not overridden. Sinks use this to
     /// determine wire encoding without observing a live write.
+    #[cfg(not(metrique_require_explicit_impls))]
     const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Opaque;
+    /// The statically-known shape of this value type for descriptor-aware sinks.
+    #[cfg(metrique_require_explicit_impls)]
+    const SHAPE: crate::descriptor::FieldShape<'static>;
 
     /// The unit this value type is reported in.
     ///
     /// Defaults to [`Unit::None`] (unitless). Types with inherent units (like
     /// `Duration`, which reports in milliseconds) override this. Explicit
     /// `#[metrics(unit = X)]` takes precedence.
+    #[cfg(not(metrique_require_explicit_impls))]
     const UNIT: crate::Unit = crate::Unit::None;
+    /// The unit this value type is reported in.
+    #[cfg(metrique_require_explicit_impls)]
+    const UNIT: crate::Unit;
 
     /// Write the value to the metric entry. This must never panic, but invalid values may trigger a validaiton panic on
     /// [`crate::EntrySink::append()`] for test sinks or a `tracing` event on production queues.
@@ -235,6 +243,7 @@ pub trait MetricValue: Value {
 
 impl<T: Value + ?Sized> Value for &T {
     const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+    const UNIT: crate::Unit = T::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -41,7 +41,7 @@ use crate::{
 pub trait Value {
     /// The statically-known shape of this value type for descriptor-aware sinks.
     ///
-    /// Defaults to [`FieldShape::Opaque`] when not overridden. Sinks use this to
+    /// Defaults to [`Opaque`](crate::descriptor::FieldShape::Opaque) when not overridden. Sinks use this to
     /// determine wire encoding without observing a live write.
     #[cfg(not(metrique_require_explicit_impls))]
     const SHAPE: crate::descriptor::FieldShape<'static> = crate::descriptor::FieldShape::Opaque;

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -188,6 +188,10 @@ pub enum Observation {
 }
 
 impl Value for Observation {
+    const SHAPE: crate::descriptor::FieldShape<'static> =
+        crate::descriptor::FieldShape::Known(crate::descriptor::KnownShape::F64);
+    const UNIT: crate::Unit = crate::Unit::None;
+
     fn write(&self, writer: impl ValueWriter) {
         writer.metric([*self], unit::None::UNIT, [], MetricFlags::empty())
     }
@@ -253,6 +257,7 @@ impl<T: Value + ?Sized> Value for &T {
 impl<T: Value> Value for Option<T> {
     const SHAPE: crate::descriptor::FieldShape<'static> =
         crate::descriptor::FieldShape::Optional(crate::descriptor::ShapeRef::new(&T::SHAPE));
+    const UNIT: crate::Unit = T::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         if let Some(data) = self.as_ref() {
@@ -263,6 +268,7 @@ impl<T: Value> Value for Option<T> {
 
 impl<T: Value> Value for Box<T> {
     const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+    const UNIT: crate::Unit = T::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)
@@ -271,6 +277,7 @@ impl<T: Value> Value for Box<T> {
 
 impl<T: Value + ?Sized> Value for Arc<T> {
     const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+    const UNIT: crate::Unit = T::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)
@@ -279,6 +286,7 @@ impl<T: Value + ?Sized> Value for Arc<T> {
 
 impl<T: Value + ToOwned + ?Sized> Value for Cow<'_, T> {
     const SHAPE: crate::descriptor::FieldShape<'static> = T::SHAPE;
+    const UNIT: crate::Unit = T::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         (**self).write(writer)

--- a/metrique-writer-core/src/value/primitive.rs
+++ b/metrique-writer-core/src/value/primitive.rs
@@ -110,6 +110,7 @@ float!(f64, KnownShape::F64);
 
 impl Value for Duration {
     const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::F64);
+    const UNIT: crate::Unit = crate::Unit::Second(Milli);
 
     #[inline]
     fn write(&self, writer: impl ValueWriter) {

--- a/metrique-writer-core/src/value/primitive.rs
+++ b/metrique-writer-core/src/value/primitive.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use super::{MetricValue, Observation, Value, ValueWriter};
 use crate::{
     Unit,
+    descriptor::{FieldShape, KnownShape, ShapeRef},
     unit::{self, NegativeScale::Milli},
 };
 
@@ -19,6 +20,8 @@ fn duration_as_millis_with_nano_precision(duration: Duration) -> f64 {
 }
 
 impl Value for str {
+    const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::String);
+
     #[inline]
     fn write(&self, writer: impl ValueWriter) {
         writer.string(self)
@@ -26,6 +29,8 @@ impl Value for str {
 }
 
 impl Value for String {
+    const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::String);
+
     #[inline]
     fn write(&self, writer: impl ValueWriter) {
         writer.string(self)
@@ -33,8 +38,10 @@ impl Value for String {
 }
 
 macro_rules! counter {
-    ($t:ty) => {
+    ($t:ty, $shape:expr) => {
         impl Value for $t {
+            const SHAPE: FieldShape<'static> = FieldShape::Known($shape);
+
             #[inline]
             fn write(&self, writer: impl ValueWriter) {
                 writer.metric(
@@ -52,13 +59,15 @@ macro_rules! counter {
     };
 }
 
-counter!(u64);
-counter!(u32);
-counter!(u16);
-counter!(u8);
-counter!(bool);
+counter!(u64, KnownShape::U64);
+counter!(u32, KnownShape::U32);
+counter!(u16, KnownShape::U16);
+counter!(u8, KnownShape::U8);
+counter!(bool, KnownShape::Bool);
 
 impl Value for usize {
+    const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::U64);
+
     #[inline]
     fn write(&self, writer: impl ValueWriter) {
         writer.metric(
@@ -75,8 +84,10 @@ impl MetricValue for usize {
 }
 
 macro_rules! float {
-    ($t:ty) => {
+    ($t:ty, $shape:expr) => {
         impl Value for $t {
+            const SHAPE: FieldShape<'static> = FieldShape::Known($shape);
+
             #[inline]
             fn write(&self, writer: impl ValueWriter) {
                 writer.metric(
@@ -94,10 +105,12 @@ macro_rules! float {
     };
 }
 
-float!(f32);
-float!(f64);
+float!(f32, KnownShape::F32);
+float!(f64, KnownShape::F64);
 
 impl Value for Duration {
+    const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::F64);
+
     #[inline]
     fn write(&self, writer: impl ValueWriter) {
         writer.metric(
@@ -124,12 +137,16 @@ impl MetricValue for Duration {
 }
 
 impl<V: Value> Value for Vec<V> {
+    const SHAPE: FieldShape<'static> = FieldShape::List(ShapeRef::new(&V::SHAPE));
+
     fn write(&self, writer: impl ValueWriter) {
         writer.values(self.iter());
     }
 }
 
 impl<V: Value> Value for [V] {
+    const SHAPE: FieldShape<'static> = FieldShape::List(ShapeRef::new(&V::SHAPE));
+
     fn write(&self, writer: impl ValueWriter) {
         writer.values(self.iter());
     }

--- a/metrique-writer-core/src/value/primitive.rs
+++ b/metrique-writer-core/src/value/primitive.rs
@@ -21,6 +21,7 @@ fn duration_as_millis_with_nano_precision(duration: Duration) -> f64 {
 
 impl Value for str {
     const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::String);
+    const UNIT: crate::Unit = crate::Unit::None;
 
     #[inline]
     fn write(&self, writer: impl ValueWriter) {
@@ -30,6 +31,7 @@ impl Value for str {
 
 impl Value for String {
     const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::String);
+    const UNIT: crate::Unit = crate::Unit::None;
 
     #[inline]
     fn write(&self, writer: impl ValueWriter) {
@@ -41,6 +43,7 @@ macro_rules! counter {
     ($t:ty, $shape:expr) => {
         impl Value for $t {
             const SHAPE: FieldShape<'static> = FieldShape::Known($shape);
+            const UNIT: crate::Unit = crate::Unit::None;
 
             #[inline]
             fn write(&self, writer: impl ValueWriter) {
@@ -67,6 +70,7 @@ counter!(bool, KnownShape::Bool);
 
 impl Value for usize {
     const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::U64);
+    const UNIT: crate::Unit = crate::Unit::None;
 
     #[inline]
     fn write(&self, writer: impl ValueWriter) {
@@ -87,6 +91,7 @@ macro_rules! float {
     ($t:ty, $shape:expr) => {
         impl Value for $t {
             const SHAPE: FieldShape<'static> = FieldShape::Known($shape);
+            const UNIT: crate::Unit = crate::Unit::None;
 
             #[inline]
             fn write(&self, writer: impl ValueWriter) {
@@ -139,6 +144,7 @@ impl MetricValue for Duration {
 
 impl<V: Value> Value for Vec<V> {
     const SHAPE: FieldShape<'static> = FieldShape::List(ShapeRef::new(&V::SHAPE));
+    const UNIT: crate::Unit = V::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         writer.values(self.iter());
@@ -147,6 +153,7 @@ impl<V: Value> Value for Vec<V> {
 
 impl<V: Value> Value for [V] {
     const SHAPE: FieldShape<'static> = FieldShape::List(ShapeRef::new(&V::SHAPE));
+    const UNIT: crate::Unit = V::UNIT;
 
     fn write(&self, writer: impl ValueWriter) {
         writer.values(self.iter());

--- a/metrique-writer/Cargo.toml
+++ b/metrique-writer/Cargo.toml
@@ -8,6 +8,9 @@ description = "Library for wide event metrics - writer-side interface"
 repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(metrique_require_explicit_impls)'] }
+
 [dependencies]
 ahash = { workspace = true }
 smallvec = { workspace = true, features = [

--- a/metrique-writer/src/entry/dimensions.rs
+++ b/metrique-writer/src/entry/dimensions.rs
@@ -162,6 +162,10 @@ impl<E: Entry, const N: usize> Entry for WithGlobalDimensions<E, N> {
             global_dimensions_denylist: self.global_dimensions_denylist(),
         })
     }
+
+    fn descriptors(&self) -> metrique_writer_core::Descriptors<'_> {
+        self.entry.descriptors()
+    }
 }
 
 struct ValueWrapper<'a, V> {
@@ -170,6 +174,9 @@ struct ValueWrapper<'a, V> {
 }
 
 impl<V: Value> Value for ValueWrapper<'_, V> {
+    const SHAPE: crate::FieldShape<'static> = V::SHAPE;
+    const UNIT: crate::Unit = V::UNIT;
+
     fn write(&self, writer: impl ValueWriter) {
         struct ValueWriterWrapper<'a, W> {
             writer: W,

--- a/metrique-writer/src/entry/map.rs
+++ b/metrique-writer/src/entry/map.rs
@@ -50,6 +50,10 @@ where
             writer.value(key.into(), value);
         }
     }
+
+    fn descriptors(&self) -> crate::Descriptors<'_> {
+        crate::Descriptors::Unavailable
+    }
 }
 
 impl<E> EnumMapEntry<E> {

--- a/metrique-writer/src/lib.rs
+++ b/metrique-writer/src/lib.rs
@@ -13,7 +13,9 @@ pub use metrique_writer_core::unit::{Convert, Unit};
 pub use metrique_writer_core::value::{
     Distribution, MetricFlags, MetricValue, Observation, Value, ValueWriter,
 };
-pub use metrique_writer_core::{ValidationError, ValidationErrorBuilder};
+pub use metrique_writer_core::{
+    Descriptors, FieldShape, KnownShape, ShapeRef, ValidationError, ValidationErrorBuilder,
+};
 pub use metrique_writer_macro::Entry;
 
 pub use crate::sink::AttachGlobalEntrySinkExt;

--- a/metrique-writer/src/value/distribution.rs
+++ b/metrique-writer/src/value/distribution.rs
@@ -63,6 +63,9 @@ pub type VecDistribution<V> = Distribution<V, 0>;
 
 #[diagnostic::do_not_recommend]
 impl<V: MetricValue, const N: usize> Value for Distribution<V, N> {
+    const SHAPE: crate::FieldShape<'static> = crate::FieldShape::Known(crate::KnownShape::F64);
+    const UNIT: crate::Unit = <V::Unit as UnitTag>::UNIT;
+
     fn write(&self, writer: impl ValueWriter) {
         if self.values.is_empty() {
             return;
@@ -88,6 +91,10 @@ impl<V: MetricValue, const N: usize> Value for Distribution<V, N> {
         }
 
         impl Value for Collected<'_> {
+            const SHAPE: crate::FieldShape<'static> =
+                crate::FieldShape::Known(crate::KnownShape::F64);
+            const UNIT: crate::Unit = crate::Unit::None;
+
             fn write(&self, writer: impl ValueWriter) {
                 match &self.result {
                     Ok(obs) => {
@@ -364,6 +371,9 @@ impl<U: UnitTag, V: Into<f64>> Extend<V> for Mean<U> {
 }
 
 impl<U: UnitTag> Value for Mean<U> {
+    const SHAPE: crate::FieldShape<'static> = crate::FieldShape::Known(crate::KnownShape::F64);
+    const UNIT: crate::Unit = U::UNIT;
+
     fn write(&self, writer: impl ValueWriter) {
         if self.occurrences > 0 {
             writer.metric(

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/awslabs/metrique"
 readme = "README.md"
 rust-version = "1.91" # See .github/workflows/ci.yml
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(metrique_require_explicit_impls)'] }
+
 [features]
 default = ["service-metrics"]
 # re-exports metrique-writer-format-emf as metrique::emf

--- a/metrique/docs/extending.md
+++ b/metrique/docs/extending.md
@@ -178,9 +178,12 @@ Since `StringValue` closes to `String`, the descriptor reports `Known(String)` f
 
 ## Recipe: a custom value formatter
 
-When the value is fine but you want to control _how it is rendered_ (without a new type),
-implement [`ValueFormatter`] and point a field at it with `#[metrics(format = ...)]`. Here a
-[`SystemTime`] is emitted as an RFC 3339 UTC string:
+A [`ValueFormatter`] controls how a value is written without introducing a new type.
+Despite the name, a formatter is not limited to string output: `format_value` receives a
+[`ValueWriter`] and may call `writer.string()` for properties, `writer.metric()` for numeric
+observations, or even `writer.error()`. Use `#[metrics(format = ...)]` to attach one to a field.
+
+Here a [`SystemTime`] is emitted as an RFC 3339 UTC string:
 
 ```rust
 use metrique::unit_of_work::metrics;
@@ -205,17 +208,18 @@ struct MyMetric {
 }
 ```
 
-Formatters that always produce a known wire type should override `ValueFormatter::SHAPE` so descriptor-aware sinks can pre-register the field correctly. `AsUtcDate` always writes a string, so:
+Formatters that always produce a known wire type should override `ValueFormatter::SHAPE` so descriptor-aware sinks can pre-register the field correctly. `AsUtcDate` always calls `writer.string()`, so its shape is `Known(String)`:
 
 ```rust,ignore
+use metrique_writer_core::descriptor::{FieldShape, KnownShape};
+
 impl metrique::writer::value::ValueFormatter<SystemTime> for AsUtcDate {
-    const SHAPE: metrique_writer_core::descriptor::FieldShape<'static> =
-        metrique_writer_core::descriptor::FieldShape::Known(
-            metrique_writer_core::descriptor::KnownShape::String,
-        );
+    const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::String);
     fn format_value(writer: impl metrique::writer::ValueWriter, value: &SystemTime) { /* ... */ }
 }
 ```
+
+A formatter that always calls `writer.metric()` should return `Known(F64)` (or the appropriate numeric shape). Formatters whose output varies at runtime should specify `FieldShape::Opaque` explicitly.
 
 The built-in `ToString` formatter already provides `Known(String)`.
 

--- a/metrique/docs/extending.md
+++ b/metrique/docs/extending.md
@@ -356,3 +356,4 @@ the helpers in the [testing guide][`testing`] (`test_metric`) to assert on the c
 [`Histogram`]: https://docs.rs/metrique-aggregation/latest/metrique_aggregation/struct.Histogram.html
 [`Duration`]: https://doc.rust-lang.org/std/time/struct.Duration.html
 [`SystemTime`]: https://doc.rust-lang.org/std/time/struct.SystemTime.html
+[`ValueWriter`]: https://docs.rs/metrique/latest/metrique/writer/trait.ValueWriter.html

--- a/metrique/docs/extending.md
+++ b/metrique/docs/extending.md
@@ -116,7 +116,7 @@ impl CloseValue for ConcurrentCounter {
 ```
 
 `Closed` is `u64`, which already implements [`metrique_writer::Value`], so `ConcurrentCounter`
-drops straight into a `#[metrics]` struct as a field. The descriptor shape resolves automatically through the closed type: `u64` has `Value::SHAPE = Known(U64)`, so the field's descriptor reports that shape with no extra work. Just like the built-in scalars, a custom
+drops straight into a `#[metrics]` struct as a field. The descriptor shape comes from the closed type: `u64` has `Value::SHAPE = Known(U64)`, so the field's descriptor reports that shape. Similarly, `Value::UNIT` provides the inherent unit (e.g. `Duration` reports `Millisecond`); types without a natural unit default to unitless. Just like the built-in scalars, a custom
 leaf type takes a unit through `#[metrics(unit = ...)]`:
 
 ```rust
@@ -174,7 +174,7 @@ struct MyMetric {
 }
 ```
 
-Since `StringValue` closes to `String`, the descriptor reports `Known(String)` for this field automatically.
+Since `StringValue` closes to `String`, the descriptor reports `Known(String)` for this field.
 
 ## Recipe: a custom value formatter
 
@@ -204,6 +204,20 @@ struct MyMetric {
     my_field: SystemTime,
 }
 ```
+
+Formatters that always produce a known wire type should override `ValueFormatter::SHAPE` so descriptor-aware sinks can pre-register the field correctly. `AsUtcDate` always writes a string, so:
+
+```rust,ignore
+impl metrique::writer::value::ValueFormatter<SystemTime> for AsUtcDate {
+    const SHAPE: metrique_writer_core::descriptor::FieldShape<'static> =
+        metrique_writer_core::descriptor::FieldShape::Known(
+            metrique_writer_core::descriptor::KnownShape::String,
+        );
+    fn format_value(writer: impl metrique::writer::ValueWriter, value: &SystemTime) { /* ... */ }
+}
+```
+
+The built-in `ToString` formatter already provides `Known(String)`.
 
 ## Recipe (advanced): a manual entry
 
@@ -293,8 +307,6 @@ for field in segment.fields() {
     }
 }
 ```
-
-Shape resolution happens through `Value::SHAPE`, a defaulted associated const. All built-in types provide shapes; custom `Value` types default to `Opaque` unless they override the const.
 
 ### Reading flag data from descriptors
 

--- a/metrique/docs/extending.md
+++ b/metrique/docs/extending.md
@@ -116,7 +116,7 @@ impl CloseValue for ConcurrentCounter {
 ```
 
 `Closed` is `u64`, which already implements [`metrique_writer::Value`], so `ConcurrentCounter`
-drops straight into a `#[metrics]` struct as a field. Just like the built-in scalars, a custom
+drops straight into a `#[metrics]` struct as a field. The descriptor shape resolves automatically through the closed type: `u64` has `Value::SHAPE = Known(U64)`, so the field's descriptor reports that shape with no extra work. Just like the built-in scalars, a custom
 leaf type takes a unit through `#[metrics(unit = ...)]`:
 
 ```rust
@@ -173,6 +173,8 @@ struct MyMetric {
     field: StringValue,
 }
 ```
+
+Since `StringValue` closes to `String`, the descriptor reports `Known(String)` for this field automatically.
 
 ## Recipe: a custom value formatter
 
@@ -252,6 +254,8 @@ fn handle_entry(entry: &impl Entry) {
                     // Or just the base (un-prefixed) name:
                     let base = field.base_name();
                     let unit = field.unit();
+                    // Field shape tells the sink what wire type to expect:
+                    let shape = field.shape();
                     // Check flags for format-specific behavior:
                     // field.flags().any(|f| f.is::<MyFlag>())
                 }
@@ -269,6 +273,28 @@ fn handle_entry(entry: &impl Entry) {
 ### Positional correspondence
 
 Descriptor fields are ordered to match `Entry::write` callback order. When walking the write path, you can correlate the Nth value callback with the Nth field in the descriptor. Multi-segment descriptors (from flattened children) concatenate in write order.
+
+### Using field shapes
+
+`field.shape()` returns the statically-known wire shape of the field's closed value. Use it to select encoding strategies, register schema types, or skip unsupported shapes:
+
+```rust,ignore
+use metrique_writer_core::descriptor::{FieldShape, KnownShape};
+
+for field in segment.fields() {
+    match field.shape() {
+        FieldShape::Known(KnownShape::U64) => { /* register as integer gauge */ }
+        FieldShape::Known(KnownShape::F64) => { /* register as float gauge */ }
+        FieldShape::Known(KnownShape::String) => { /* register as attribute */ }
+        FieldShape::Optional(inner) => { /* nullable variant of inner.get() */ }
+        FieldShape::List(inner) => { /* repeated field of inner.get() */ }
+        FieldShape::Opaque => { /* fall back to write-path observation */ }
+        _ => { /* forward compat */ }
+    }
+}
+```
+
+Shape resolution happens through `Value::SHAPE`, a defaulted associated const. All built-in types provide shapes; custom `Value` types default to `Opaque` unless they override the const.
 
 ### Reading flag data from descriptors
 

--- a/metrique/src/emf.rs
+++ b/metrique/src/emf.rs
@@ -31,6 +31,10 @@ impl Entry for SetEntryDimensions {
     fn write<'a>(&'a self, writer: &mut impl metrique_writer_core::EntryWriter<'a>) {
         writer.config(&self.dimensions);
     }
+
+    fn descriptors(&self) -> metrique_writer_core::Descriptors<'_> {
+        metrique_writer_core::Descriptors::Unavailable
+    }
 }
 
 pub use metrique_writer_core::config::EntryDimensions as __EntryDimensions;

--- a/metrique/src/flex.rs
+++ b/metrique/src/flex.rs
@@ -141,6 +141,10 @@ impl<T: Value> Entry for FlexEntry<T> {
     fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
         writer.value(Cow::Borrowed(self.key.as_ref()), &self.value);
     }
+
+    fn descriptors(&self) -> metrique_writer_core::Descriptors<'_> {
+        metrique_writer_core::Descriptors::Unavailable
+    }
 }
 
 impl<T: Value, NS: NameStyle> InflectableEntry<NS> for FlexEntry<T> {

--- a/metrique/src/timers.rs
+++ b/metrique/src/timers.rs
@@ -169,6 +169,11 @@ pub struct TimestampFormat<Unit> {
 }
 
 impl<U: TimestampToStr> ValueFormatter<TimestampValue> for TimestampFormat<U> {
+    const SHAPE: metrique_writer_core::descriptor::FieldShape<'static> =
+        metrique_writer_core::descriptor::FieldShape::Known(
+            metrique_writer_core::descriptor::KnownShape::String,
+        );
+
     fn format_value(writer: impl metrique_writer_core::ValueWriter, value: &TimestampValue) {
         U::to_str(value.duration_since_epoch, |s| writer.string(s));
     }

--- a/metrique/src/timers.rs
+++ b/metrique/src/timers.rs
@@ -137,6 +137,10 @@ pub struct TimestampValue {
 }
 
 impl Value for TimestampValue {
+    const SHAPE: metrique_writer_core::FieldShape<'static> =
+        metrique_writer_core::FieldShape::Known(metrique_writer_core::KnownShape::String);
+    const UNIT: metrique_writer_core::Unit = metrique_writer_core::Unit::None;
+
     fn write(&self, writer: impl metrique_writer_core::ValueWriter) {
         // by default, use the milliseconds format
         <Millisecond as TimestampToStr>::to_str(self.duration_since_epoch, |v| writer.string(v));

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -1362,3 +1362,319 @@ fn flatten_site_default_flags_combines_with_prefix() {
             .any(|fl| fl.type_id() == TypeId::of::<AuditExport>())
     );
 }
+
+// ==================== Shape resolution tests ====================
+
+mod shape_tests {
+    use metrique::unit_of_work::metrics;
+    use metrique::writer::Entry;
+    use metrique_writer_core::descriptor::{FieldShape, KnownShape, ShapeRef};
+    use std::borrow::Cow;
+    use std::time::Duration;
+
+    /// Helper: assert the shape of the Nth field in the first descriptor segment.
+    fn assert_field_shape(entry: &impl Entry, idx: usize, expected: FieldShape<'static>) {
+        let descs = entry.descriptors().unwrap();
+        let shape = descs[0].fields().nth(idx).unwrap().shape();
+        assert_eq!(shape, expected, "field index {idx}");
+    }
+
+    // -- Scalars --
+
+    #[metrics]
+    #[derive(Default)]
+    struct ScalarShapes {
+        a_bool: bool,
+        a_u8: u8,
+        a_u16: u16,
+        a_u32: u32,
+        a_u64: u64,
+        a_usize: usize,
+        a_f32: f32,
+        a_f64: f64,
+        a_string: String,
+    }
+
+    #[test]
+    fn scalar_shapes() {
+        let m = ScalarShapes::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::Bool));
+        assert_field_shape(&entry, 1, FieldShape::Known(KnownShape::U8));
+        assert_field_shape(&entry, 2, FieldShape::Known(KnownShape::U16));
+        assert_field_shape(&entry, 3, FieldShape::Known(KnownShape::U32));
+        assert_field_shape(&entry, 4, FieldShape::Known(KnownShape::U64));
+        assert_field_shape(&entry, 5, FieldShape::Known(KnownShape::U64)); // usize -> U64
+        assert_field_shape(&entry, 6, FieldShape::Known(KnownShape::F32));
+        assert_field_shape(&entry, 7, FieldShape::Known(KnownShape::F64));
+        assert_field_shape(&entry, 8, FieldShape::Known(KnownShape::String));
+    }
+
+    // -- Duration and Timer (close through CloseValue) --
+
+    #[metrics]
+    #[derive(Default)]
+    struct DurationShapes {
+        dur: Duration,
+        timer: metrique::timers::Timer,
+    }
+
+    #[test]
+    fn duration_and_timer_shapes() {
+        let m = DurationShapes::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // Duration writes as f64 (millis)
+        assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::F64));
+        // Timer closes to Duration, same shape
+        assert_field_shape(&entry, 1, FieldShape::Known(KnownShape::F64));
+    }
+
+    // -- Optional --
+
+    #[metrics]
+    #[derive(Default)]
+    struct OptionalShapes {
+        opt_u64: Option<u64>,
+        opt_string: Option<String>,
+        opt_duration: Option<Duration>,
+    }
+
+    #[test]
+    fn optional_shapes() {
+        let m = OptionalShapes::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        static U64_SHAPE: FieldShape = FieldShape::Known(KnownShape::U64);
+        static STRING_SHAPE: FieldShape = FieldShape::Known(KnownShape::String);
+        static F64_SHAPE: FieldShape = FieldShape::Known(KnownShape::F64);
+        assert_field_shape(&entry, 0, FieldShape::Optional(ShapeRef::new(&U64_SHAPE)));
+        assert_field_shape(
+            &entry,
+            1,
+            FieldShape::Optional(ShapeRef::new(&STRING_SHAPE)),
+        );
+        assert_field_shape(&entry, 2, FieldShape::Optional(ShapeRef::new(&F64_SHAPE)));
+    }
+
+    // -- Vec / List --
+
+    #[metrics]
+    #[derive(Default)]
+    struct ListShapes {
+        vec_u64: Vec<u64>,
+        vec_string: Vec<String>,
+    }
+
+    #[test]
+    fn list_shapes() {
+        let m = ListShapes::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        static U64_SHAPE: FieldShape = FieldShape::Known(KnownShape::U64);
+        static STRING_SHAPE: FieldShape = FieldShape::Known(KnownShape::String);
+        assert_field_shape(&entry, 0, FieldShape::List(ShapeRef::new(&U64_SHAPE)));
+        assert_field_shape(&entry, 1, FieldShape::List(ShapeRef::new(&STRING_SHAPE)));
+    }
+
+    // -- Nested composition: Option<Vec<T>>, Vec<Option<T>> --
+
+    #[metrics]
+    #[derive(Default)]
+    struct NestedShapes {
+        opt_vec: Option<Vec<u64>>,
+        vec_opt: Vec<Option<String>>,
+    }
+
+    #[test]
+    fn nested_composition_shapes() {
+        let m = NestedShapes::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // Option<Vec<u64>> -> Optional(List(Known(U64)))
+        static INNER_U64: FieldShape = FieldShape::Known(KnownShape::U64);
+        static LIST_U64: FieldShape = FieldShape::List(ShapeRef::new(&INNER_U64));
+        assert_field_shape(&entry, 0, FieldShape::Optional(ShapeRef::new(&LIST_U64)));
+        // Vec<Option<String>> -> List(Optional(Known(String)))
+        static INNER_STRING: FieldShape = FieldShape::Known(KnownShape::String);
+        static OPT_STRING: FieldShape = FieldShape::Optional(ShapeRef::new(&INNER_STRING));
+        assert_field_shape(&entry, 1, FieldShape::List(ShapeRef::new(&OPT_STRING)));
+    }
+
+    // -- Lifetimed types (Cow) --
+
+    #[metrics]
+    struct LifetimedShapes<'a> {
+        cow_str: Cow<'a, str>,
+        opt_cow: Option<Cow<'a, str>>,
+    }
+
+    #[test]
+    fn lifetimed_shapes() {
+        let m = LifetimedShapes {
+            cow_str: Cow::Borrowed("hello"),
+            opt_cow: None,
+        };
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // Cow<'a, str> closes to Cow<'a, str> which is Value with SHAPE = str::SHAPE = String
+        assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::String));
+        // Option<Cow<'a, str>> -> Optional(Known(String))
+        static INNER_STR: FieldShape = FieldShape::Known(KnownShape::String);
+        assert_field_shape(&entry, 1, FieldShape::Optional(ShapeRef::new(&INNER_STR)));
+    }
+
+    // -- Custom CloseValue resolves through closed type --
+
+    struct CustomGauge(f64);
+    impl Default for CustomGauge {
+        fn default() -> Self {
+            Self(0.0)
+        }
+    }
+    impl metrique::CloseValue for CustomGauge {
+        type Closed = f64;
+        fn close(self) -> f64 {
+            self.0
+        }
+    }
+    impl metrique::CloseValue for &'_ CustomGauge {
+        type Closed = f64;
+        fn close(self) -> f64 {
+            self.0
+        }
+    }
+
+    #[metrics]
+    #[derive(Default)]
+    struct CustomCloseShapes {
+        gauge: CustomGauge,
+    }
+
+    #[test]
+    fn custom_close_value_resolves_shape() {
+        let m = CustomCloseShapes::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // CustomGauge closes to f64, which has SHAPE = Known(F64)
+        assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::F64));
+    }
+
+    // -- no_close field: Value::SHAPE used directly --
+
+    #[derive(Clone, Default)]
+    struct OpaqueNoClose;
+    impl metrique::writer::Value for OpaqueNoClose {
+        fn write(&self, writer: impl metrique::writer::ValueWriter) {
+            writer.string("opaque");
+        }
+    }
+
+    #[metrics]
+    #[derive(Default)]
+    struct NoCloseShapes {
+        #[metrics(no_close)]
+        opaque: OpaqueNoClose,
+        normal: u64,
+    }
+
+    #[test]
+    fn no_close_field_uses_value_shape_directly() {
+        let m = NoCloseShapes::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // OpaqueNoClose doesn't override SHAPE, gets default Opaque
+        assert_field_shape(&entry, 0, FieldShape::Opaque);
+        // Normal field still resolves
+        assert_field_shape(&entry, 1, FieldShape::Known(KnownShape::U64));
+    }
+
+    // -- Custom type with SHAPE override --
+
+    #[derive(Clone, Default)]
+    struct TypedNoClose;
+    impl metrique::writer::Value for TypedNoClose {
+        const SHAPE: FieldShape<'static> = FieldShape::Known(KnownShape::String);
+        fn write(&self, writer: impl metrique::writer::ValueWriter) {
+            writer.string("typed");
+        }
+    }
+
+    #[metrics]
+    #[derive(Default)]
+    struct CustomShapeOverride {
+        #[metrics(no_close)]
+        typed: TypedNoClose,
+    }
+
+    #[test]
+    fn custom_value_shape_override() {
+        let m = CustomShapeOverride::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // TypedNoClose overrides SHAPE to Known(String)
+        assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::String));
+    }
+
+    // -- Wrapper passthrough (via CloseValue chain) --
+
+    #[metrics]
+    #[derive(Default)]
+    struct WrapperShapes {
+        arc_str: std::sync::Arc<String>,
+    }
+
+    #[test]
+    fn wrapper_shapes_passthrough() {
+        let m = WrapperShapes {
+            arc_str: std::sync::Arc::new("hello".to_string()),
+        };
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // Arc<String> closes to Arc<String>, Value impl forwards to String shape
+        assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::String));
+    }
+
+    // -- #[metrics(value)] struct and enum shape forwarding --
+
+    #[metrics(value)]
+    struct Percent(u8);
+
+    #[metrics(value(string))]
+    enum Operation {
+        CountDucks,
+        FeedDucks,
+    }
+
+    #[metrics]
+    struct ValueShapes {
+        pct: Percent,
+        op: Operation,
+    }
+
+    #[test]
+    fn metrics_value_forwards_shape() {
+        let m = ValueShapes {
+            pct: Percent(50),
+            op: Operation::CountDucks,
+        };
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // Percent(u8) wraps u8 -> Known(U8)
+        assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::U8));
+        // Operation is a string-value enum -> Known(String)
+        assert_field_shape(&entry, 1, FieldShape::Known(KnownShape::String));
+    }
+}

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -1427,10 +1427,27 @@ mod shape_tests {
         let closed = metrique::CloseValue::close(m);
         let entry = metrique::RootEntry::new(closed);
 
+        let descs = entry.descriptors().unwrap();
+        let fields: Vec<_> = descs[0].fields().collect();
+
         // Duration writes as f64 (millis)
         assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::F64));
         // Timer closes to Duration, same shape
         assert_field_shape(&entry, 1, FieldShape::Known(KnownShape::F64));
+
+        // Both resolve Millisecond unit from the type (no explicit #[metrics(unit = ...)] needed)
+        assert_eq!(
+            fields[0].unit(),
+            Some(metrique_writer_core::Unit::Second(
+                metrique_writer_core::unit::NegativeScale::Milli
+            ))
+        );
+        assert_eq!(
+            fields[1].unit(),
+            Some(metrique_writer_core::Unit::Second(
+                metrique_writer_core::unit::NegativeScale::Milli
+            ))
+        );
     }
 
     // -- Optional --
@@ -1676,5 +1693,36 @@ mod shape_tests {
         assert_field_shape(&entry, 0, FieldShape::Known(KnownShape::U8));
         // Operation is a string-value enum -> Known(String)
         assert_field_shape(&entry, 1, FieldShape::Known(KnownShape::String));
+    }
+
+    // -- Formatted fields: shape falls back to Opaque (formatter controls wire representation) --
+
+    struct AsString;
+    impl metrique::writer::value::ValueFormatter<bool> for AsString {
+        const SHAPE: metrique_writer_core::descriptor::FieldShape<'static> =
+            metrique_writer_core::descriptor::FieldShape::Known(
+                metrique_writer_core::descriptor::KnownShape::String,
+            );
+        fn format_value(writer: impl metrique::writer::ValueWriter, value: &bool) {
+            writer.string(if *value { "true" } else { "false" });
+        }
+    }
+
+    #[metrics]
+    #[derive(Default)]
+    struct FormattedShapes {
+        #[metrics(format = AsString)]
+        formatted_bool: bool,
+    }
+
+    #[test]
+    fn formatted_field_shape_is_opaque() {
+        let m = FormattedShapes::default();
+        let closed = metrique::CloseValue::close(m);
+        let entry = metrique::RootEntry::new(closed);
+
+        // Formatted fields fall back to Opaque because the raw type may not impl Value.
+        // ValueFormatter::SHAPE is available for sinks that want to query it separately.
+        assert_field_shape(&entry, 0, FieldShape::Opaque);
     }
 }

--- a/metrique/tests/descriptor_shape_sink.rs
+++ b/metrique/tests/descriptor_shape_sink.rs
@@ -1,0 +1,213 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! E2E test: a descriptor-aware sink that uses shapes to select encoding strategies.
+//!
+//! Demonstrates the intended consumption pattern where a sink pre-registers a schema
+//! from descriptor metadata (shapes, names, units, flags) and then uses the write path
+//! to fill in values against that schema.
+
+use metrique::timers::Timer;
+use metrique::unit_of_work::metrics;
+use metrique::writer::Entry;
+use metrique_writer_core::Unit;
+use metrique_writer_core::descriptor::{FieldShape, KnownShape, ShapeRef};
+use metrique_writer_core::value::{FlagConstructor, MetricFlags, MetricOptions};
+use std::any::TypeId;
+use std::time::Duration;
+
+// A flag marking fields for export to an external system.
+#[derive(Debug)]
+struct ExportOpt;
+impl MetricOptions for ExportOpt {}
+struct Export;
+impl FlagConstructor for Export {
+    fn construct() -> MetricFlags<'static> {
+        MetricFlags::upcast(&ExportOpt)
+    }
+}
+
+/// Simulates a sink's per-entry-type schema, built once from descriptors.
+#[derive(Debug)]
+struct FieldSchema {
+    name: String,
+    encoding: Encoding,
+    unit: Option<Unit>,
+    export: bool,
+}
+
+/// The encoding a sink would choose based on shape.
+#[derive(Debug, PartialEq)]
+enum Encoding {
+    IntGauge,
+    FloatGauge,
+    Attribute,
+    NullableInt,
+    NullableFloat,
+    NullableAttribute,
+    IntList,
+    Opaque,
+}
+
+fn encoding_for_shape(shape: FieldShape<'_>) -> Encoding {
+    match shape {
+        FieldShape::Known(KnownShape::Bool)
+        | FieldShape::Known(KnownShape::U8)
+        | FieldShape::Known(KnownShape::U16)
+        | FieldShape::Known(KnownShape::U32)
+        | FieldShape::Known(KnownShape::U64) => Encoding::IntGauge,
+        FieldShape::Known(KnownShape::F32) | FieldShape::Known(KnownShape::F64) => {
+            Encoding::FloatGauge
+        }
+        FieldShape::Known(KnownShape::String) => Encoding::Attribute,
+        FieldShape::Optional(inner) => match inner.get() {
+            FieldShape::Known(KnownShape::String) => Encoding::NullableAttribute,
+            FieldShape::Known(KnownShape::F32) | FieldShape::Known(KnownShape::F64) => {
+                Encoding::NullableFloat
+            }
+            FieldShape::Known(_) => Encoding::NullableInt,
+            _ => Encoding::Opaque,
+        },
+        FieldShape::List(inner) => match inner.get() {
+            FieldShape::Known(
+                KnownShape::U8
+                | KnownShape::U16
+                | KnownShape::U32
+                | KnownShape::U64
+                | KnownShape::Bool,
+            ) => Encoding::IntList,
+            _ => Encoding::Opaque,
+        },
+        _ => Encoding::Opaque,
+    }
+}
+
+/// Build a schema from entry descriptors, the way a real sink would on first encounter.
+fn build_schema(entry: &impl Entry) -> Vec<FieldSchema> {
+    let export_id = TypeId::of::<Export>();
+    let descs = entry.descriptors().unwrap();
+    let mut schema = Vec::new();
+
+    for seg in descs.iter() {
+        for field in seg.fields() {
+            schema.push(FieldSchema {
+                name: field.name_parts().collect(),
+                encoding: encoding_for_shape(field.shape()),
+                unit: field.unit(),
+                export: field.flags().any(|f| f.type_id() == export_id),
+            });
+        }
+    }
+    schema
+}
+
+#[test]
+fn shape_driven_schema_registration() {
+    #[metrics(rename_all = "PascalCase", default_flags(Export))]
+    struct RequestMetrics {
+        operation: String,
+        request_count: u64,
+        latency: Timer,
+        success: bool,
+        opt_note: Option<String>,
+        opt_retry_count: Option<u32>,
+        batch_sizes: Vec<u64>,
+        #[metrics(flags(skip(Export)))]
+        internal_debug: f64,
+    }
+
+    let m = RequestMetrics {
+        operation: "ListDucks".into(),
+        request_count: 1,
+        latency: Timer::default(),
+        success: true,
+        opt_note: Some("ok".into()),
+        opt_retry_count: None,
+        batch_sizes: vec![10, 20],
+        internal_debug: 3.14,
+    };
+
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+    let schema = build_schema(&entry);
+
+    // Verify schema built from shapes matches expected encodings
+    assert_eq!(schema.len(), 8);
+
+    assert_eq!(schema[0].name, "Operation");
+    assert_eq!(schema[0].encoding, Encoding::Attribute);
+    assert!(schema[0].export);
+
+    assert_eq!(schema[1].name, "RequestCount");
+    assert_eq!(schema[1].encoding, Encoding::IntGauge);
+    assert!(schema[1].export);
+
+    assert_eq!(schema[2].name, "Latency");
+    assert_eq!(schema[2].encoding, Encoding::FloatGauge);
+    assert_eq!(
+        schema[2].unit,
+        Some(Unit::Second(
+            metrique_writer_core::unit::NegativeScale::Milli
+        ))
+    );
+    assert!(schema[2].export);
+
+    assert_eq!(schema[3].name, "Success");
+    assert_eq!(schema[3].encoding, Encoding::IntGauge); // bool encodes as int
+    assert!(schema[3].export);
+
+    assert_eq!(schema[4].name, "OptNote");
+    assert_eq!(schema[4].encoding, Encoding::NullableAttribute);
+    assert!(schema[4].export);
+
+    assert_eq!(schema[5].name, "OptRetryCount");
+    assert_eq!(schema[5].encoding, Encoding::NullableInt);
+    assert!(schema[5].export);
+
+    assert_eq!(schema[6].name, "BatchSizes");
+    assert_eq!(schema[6].encoding, Encoding::IntList);
+    assert!(schema[6].export);
+
+    assert_eq!(schema[7].name, "InternalDebug");
+    assert_eq!(schema[7].encoding, Encoding::FloatGauge);
+    assert!(!schema[7].export); // explicitly skipped
+}
+
+#[test]
+fn schema_caching_by_descriptor_id() {
+    #[metrics(rename_all = "PascalCase")]
+    struct CacheableMetrics {
+        count: u64,
+        name: String,
+    }
+
+    // First entry
+    let m1 = CacheableMetrics {
+        count: 1,
+        name: "a".into(),
+    };
+    let closed1 = metrique::CloseValue::close(m1);
+    let entry1 = metrique::RootEntry::new(closed1);
+
+    // Second entry of same type
+    let m2 = CacheableMetrics {
+        count: 2,
+        name: "b".into(),
+    };
+    let closed2 = metrique::CloseValue::close(m2);
+    let entry2 = metrique::RootEntry::new(closed2);
+
+    // Same descriptor ID means schema can be cached and reused
+    let descs1 = entry1.descriptors().unwrap();
+    let descs2 = entry2.descriptors().unwrap();
+    assert_eq!(descs1[0].id(), descs2[0].id());
+
+    // Schema is identical for both
+    let schema1 = build_schema(&entry1);
+    let schema2 = build_schema(&entry2);
+    assert_eq!(schema1.len(), schema2.len());
+    for (a, b) in schema1.iter().zip(schema2.iter()) {
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.encoding, b.encoding);
+    }
+}

--- a/metrique/tests/ui/fail/missing_flatten_attribute.stderr
+++ b/metrique/tests/ui/fail/missing_flatten_attribute.stderr
@@ -3,6 +3,31 @@ error[E0277]: `ChildMetricsEntry` is not a metric value
    |
 13 | #[metrics(rename_all = "PascalCase")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Value` is not implemented for `ChildMetricsEntry`
+  --> tests/ui/fail/missing_flatten_attribute.rs:7:1
+   |
+ 7 | #[metrics(rename_all = "snake_case")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: If `ChildMetricsEntry` is a metric *entry*, flatten it using `#[metrics(flatten)]`
+   = help: the following other types implement trait `Value`:
+             &T
+             Arc<T>
+             Box<T>
+             Cow<'_, T>
+             Duration
+             ForceFlag<T, FLAGS>
+             Mean<U>
+             Observation
+           and $N others
+   = note: required for `Option<ChildMetricsEntry>` to implement `Value`
+   = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `ChildMetricsEntry` is not a metric value
+  --> tests/ui/fail/missing_flatten_attribute.rs:13:1
+   |
+13 | #[metrics(rename_all = "PascalCase")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
 ...
 19 |     downstream_operation: Slot<ChildMetrics>,
    |     -------------------- required by a bound introduced by this call

--- a/metrique/tests/ui/fail/subfield_no_metric.stderr
+++ b/metrique/tests/ui/fail/subfield_no_metric.stderr
@@ -128,6 +128,31 @@ note: required by a bound in `EntrySink`
    = note: this error originates in the attribute macro `metrics` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: CloseValue is not implemented for ChildMetrics
+  --> tests/ui/fail/subfield_no_metric.rs:8:12
+   |
+ 8 |     child: ChildMetrics,
+   |            ^^^^^^^^^^^^ This type must implement `CloseValue`
+   |
+help: the trait `CloseValue` is not implemented for `ChildMetrics`
+  --> tests/ui/fail/subfield_no_metric.rs:11:1
+   |
+11 | struct ChildMetrics {
+   | ^^^^^^^^^^^^^^^^^^^
+   = note: You may need to add `#[metrics]` to `ChildMetrics` or implement `CloseValue` directly.
+   = note: if ChildMetrics implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
+   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
+   = help: the following other types implement trait `CloseValue`:
+             &AtomicBool
+             &AtomicU16
+             &AtomicU32
+             &AtomicU64
+             &AtomicU8
+             &AtomicUsize
+             &Counter
+             &Duration
+           and $N others
+
+error[E0277]: CloseValue is not implemented for ChildMetrics
   --> tests/ui/fail/subfield_no_metric.rs:6:1
    |
  6 | #[metrics(rename_all = "snake_case")]


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

Follows #289 (entry descriptors). Descriptors previously reported `Opaque` for all field shapes and only surfaced units from explicit `#[metrics(unit = X)]`.

### Summary

Adds `const SHAPE` and `const UNIT` as defaulted associated consts on the `Value` trait. The macro resolves both through the `CloseValue::Closed` chain at compile time, so descriptors now carry type-accurate shapes and inherent units for all built-in types with zero user effort and zero runtime cost.

The approach avoids breakage: existing `Value` impls compile unchanged (they inherit `Opaque` and `Unit::None`). Custom types that close to a known type (e.g. a counter closing to `u64`) get the correct shape and unit from the closed type's impl. Users who want richer metadata for custom `Value` types override the consts.

`ValueFormatter` also gets a `const SHAPE` with the same pattern. Formatter-aware sinks can query it separately, though the descriptor's field shape reflects the closed type (not the formatter's rendering).

Lifetime parameters in field types are handled by anonymizing them to `'_` in the macro-generated static expressions, which the compiler resolves correctly since `SHAPE`/`UNIT` are `'static` regardless of the input lifetime.

### Testing

Shape tests cover the full type matrix: all scalar types, Duration/Timer (through CloseValue), Optional, List, nested composition (Option<Vec<T>>), lifetimed types (Cow<'a, str>, Option<Cow<'a, str>>), custom CloseValue resolution, no_close fields falling to Opaque, custom SHAPE overrides, `#[metrics(value)]` struct/enum forwarding, Arc wrapper passthrough, and formatted fields.

A new e2e test (`descriptor_shape_sink.rs`) demonstrates the intended consumption pattern: a sink builds a typed schema from descriptor shapes, units, and flags, then caches it by DescriptorId.


🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
