### PR TITLE
feat: Add convenience API for FlushImmediately setup

### DIFF
--- a/metrique-writer/src/sink/mod.rs
+++ b/metrique-writer/src/sink/mod.rs
@@ -242,4 +242,29 @@ mod tests {
         assert_eq!(output.lock().unwrap().values, vec![1]);
         assert_eq!(output.lock().unwrap().flushes, 1);
     }
+
+    #[test]
+    fn write_directly_to_does_not_lose_entries_under_concurrent_appends() {
+        use metrique_writer_core::global::GlobalEntrySink;
+        use metrique_writer_core::test_stream::{TestEntry as StreamTestEntry, TestStream};
+
+        global_entry_sink! { ConcurrentTestGlobalSink }
+
+        let output: Arc<Mutex<TestStream>> = Default::default();
+        let _handle = ConcurrentTestGlobalSink::write_directly_to(Arc::clone(&output));
+
+        std::thread::scope(|scope| {
+            for t in 0..20 {
+                scope.spawn(move || {
+                    for i in 0..10 {
+                        ConcurrentTestGlobalSink::append(StreamTestEntry(t * 10 + i));
+                    }
+                });
+            }
+        });
+
+        let values = &mut output.lock().unwrap().values;
+        values.sort();
+        assert_eq!(*values, (0..200).collect::<Vec<_>>());
+    }
 }

--- a/metrique-writer/src/sink/mod.rs
+++ b/metrique-writer/src/sink/mod.rs
@@ -226,4 +226,20 @@ mod tests {
         });
         futures::executor::block_on(EntrySink::<TestEntry>::flush_async(&sink));
     }
+
+    #[test]
+    fn write_directly_to_flushes_synchronously() {
+        use metrique_writer_core::global::GlobalEntrySink;
+        use metrique_writer_core::test_stream::{TestEntry as StreamTestEntry, TestStream};
+
+        global_entry_sink! { TestGlobalSink }
+
+        let output: Arc<Mutex<TestStream>> = Default::default();
+        let _handle = TestGlobalSink::write_directly_to(Arc::clone(&output));
+
+        TestGlobalSink::append(StreamTestEntry(1));
+
+        assert_eq!(output.lock().unwrap().values, vec![1]);
+        assert_eq!(output.lock().unwrap().flushes, 1);
+    }
 }

--- a/metrique-writer/src/sink/mod.rs
+++ b/metrique-writer/src/sink/mod.rs
@@ -42,6 +42,16 @@ pub trait AttachGlobalEntrySinkExt: AttachGlobalEntrySink {
     fn attach_to_stream(output: impl EntryIoStream + Send + 'static) -> AttachHandle {
         Self::attach(BackgroundQueue::new(output))
     }
+
+    /// Attach the given output stream to a [`FlushImmediately`] sink and then to this
+    /// global sink reference. Unlike [`attach_to_stream`](Self::attach_to_stream), this
+    /// does not use a background thread - each entry is written and flushed inline.
+    /// Suitable for short-lived environments like AWS Lambda.
+    /// # Panics
+    /// Panics if a queue is already attached.
+    fn write_directly_to(output: impl EntryIoStream + Send + Sync + 'static) -> AttachHandle {
+        Self::attach((FlushImmediately::new_boxed(output), ()))
+    }
 }
 
 impl<Q: AttachGlobalEntrySink + ?Sized> AttachGlobalEntrySinkExt for Q {}

--- a/metrique/docs/sinks.md
+++ b/metrique/docs/sinks.md
@@ -68,10 +68,9 @@ struct MyMetrics {
 
 fn main() {
     let _handle = ServiceMetrics::write_directly_to(
-        Emf::no_validations(
-            "MyNS".to_string(),
-            vec![vec![/*your dimensions here*/]],
-        ).output_to(std::io::stdout()),
+        Emf::builder("MyNS".to_string(), vec![vec![/*your dimensions here*/]])
+            .build()
+            .output_to(std::io::stdout()),
     );
     handle_request();
 }

--- a/metrique/docs/sinks.md
+++ b/metrique/docs/sinks.md
@@ -58,8 +58,7 @@ and requires a custom graceful shutdown to drain. For these cases, consider usin
 ```rust
 use metrique::emf::Emf;
 use metrique::ServiceMetrics;
-use metrique::writer::{AttachGlobalEntrySink, FormatExt, GlobalEntrySink};
-use metrique::writer::sink::FlushImmediately;
+use metrique::writer::{AttachGlobalEntrySinkExt, FormatExt, GlobalEntrySink};
 use metrique::unit_of_work::metrics;
 
 #[metrics]
@@ -68,14 +67,12 @@ struct MyMetrics {
 }
 
 fn main() {
-    let sink = FlushImmediately::new_boxed(
+    let _handle = ServiceMetrics::write_directly_to(
         Emf::no_validations(
             "MyNS".to_string(),
-            vec![vec![/*your dimensions here */]],
-        )
-        .output_to(std::io::stdout()),
+            vec![vec![/*your dimensions here*/]],
+        ).output_to(std::io::stdout()),
     );
-    let _handle = ServiceMetrics::attach((sink, ()));
     handle_request();
 }
 


### PR DESCRIPTION
📬 *Issue #, if available:*
https://github.com/awslabs/metrique/issues/230

✍️ *Description of changes:*
- `metrique-writer/src/sink/mod.rs`
  -  Add `write_directly_to` to `AttachGlobalEntrySinkExt` as a one-line convenience method for attaching a `FlushImmediately` sink to a global sink - mirroring the existing `attach_to_stream` for `BackgroundQueue` + tests.
- `metrique/docs/sinks.md`
  - Update "Immediate Flushing for ephemeral environments" example to demonstrate the new API usage

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
