### PR TITLE
Release: Jul 20th 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28](https://github.com/awslabs/metrique/compare/metrique-v0.1.27...metrique-v0.1.28) - 2026-07-20
+
+### Other
+
+- Fix cross-crate E0119 for entry-mode #[aggregate] ([#339](https://github.com/awslabs/metrique/pull/339))
+
 ## [0.1.27](https://github.com/awslabs/metrique/compare/metrique-v0.1.26...metrique-v0.1.27) - 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "assert2",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-aggregation"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aggregate-dep",
  "assert2",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-macro"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "Inflector",
  "assert2",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-format-json"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dtoa",
  "itoa",
@@ -2647,7 +2647,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2754,7 +2754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2999,7 +2999,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3645,7 +3645,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/metrique-aggregation/Cargo.toml
+++ b/metrique-aggregation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-aggregation"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-macro/Cargo.toml
+++ b/metrique-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-macro"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 rust-version = "1.91" # See .github/workflows/ci.yml
 license = "Apache-2.0"

--- a/metrique-writer-format-json/Cargo.toml
+++ b/metrique-writer-format-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique-writer-format-json"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 rust-version = "1.91"
 license = "Apache-2.0"

--- a/metrique/Cargo.toml
+++ b/metrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrique"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2024"
 license = "Apache-2.0"
 description = "Library for generating wide event metrics"


### PR DESCRIPTION
Bump all metrique crate versions and update CHANGELOG via release-plz update

metrique 0.1.27 -> 0.1.28 (and all sub-crates that changed: metrique-aggregation, metrique-macro, metrique-writer-format-json).

📬 *Issue #, if available:*

✍️ *Description of changes:*

🔏 *By submitting this pull request*

- [x ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [ x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
