### PR TITLE
Release: Jul 8th 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,114 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.27](https://github.com/awslabs/metrique/compare/metrique-v0.1.26...metrique-v0.1.27) - 2026-07-08
+
+### Added
+
+- Add convenience API for FlushImmediately setup ([#333](https://github.com/awslabs/metrique/pull/333))
+- Entry descriptors ([#289](https://github.com/awslabs/metrique/pull/289))
+- *(value)* support `Arc<str>` in metric structs ([#318](https://github.com/awslabs/metrique/pull/318))
+- Support folding sysinfo metrics into other structs ([#301](https://github.com/awslabs/metrique/pull/301))
+- allow non-default MergeConfig in KeyedAggregator ([#310](https://github.com/awslabs/metrique/pull/310))
+
 ### Changed
 
 - MSRV raised from 1.89 to 1.91 (required for `const TypeId::of`).
 
 ### Fixed
 
+- *(cloudwatch)* use proper SdkError pattern matching for ResourceAlreadyExistsException ([#315](https://github.com/awslabs/metrique/pull/315))
 - *(metrique-aggregation)* `#[aggregate]` now propagates the parent's `rename_all` to the generated key struct. Previously key fields (dimensions) kept their Rust field names even when `rename_all` was set on the parent.
+
+### Other
+
+- [metrique-writer-core + metrique-macro] Resolve FieldShape and Unit from Value trait ([#331](https://github.com/awslabs/metrique/pull/331))
+- adopt ci-pass aggregator pattern for GitHub Actions ([#330](https://github.com/awslabs/metrique/pull/330))
+- Add SCREAMING_SNAKE_CASE support to metrique-macro NameStyle ([#329](https://github.com/awslabs/metrique/pull/329))
+- Support folding RuntimeMetrics (tokio-metrics) into other structs  ([#293](https://github.com/awslabs/metrique/pull/293))
+
+## [0.1.26](https://github.com/awslabs/metrique/compare/metrique-v0.1.25...metrique-v0.1.26) - 2026-06-09
+
+### Added
+
+- **`metrique-otel`**: New crate for OpenTelemetry integration. Records metrique entries directly onto an OTel `SdkMeterProvider` with OTLP/gRPC export. Use `flags(...)` to select OTel instrument kinds; non-OTel sinks ignore the flags, so the same struct works in mixed topologies. ([#291](https://github.com/awslabs/metrique/pull/291))
+
+  ```rust
+  use metrique_otel::OtelSink;
+  use metrique_otel::flags::Counter;
+
+  #[aggregate]
+  #[metrics(rename_all = "PascalCase")]
+  struct RequestMetrics {
+      #[aggregate(key)]
+      operation: String,
+      #[aggregate(strategy = Sum)]
+      #[metrics(flags(Counter))]
+      request_count: u64,
+      #[aggregate(strategy = Histogram<Duration>)]
+      #[metrics(unit = Millisecond)]
+      latency: Duration,
+  }
+  ```
+
+- *(metrique-util)* System metrics bridge via `sysinfo` (feature: `sysinfo-bridge`). Periodically samples CPU, memory, swap, load average, uptime, and current-process metrics. Opt-in disk, network, and thermal metrics via builder methods. ([#283](https://github.com/awslabs/metrique/pull/283))
+
+  ```rust
+  use metrique_util::{AttachGlobalEntrySinkSysinfoExt, SysinfoMetricsConfig};
+
+  ServiceMetrics::subscribe_sysinfo_metrics(
+      SysinfoMetricsConfig::default()
+          .with_interval(Duration::from_secs(30))
+          .with_name_style(MetricNameStyle::KebabCase)
+          .with_disks()
+          .with_networks(),
+  );
+  ```
+
+- *(macro)* `#[metrics(flags(...))]` field attribute for per-field `ForceFlag` without wrapping the type. Multiple flags can be combined on a single field. ([#290](https://github.com/awslabs/metrique/pull/290))
+
+  ```rust
+  use metrique::emf::flags::{HighStorageResolution, NoMetric};
+
+  #[metrics(rename_all = "PascalCase")]
+  struct Metrics {
+      #[metrics(flags(HighStorageResolution))]
+      latency: u64,
+      #[metrics(flags(NoMetric))]
+      debug_count: u64,
+  }
+  ```
+
+- Observer hooks for `BackgroundQueue` and `FlushImmediately` sinks. Backend-agnostic trait replaces the deprecated internal `MetricRecorder` approach—any closure of the right shape is an observer. ([#296](https://github.com/awslabs/metrique/pull/296))
+
+  ```rust
+  use metrique_writer::sink::{BackgroundQueueBuilder, BackgroundQueueEvent};
+
+  let queue = BackgroundQueueBuilder::new().observer(move |_queue: &str, event| {
+      if let BackgroundQueueEvent::QueueOverflow { .. } = event {
+          overflow_counter.fetch_add(1, Ordering::Relaxed);
+      }
+  });
+  ```
+
+- **`metrique-writer-cloudwatch`**: New crate providing a CloudWatch Logs `PutLogEvents` (EMF) `EntryIoStream` backend. Channel-based async architecture with bounded backpressure, respects CW Logs limits (1MB payload, 10k events), graceful shutdown, and auto-creates log group/stream on startup. ([#302](https://github.com/awslabs/metrique/pull/302))
+
+### Changed
+
+- *(metrique-writer-cloudwatch)* **Breaking:** Gate default Tokio runtime behind `tokio_runtime` feature. `TaskSpawner::tokio()` now requires the feature; the spawner no longer returns a `JoinHandle` but spawns-and-detaches instead. ([#305](https://github.com/awslabs/metrique/pull/305))
+
+### Fixed
+
+- *(metrique-writer-cloudwatch)* Avoid legacy AWS client stack that was pulling in old rustls/hyper dependencies causing critical vulnerability findings ([#306](https://github.com/awslabs/metrique/pull/306))
+- Deterministically sort keys in snapshot test ([#303](https://github.com/awslabs/metrique/pull/303))
+
+### Other
+
+- Add [`_guide::extending`](https://docs.rs/metrique/latest/metrique/_guide/extending/) documentation covering the closing model, core traits, and copy-paste recipes for custom accumulators, value wrappers, and manual `Entry` impls ([#297](https://github.com/awslabs/metrique/pull/297))
+- Clean up `GlobalEntrySink` description ([#292](https://github.com/awslabs/metrique/pull/292))
+- Fix race condition in worker tests ([#285](https://github.com/awslabs/metrique/pull/285))
+- Make worker sink exit cleanly ([#284](https://github.com/awslabs/metrique/pull/284))
+- *(metrique-util)* Mention pending-sink in README ([#279](https://github.com/awslabs/metrique/pull/279))
 
 ## [0.1.25](https://github.com/awslabs/metrique/compare/metrique-v0.1.24...metrique-v0.1.25) - 2026-04-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "anyhow",
  "assert2",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-aggregation"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "assert2",
  "divan",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-core"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "itertools",
  "metrique",
@@ -1756,7 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-macro"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "Inflector",
  "assert2",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-metricsrs"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "derive-where",
  "futures",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-otel"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "divan",
  "metrique",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-service-metrics"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "metrique",
  "metrique-writer",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-timesource"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "metrique-timesource",
  "tokio",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-util"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arc-swap",
  "assert2",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "ahash",
  "assert-json-diff",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-cloudwatch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aws-sdk-cloudwatchlogs",
  "aws-smithy-http-client",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "assert-json-diff",
  "derive-where",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-emf"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "assert-json-diff",
  "assert_approx_eq",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-json"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "dtoa",
  "itoa",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-macro"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2638,7 +2638,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2745,7 +2745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2990,7 +2990,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3636,7 +3636,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-aggregation"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-core/Cargo.toml
+++ b/metrique-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-core"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-macro"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-metricsrs/Cargo.toml
+++ b/metrique-metricsrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-metricsrs"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-otel/Cargo.toml
+++ b/metrique-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-otel"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.91"
 license = "Apache-2.0"

--- a/metrique-service-metrics/Cargo.toml
+++ b/metrique-service-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-service-metrics"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-timesource/Cargo.toml
+++ b/metrique-timesource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-timesource"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-util/Cargo.toml
+++ b/metrique-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-util"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-writer-cloudwatch/Cargo.toml
+++ b/metrique-writer-cloudwatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-cloudwatch"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.91"
 license = "Apache-2.0"

--- a/metrique-writer-core/Cargo.toml
+++ b/metrique-writer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-core"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-writer-format-emf/Cargo.toml
+++ b/metrique-writer-format-emf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-format-emf"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-writer-format-json/Cargo.toml
+++ b/metrique-writer-format-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-format-json"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 rust-version = "1.91"
 license = "Apache-2.0"

--- a/metrique-writer-macro/Cargo.toml
+++ b/metrique-writer-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-macro"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-writer/Cargo.toml
+++ b/metrique-writer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2024"
 license = "Apache-2.0"
 description = "Library for generating wide event metrics"


### PR DESCRIPTION
Bump all metrique crate versions and update CHANGELOG via `release-plz update`.

metrique 0.1.26 -> 0.1.27 (and all sub-crates). Also restores the 0.1.26 CHANGELOG section that was accidentally removed in #289.

Looks like 0.1.26 got deleted at some point, I brought it back

📬 *Issue #, if available:*

✍️ *Description of changes:*

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
