### PR TITLE
fix: Yield descriptor segments in Entry::write order for flattened entries

### DIFF
--- a/docs/entry-descriptors.md
+++ b/docs/entry-descriptors.md
@@ -184,7 +184,7 @@ Extending `Entry` rather than introducing a separate trait keeps descriptor look
 
 Each enum variant gets its own static descriptor containing only that variant's fields (plus the tag field if present). The `descriptors()` method matches on self and yields the active variant's descriptor. Different variants produce different `DescriptorId`s. The descriptor name includes the variant (e.g., `"MyEnum::Read"`).
 
-For variants with flatten fields, the variant's base descriptor is followed by the flatten children's descriptors (same chaining pattern as structs). A generated enum iterator type (same pattern as sample_group) unifies the different return types across match arms.
+For variants with flatten fields, the children's descriptors are interleaved at their declaration position, with the variant's own fields split into runs at flatten boundaries (same segmentation as structs). The variant's first segment carries the tag field (written before any variant fields) and the variant's canonical name.
 
 Sinks see different descriptor sequences depending on which variant is active. Each segment has its own `DescriptorId`, so per-segment caching works naturally. Sinks that want a single cache key for the whole entry can hash the sequence of ids.
 
@@ -252,9 +252,9 @@ Flattened children manage their own flags independently. This matches the scopin
 │    yields one or more DescriptorRef segments in write order  │
 │                                                             │
 │  Simple struct:    [own fields]                             │
-│  With flatten:     [own fields] [child1] [child2] ...       │
+│  With flatten:     [own run] [child1] [own run] [child2] ..  │
 │  AggregationResult: [key fields] [aggregated fields]        │
-│  Enum variant:     [variant's fields] [variant's children]  │
+│  Enum variant:     [tag + own run] [child] [own run] ...    │
 └─────────────────────────────────────────────────────────────┘
                             │
                             ▼
@@ -288,12 +288,30 @@ One descriptor entry regardless of runtime cardinality. Sinks that understand `L
 - **`#[metrics(timestamp)]`**: timestamp fields are excluded from the field list and exposed separately.
 - **`#[metrics(ignore)]`**: excluded from the descriptor entirely.
 - **`#[metrics(subfield)]`**: subfield structs get their own descriptor, chained by the parent.
-- **`flatten` / `flatten_entry`**: both chain the child's descriptor segments after the parent's own.
+- **`flatten` / `flatten_entry`**: both interleave the child's descriptor segments at the flatten site's declaration position, splitting the parent's own fields into contiguous runs (see "Flatten descriptor mechanics").
 - **`#[metrics(value)]` newtypes**: lower to their wrapped type's shape when macro-known.
 
 ## Flatten descriptor mechanics
 
-When a parent flattens a child, the parent's `descriptors()` chains the child's descriptor segments after its own. Prefixes and default flags from the flatten site are applied as modifiers on the child's `DescriptorRef`.
+When a parent flattens a child, the child's descriptor segments appear at the flatten site's declaration position, so segments come out in the same order `Entry::write` emits values. The parent's own (non-flatten) fields are split into contiguous runs at flatten boundaries, and each run becomes its own segment. For example:
+
+```rust
+#[metrics]
+struct Parent {
+    a: u64,
+    #[metrics(flatten)]
+    child: Child,   // Child { x: u64 }
+    b: u64,
+}
+```
+
+yields three segments in write order: `[Parent: a]`, `[Child: x]`, `[Parent: b]`. All of the parent's segments report the parent's canonical name.
+
+The first segment always belongs to the parent and is emitted even when no own fields precede the first flatten site (it then lists zero fields and consumes zero values). This keeps the parent's canonical name first and gives the timestamp a stable home: the timestamp is emitted through `EntryWriter::timestamp` rather than `value()`, so it has no position in the field stream and always lives on the first segment. Later runs are emitted only when non-empty.
+
+A cfg-disabled flatten site still splits the surrounding own fields into separate runs; two adjacent parent segments still satisfy the order contract.
+
+Prefixes and default flags from the flatten site are applied as modifiers on the child's `DescriptorRef`.
 
 ### How flatten propagates naming
 

--- a/docs/entry-descriptors.md
+++ b/docs/entry-descriptors.md
@@ -176,7 +176,7 @@ for desc in entry.descriptors() {
 }
 ```
 
-Sinks key their per-segment caches on `DescriptorId`. For simple entries (one descriptor), a single id suffices. For composed entries (multiple descriptors), sinks cache per-segment or use the sequence of ids as a composite key. `DescriptorId` incorporates the base descriptor pointer plus prefixes, so the same child struct with different flatten-site prefixes produces different ids.
+Sinks key their per-segment caches on `DescriptorId`. For simple entries (one descriptor), a single id suffices. For composed entries (multiple descriptors), sinks cache per-segment or use the sequence of ids as a composite key. `DescriptorId` incorporates the base descriptor pointer plus flatten-site modifiers (prefixes and extra flags), so the same child struct flattened with different prefixes or `default_flags` produces different ids.
 
 Extending `Entry` rather than introducing a separate trait keeps descriptor lookup on the path users already know, keeps `BoxEntry` forwarding natural, and avoids growing the object-safety surface.
 

--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -478,6 +478,71 @@ pub(crate) fn build_descriptors_chain(base: Ts2, children: &[(Vec<Ts2>, Ts2)]) -
     }
 }
 
+/// Generates a `Descriptors` expression yielding a flattened child's segments,
+/// with any flatten-site modifiers (prefix, `default_flags`) applied.
+///
+/// `binding` is the expression that borrows the child entry: `&self.field` for
+/// structs, a match-arm binding for enum variants.
+pub(crate) fn flatten_descriptors_expr(kind: &MetricsFieldKind, binding: &Ts2, ns: &Ts2) -> Ts2 {
+    match kind {
+        MetricsFieldKind::Flatten {
+            prefix,
+            default_flags: flatten_default_flags,
+            ..
+        } => {
+            let prefix_expr = prefix.as_ref().map(|pfx| {
+                // Generate a per-style prefix array so the correct inflection
+                // is selected at runtime based on the parent's propagated style.
+                let inflected: Vec<String> = crate::inflect::NameStyle::ALL
+                    .iter()
+                    .map(|s| pfx.apply_prefix_only(*s))
+                    .collect();
+                quote! {
+                    .with_prefix(
+                        [#(#inflected),*][<#ns as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX as usize]
+                    )
+                }
+            });
+
+            let extra_flags_expr = if flatten_default_flags.is_empty() {
+                None
+            } else {
+                let flag_exprs: Vec<_> = flatten_default_flags
+                    .iter()
+                    .map(|f| {
+                        let path = &f.path;
+                        quote! { ::metrique::writer::core::FieldFlag::new::<#path>() }
+                    })
+                    .collect();
+                let num_flags = flag_exprs.len();
+                Some(quote! {
+                    .with_extra_flags({
+                        static __FLATTEN_FLAGS: [::metrique::writer::core::FieldFlag; #num_flags] = [
+                            #(#flag_exprs),*
+                        ];
+                        &__FLATTEN_FLAGS
+                    })
+                })
+            };
+
+            if prefix_expr.is_some() || extra_flags_expr.is_some() {
+                quote! {
+                    ::metrique::InflectableEntry::<#ns>::descriptors(#binding)
+                        .map_available(|d| d #prefix_expr #extra_flags_expr)
+                }
+            } else {
+                quote! {
+                    ::metrique::InflectableEntry::<#ns>::descriptors(#binding)
+                }
+            }
+        }
+        MetricsFieldKind::FlattenEntry(_) => {
+            quote! { ::metrique::writer::Entry::descriptors(#binding) }
+        }
+        _ => unreachable!("flatten_descriptors_expr is only called for flatten/flatten_entry"),
+    }
+}
+
 /// Generate a block that selects one of 4 pre-computed EntryDescriptor statics based on a style u8.
 ///
 /// Returns a token stream like:
@@ -617,23 +682,58 @@ fn anonymize_lifetimes(ty: &syn::Type) -> syn::Type {
     ty
 }
 
+/// Name of the inherent descriptor method for a given own-field run.
+///
+/// Run 0 keeps the historical `__metrique_descriptor` name; later runs
+/// (own fields declared after a flatten site) get numbered methods.
+pub(crate) fn descriptor_method_ident(run: usize) -> Ident {
+    if run == 0 {
+        format_ident!("__metrique_descriptor")
+    } else {
+        format_ident!("__metrique_descriptor_run_{}", run)
+    }
+}
+
 pub(crate) fn generate_descriptor_impl(
     entry_name: &Ident,
     generics: &syn::Generics,
     struct_name: &str,
-    fields: &[DescriptorFieldMeta],
+    runs: &[Vec<DescriptorFieldMeta>],
     timestamp_descriptor: &Ts2,
 ) -> Ts2 {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let body = generate_style_matched_descriptor(fields, struct_name, timestamp_descriptor, "");
+    let none_timestamp = quote! { None };
+
+    let methods: Vec<Ts2> = runs
+        .iter()
+        .enumerate()
+        // Run 0 is always emitted (it carries the canonical entry name and
+        // timestamp); later runs are skipped when empty.
+        .filter(|(i, run)| *i == 0 || !run.is_empty())
+        .map(|(i, run)| {
+            // The timestamp is emitted via `EntryWriter::timestamp`, not
+            // `value()`, so it has no position in the field stream; it always
+            // lives on the first segment.
+            let ts = if i == 0 {
+                timestamp_descriptor
+            } else {
+                &none_timestamp
+            };
+            let body = generate_style_matched_descriptor(run, struct_name, ts, "");
+            let method_ident = descriptor_method_ident(i);
+            quote! {
+                #[doc(hidden)]
+                #[inline(always)]
+                fn #method_ident() -> &'static ::metrique::writer::core::EntryDescriptor {
+                    #body
+                }
+            }
+        })
+        .collect();
 
     quote! {
         impl #impl_generics #entry_name #ty_generics #where_clause {
-            #[doc(hidden)]
-            #[inline(always)]
-            fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
-                #body
-            }
+            #(#methods)*
         }
     }
 }

--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -694,11 +694,21 @@ pub(crate) fn descriptor_method_ident(run: usize) -> Ident {
     }
 }
 
+/// One contiguous run of own fields, becoming one descriptor segment.
+///
+/// `cfg` carries the field's `#[cfg(...)]`/`#[cfg_attr(...)]` attributes for
+/// runs holding a single cfg-gated field; the generated method and chain call
+/// are gated the same way so the segment disappears along with the field.
+pub(crate) struct DescriptorRun {
+    pub(crate) cfg: Vec<Ts2>,
+    pub(crate) fields: Vec<DescriptorFieldMeta>,
+}
+
 pub(crate) fn generate_descriptor_impl(
     entry_name: &Ident,
     generics: &syn::Generics,
     struct_name: &str,
-    runs: &[Vec<DescriptorFieldMeta>],
+    runs: &[DescriptorRun],
     timestamp_descriptor: &Ts2,
 ) -> Ts2 {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
@@ -709,7 +719,7 @@ pub(crate) fn generate_descriptor_impl(
         .enumerate()
         // Run 0 is always emitted (it carries the canonical entry name and
         // timestamp); later runs are skipped when empty.
-        .filter(|(i, run)| *i == 0 || !run.is_empty())
+        .filter(|(i, run)| *i == 0 || !run.fields.is_empty())
         .map(|(i, run)| {
             // The timestamp is emitted via `EntryWriter::timestamp`, not
             // `value()`, so it has no position in the field stream; it always
@@ -719,9 +729,11 @@ pub(crate) fn generate_descriptor_impl(
             } else {
                 &none_timestamp
             };
-            let body = generate_style_matched_descriptor(run, struct_name, ts, "");
+            let body = generate_style_matched_descriptor(&run.fields, struct_name, ts, "");
             let method_ident = descriptor_method_ident(i);
+            let cfg = &run.cfg;
             quote! {
+                #(#cfg)*
                 #[doc(hidden)]
                 #[inline(always)]
                 fn #method_ident() -> &'static ::metrique::writer::core::EntryDescriptor {

--- a/metrique-macro/src/entry_impl.rs
+++ b/metrique-macro/src/entry_impl.rs
@@ -419,7 +419,7 @@ fn collect_field_sample_group<'a>(
 
 /// Output of descriptor generation for a struct or enum entry.
 pub(crate) struct DescriptorOutput {
-    /// The `__metrique_descriptor(style)` inherent impl with 4 statics.
+    /// The inherent impl with the per-run `__metrique_descriptor_run_N()` methods.
     /// Goes outside the `InflectableEntry` impl block but inside `const _: ()`.
     pub(crate) trait_impls: Ts2,
     /// The `fn descriptors()` method body.
@@ -683,15 +683,8 @@ fn anonymize_lifetimes(ty: &syn::Type) -> syn::Type {
 }
 
 /// Name of the inherent descriptor method for a given own-field run.
-///
-/// Run 0 keeps the historical `__metrique_descriptor` name; later runs
-/// (own fields declared after a flatten site) get numbered methods.
 pub(crate) fn descriptor_method_ident(run: usize) -> Ident {
-    if run == 0 {
-        format_ident!("__metrique_descriptor")
-    } else {
-        format_ident!("__metrique_descriptor_run_{}", run)
-    }
+    format_ident!("__metrique_descriptor_run_{}", run)
 }
 
 /// One contiguous run of own fields, becoming one descriptor segment.

--- a/metrique-macro/src/entry_impl/enum_impl.rs
+++ b/metrique-macro/src/entry_impl/enum_impl.rs
@@ -93,10 +93,7 @@ fn generate_write_arms(
     variants: &[MetricsVariant],
     root_attrs: &RootAttributes,
 ) -> Vec<Ts2> {
-    let tag_name = root_attrs
-        .tag
-        .as_ref()
-        .map(|tag| tag.field_name(root_attrs));
+    let tag = root_attrs.tag.as_ref();
     let writer_ident = mixed_site_writer();
 
     variants
@@ -104,11 +101,11 @@ fn generate_write_arms(
         .map(|variant| {
             let variant_ident = &variant.ident;
 
-            let tag_write = tag_name.as_ref().map(|tag_name| {
+            let tag_write = tag.map(|tag| {
                 let (extra, name) = make_inflect(
                     &make_ns(root_attrs.rename_all, variant.ident.span()),
                     variant.ident.span(),
-                    |style| style.apply(tag_name),
+                    |style| tag.styled_name(root_attrs, style),
                 );
                 let value = crate::inflect::inflect_no_prefix(root_attrs, variant);
                 quote! {
@@ -250,21 +247,18 @@ fn generate_sample_group_arms(
     root_attrs: &RootAttributes,
     iter_enum_name: &Ident,
 ) -> Vec<Ts2> {
-    let tag_name = root_attrs
-        .tag
-        .as_ref()
-        .map(|tag| tag.field_name(root_attrs));
+    let tag = root_attrs.tag.as_ref();
     let include_tag_in_sample_group = root_attrs.tag.as_ref().is_some_and(|t| t.sample_group());
 
     variants.iter().enumerate().map(|(idx, variant)| {
         let variant_ident = &variant.ident;
         let iter_variant_name = quote::format_ident!("V{}", idx);
 
-        let tag_sample_group = if let Some(tag_name) = tag_name.as_ref().filter(|_| include_tag_in_sample_group) {
+        let tag_sample_group = if let Some(tag) = tag.filter(|_| include_tag_in_sample_group) {
             let (extra, name) = make_inflect(
                 &make_ns(root_attrs.rename_all, variant.ident.span()),
                 variant.ident.span(),
-                |style| style.apply(tag_name),
+                |style| tag.styled_name(root_attrs, style),
             );
             let value = crate::inflect::inflect_no_prefix(root_attrs, variant);
             Some(quote! {
@@ -393,10 +387,10 @@ fn generate_enum_descriptor(
             // written before any variant fields.
             let mut runs: Vec<Vec<DescriptorFieldMeta>> = vec![Vec::new()];
             if let Some(tag) = &root_attrs.tag {
-                // The write path inflects the tag through the propagated style.
-                let tag_name = tag.field_name(root_attrs);
+                // The write path inflects the tag through the propagated
+                // style; `styled_name` keeps `name_exact` tags verbatim.
                 let names: [String; metrique_core::Styles::COUNT] =
-                    std::array::from_fn(|i| styles[i].apply(&tag_name));
+                    std::array::from_fn(|i| tag.styled_name(root_attrs, styles[i]));
                 runs[0].push(DescriptorFieldMeta {
                     names,
                     flags: vec![],

--- a/metrique-macro/src/entry_impl/enum_impl.rs
+++ b/metrique-macro/src/entry_impl/enum_impl.rs
@@ -361,9 +361,14 @@ fn collect_tuple_sample_group(
     }
 }
 
-/// Generates the enum iterator type for per-variant descriptor dispatch.
-/// Each variant's chain uses make_binary_tree_chain for balanced type nesting.
-/// Same pattern as sample_group: one variant per enum arm, unified via Iterator impl.
+/// Generates the per-variant `descriptors()` match arms.
+///
+/// Like structs, each variant's own (non-flatten) fields are split into
+/// contiguous runs at flatten boundaries so segments come out in write order.
+/// Run 0 additionally carries the tag field (written first) and the variant's
+/// canonical name, and is always emitted; later runs are emitted only when
+/// non-empty. Flattened children's segments are interleaved at their
+/// declaration position.
 fn generate_enum_descriptor(
     entry_name: &Ident,
     _generics: &syn::Generics,
@@ -381,14 +386,16 @@ fn generate_enum_descriptor(
         .enumerate()
         .map(|(v_idx, variant)| {
             let variant_ident = &variant.ident;
-
-            // Collect this variant's non-flatten fields
-            let mut v_field_metas: Vec<super::DescriptorFieldMeta> = Vec::new();
+            let variant_name = format!("{}::{}", struct_name, variant_ident);
             let mut v_timestamp_expr = quote! { None };
+
+            // Run 0 starts with the tag field, if present: the tag value is
+            // written before any variant fields.
+            let mut runs: Vec<Vec<DescriptorFieldMeta>> = vec![Vec::new()];
             if let Some(tag) = &root_attrs.tag {
                 let names: [String; metrique_core::Styles::COUNT] =
                     std::array::from_fn(|_| tag.field_name(root_attrs));
-                v_field_metas.push(DescriptorFieldMeta {
+                runs[0].push(DescriptorFieldMeta {
                     names,
                     flags: vec![],
                     skipped_flags: vec![],
@@ -398,56 +405,155 @@ fn generate_enum_descriptor(
                     format: None,
                 });
             }
-            if let Some(VariantData::Struct(fields)) = &variant.data {
-                for field in fields {
-                    match &field.attrs.kind {
-                        MetricsFieldKind::Field { unit, format, .. } => {
-                            let names: [String; metrique_core::Styles::COUNT] =
-                                std::array::from_fn(|i| metric_name(root_attrs, styles[i], field));
-                            let resolved =
-                                resolve_field_flags(&field.attrs.flags, &root_attrs.default_flags);
-                            v_field_metas.push(DescriptorFieldMeta {
-                                names,
-                                flags: resolved.flags,
-                                skipped_flags: resolved.skipped_flags,
-                                explicit_unit: unit.clone(),
-                                field_type: field.ty.clone(),
-                                close: field.attrs.close,
-                                format: format.clone(),
-                            });
-                        }
-                        MetricsFieldKind::Timestamp(_) => {
-                            let ts_name = field.name.as_deref().unwrap_or("timestamp");
-                            v_timestamp_expr = quote! {
-                                Some(::metrique::writer::core::TimestampDescriptor::new(#ts_name))
-                            };
-                        }
-                        _ => {}
-                    }
-                }
+
+            // Chain items after the base segment, in declaration order.
+            // Run segments are recorded by index and materialized after the
+            // walk (a timestamp field may appear after a flatten site).
+            enum ChainItem {
+                Run(usize),
+                Child(Ts2),
             }
-
-            // Generate this variant's descriptor static using the shared helper.
-            let variant_name = format!("{}::{}", struct_name, variant_ident);
-            let ident_prefix = format!("V{}", v_idx);
-            let desc_block = super::generate_style_matched_descriptor(
-                &v_field_metas,
-                &variant_name,
-                &v_timestamp_expr,
-                &ident_prefix,
-            );
-
-            let base = quote! {
-                ::metrique::writer::core::Descriptors::available(
-                    ::std::iter::once(::metrique::writer::core::DescriptorRef::from_static(
-                        #desc_block,
-                        <#ns as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
-                    ))
-                )
+            let mut chain_items: Vec<ChainItem> = Vec::new();
+            let close_run = |runs: &mut Vec<Vec<DescriptorFieldMeta>>,
+                                 chain_items: &mut Vec<ChainItem>| {
+                let run_index = runs.len() - 1;
+                if run_index > 0 && !runs[run_index].is_empty() {
+                    chain_items.push(ChainItem::Run(run_index));
+                }
+                runs.push(Vec::new());
             };
 
-            let (pattern, chain_expr) =
-                build_variant_descriptor_arm(entry_name, variant, &base, &ns);
+            let pattern = match &variant.data {
+                Some(VariantData::Struct(fields)) => {
+                    let mut flatten_bindings: Vec<&Ts2> = Vec::new();
+                    for field in fields {
+                        // Cfg on enum variant fields is rejected at parse time,
+                        // so no cfg handling is needed here (unlike structs).
+                        match &field.attrs.kind {
+                            MetricsFieldKind::Ignore(_) => {}
+                            MetricsFieldKind::Timestamp(_) => {
+                                let ts_name = field.name.as_deref().unwrap_or("timestamp");
+                                v_timestamp_expr = quote! {
+                                    Some(::metrique::writer::core::TimestampDescriptor::new(#ts_name))
+                                };
+                            }
+                            MetricsFieldKind::Field { unit, format, .. } => {
+                                let names: [String; metrique_core::Styles::COUNT] =
+                                    std::array::from_fn(|i| {
+                                        metric_name(root_attrs, styles[i], field)
+                                    });
+                                let resolved = resolve_field_flags(
+                                    &field.attrs.flags,
+                                    &root_attrs.default_flags,
+                                );
+                                runs.last_mut().expect("runs is never empty").push(
+                                    DescriptorFieldMeta {
+                                        names,
+                                        flags: resolved.flags,
+                                        skipped_flags: resolved.skipped_flags,
+                                        explicit_unit: unit.clone(),
+                                        field_type: field.ty.clone(),
+                                        close: field.attrs.close,
+                                        format: format.clone(),
+                                    },
+                                );
+                            }
+                            MetricsFieldKind::Flatten { .. }
+                            | MetricsFieldKind::FlattenEntry(_) => {
+                                close_run(&mut runs, &mut chain_items);
+                                let binding = &field.ident;
+                                flatten_bindings.push(binding);
+                                let child = super::flatten_descriptors_expr(
+                                    &field.attrs.kind,
+                                    &quote! { #binding },
+                                    &ns,
+                                );
+                                chain_items.push(ChainItem::Child(child));
+                            }
+                        }
+                    }
+                    if flatten_bindings.is_empty() {
+                        quote! { #entry_name::#variant_ident { .. } }
+                    } else {
+                        quote! { #entry_name::#variant_ident { #(#flatten_bindings,)* .. } }
+                    }
+                }
+                Some(VariantData::Tuple(tds)) => {
+                    // Tuple variants only contain flatten/ignore fields
+                    // (plain fields are rejected at parse time).
+                    let patterns: Vec<_> = tds
+                        .iter()
+                        .enumerate()
+                        .map(|(i, td)| {
+                            if is_flatten(&td.kind) {
+                                let b = format_ident!("__v{}", i);
+                                quote! { #b }
+                            } else {
+                                quote! { _ }
+                            }
+                        })
+                        .collect();
+                    for (i, td) in tds.iter().enumerate() {
+                        if is_flatten(&td.kind) {
+                            close_run(&mut runs, &mut chain_items);
+                            let b = format_ident!("__v{}", i);
+                            let child = super::flatten_descriptors_expr(
+                                &td.kind,
+                                &quote! { #b },
+                                &ns,
+                            );
+                            chain_items.push(ChainItem::Child(child));
+                        }
+                    }
+                    if tds.iter().any(|td| is_flatten(&td.kind)) {
+                        quote! { #entry_name::#variant_ident(#(#patterns),*) }
+                    } else {
+                        quote! { #entry_name::#variant_ident(..) }
+                    }
+                }
+                None => quote! { #entry_name::#variant_ident },
+            };
+            // Close the trailing run.
+            let last_run = runs.len() - 1;
+            if last_run > 0 && !runs[last_run].is_empty() {
+                chain_items.push(ChainItem::Run(last_run));
+            }
+
+            // Materialize segments. Each run gets its own static block; the
+            // timestamp lives on the base segment.
+            let run_segment = |run: usize, ts_expr: &Ts2| {
+                let ident_prefix = if run == 0 {
+                    format!("V{}", v_idx)
+                } else {
+                    format!("V{}R{}", v_idx, run)
+                };
+                let desc_block = super::generate_style_matched_descriptor(
+                    &runs[run],
+                    &variant_name,
+                    ts_expr,
+                    &ident_prefix,
+                );
+                quote! {
+                    ::metrique::writer::core::Descriptors::available(
+                        ::std::iter::once(::metrique::writer::core::DescriptorRef::from_static(
+                            #desc_block,
+                            <#ns as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
+                        ))
+                    )
+                }
+            };
+
+            let base = run_segment(0, &v_timestamp_expr);
+            let none_ts = quote! { None };
+            let children: Vec<(Vec<Ts2>, Ts2)> = chain_items
+                .iter()
+                .map(|item| match item {
+                    ChainItem::Run(i) => (vec![], run_segment(*i, &none_ts)),
+                    ChainItem::Child(expr) => (vec![], expr.clone()),
+                })
+                .collect();
+            let chain_expr = super::build_descriptors_chain(base, &children);
+
             quote! { #pattern => #chain_expr }
         })
         .collect();
@@ -472,107 +578,4 @@ fn is_flatten(kind: &MetricsFieldKind) -> bool {
         kind,
         MetricsFieldKind::Flatten { .. } | MetricsFieldKind::FlattenEntry(_)
     )
-}
-
-/// Generates a `.chain(child.descriptors())` expression for a flatten field,
-/// including prefix application if the field has one.
-fn flatten_chain_expr(field_kind: &MetricsFieldKind, binding: &Ts2, ns: &Ts2) -> Ts2 {
-    match field_kind {
-        MetricsFieldKind::Flatten { prefix, .. } => {
-            let base = quote! { ::metrique::InflectableEntry::<#ns>::descriptors(#binding) };
-            if let Some(pfx) = prefix {
-                let inflected: Vec<String> = crate::inflect::NameStyle::ALL
-                    .iter()
-                    .map(|s| pfx.apply_prefix_only(*s))
-                    .collect();
-                quote! {
-                    #base.map_available(|d| d.with_prefix(
-                        [#(#inflected),*][<#ns as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX as usize]
-                    ))
-                }
-            } else {
-                base
-            }
-        }
-        MetricsFieldKind::FlattenEntry(_) => {
-            quote! { ::metrique::writer::Entry::descriptors(#binding) }
-        }
-        _ => unreachable!("flatten_chain_expr is only called for flatten/flatten_entry"),
-    }
-}
-
-/// Generates a match arm pattern and iterator expression for one enum variant's descriptors.
-///
-/// Generates a match arm pattern and iterator expression for one enum variant.
-///
-/// Takes the base iterator and appends flatten children's descriptors if the variant has them.
-/// Returns (pattern, chain_expr) for use in the generated match.
-fn build_variant_descriptor_arm(
-    entry_name: &Ident,
-    variant: &MetricsVariant,
-    base: &Ts2,
-    ns: &Ts2,
-) -> (Ts2, Ts2) {
-    let variant_ident = &variant.ident;
-
-    match &variant.data {
-        Some(VariantData::Struct(fields)) => {
-            let flatten_fields: Vec<_> = fields
-                .iter()
-                .filter(|f| is_flatten(&f.attrs.kind))
-                .collect();
-
-            if flatten_fields.is_empty() {
-                (quote! { #entry_name::#variant_ident { .. } }, base.clone())
-            } else {
-                // Cfg on enum variant fields is rejected at parse time, so no cfg filtering needed.
-                let bindings: Vec<_> = flatten_fields.iter().map(|f| &f.ident).collect();
-                let children: Vec<(Vec<Ts2>, Ts2)> = flatten_fields
-                    .iter()
-                    .map(|f| {
-                        let child = flatten_chain_expr(&f.attrs.kind, &f.ident, ns);
-                        (vec![], child)
-                    })
-                    .collect();
-                let expr = super::build_descriptors_chain(base.clone(), &children);
-                (
-                    quote! { #entry_name::#variant_ident { #(#bindings,)* .. } },
-                    expr,
-                )
-            }
-        }
-        Some(VariantData::Tuple(tds)) => {
-            if !tds.iter().any(|td| is_flatten(&td.kind)) {
-                return (quote! { #entry_name::#variant_ident(..) }, base.clone());
-            }
-
-            let patterns: Vec<_> = tds
-                .iter()
-                .enumerate()
-                .map(|(i, td)| {
-                    if is_flatten(&td.kind) {
-                        let b = format_ident!("__v{}", i);
-                        quote! { #b }
-                    } else {
-                        quote! { _ }
-                    }
-                })
-                .collect();
-
-            let children: Vec<(Vec<Ts2>, Ts2)> = tds
-                .iter()
-                .enumerate()
-                .filter(|(_, td)| is_flatten(&td.kind))
-                .map(|(i, td)| {
-                    let b = format_ident!("__v{}", i);
-                    let child = flatten_chain_expr(&td.kind, &quote! { #b }, ns);
-                    (vec![], child)
-                })
-                .collect();
-            let expr = super::build_descriptors_chain(base.clone(), &children);
-
-            (quote! { #entry_name::#variant_ident(#(#patterns),*) }, expr)
-        }
-        None => (quote! { #entry_name::#variant_ident }, base.clone()),
-    }
 }

--- a/metrique-macro/src/entry_impl/enum_impl.rs
+++ b/metrique-macro/src/entry_impl/enum_impl.rs
@@ -393,8 +393,10 @@ fn generate_enum_descriptor(
             // written before any variant fields.
             let mut runs: Vec<Vec<DescriptorFieldMeta>> = vec![Vec::new()];
             if let Some(tag) = &root_attrs.tag {
+                // The write path inflects the tag through the propagated style.
+                let tag_name = tag.field_name(root_attrs);
                 let names: [String; metrique_core::Styles::COUNT] =
-                    std::array::from_fn(|_| tag.field_name(root_attrs));
+                    std::array::from_fn(|i| styles[i].apply(&tag_name));
                 runs[0].push(DescriptorFieldMeta {
                     names,
                     flags: vec![],

--- a/metrique-macro/src/entry_impl/struct_impl.rs
+++ b/metrique-macro/src/entry_impl/struct_impl.rs
@@ -13,8 +13,8 @@ pub(crate) fn generate_struct_entry_impl(
     let writes = generate_write_statements(fields, root_attrs);
     let sample_groups = generate_sample_group_statements(fields, root_attrs);
 
-    // Generate descriptor infrastructure: a __metrique_descriptor(style) method with 4 statics
-    // (one per name style), and a descriptors() method that selects the right one.
+    // Generate descriptor infrastructure: one __metrique_descriptor_run_N()
+    // method per own-field run, and the descriptors() method body.
     let descriptor = generate_descriptor(entry_name, generics, fields, root_attrs);
 
     // Add NS as an additional generic parameter
@@ -48,7 +48,7 @@ pub(crate) fn generate_struct_entry_impl(
 
     quote! {
         const _: () = {
-            // Descriptor: __metrique_descriptor(style) method with 4 statics.
+            // Descriptor: per-run __metrique_descriptor_run_N() methods.
             #descriptor_trait_impls
 
             #[expect(deprecated)]

--- a/metrique-macro/src/entry_impl/struct_impl.rs
+++ b/metrique-macro/src/entry_impl/struct_impl.rs
@@ -96,9 +96,15 @@ fn generate_sample_group_statements(fields: &[MetricsField], root_attrs: &RootAt
 
 /// Generates descriptor infrastructure for a struct entry.
 ///
-/// Collects field metadata (names in 4 styles, tags, units), builds flatten chains
-/// with modifiers, and delegates to shared helpers for the `__metrique_descriptor`
-/// method and the `descriptors()` method body.
+/// Own (non-flatten) fields are split into contiguous runs at flatten
+/// boundaries so that `descriptors()` yields segments in the same order
+/// `Entry::write` emits values: each run of own fields becomes its own
+/// segment, interleaved with the flattened children's segments at their
+/// declaration position.
+///
+/// Run 0 is always emitted (even when empty) so the first segment carries the
+/// entry's canonical name and timestamp; later runs are emitted only when
+/// non-empty.
 fn generate_descriptor(
     entry_name: &Ident,
     generics: &syn::Generics,
@@ -107,15 +113,18 @@ fn generate_descriptor(
 ) -> super::DescriptorOutput {
     let struct_name = entry_name.to_string().trim_end_matches("Entry").to_string();
     let mut timestamp_descriptor = quote! { None };
-    let mut field_metas = Vec::new();
     let styles = NameStyle::ALL;
+    let own_style_ns = make_ns(root_attrs.rename_all, entry_name.span());
 
-    // Collect field metadata and timestamp
+    // Own-field runs split at flatten boundaries, and the chain items
+    // (own-run segments and flatten children) following the base segment,
+    // in declaration order.
+    let mut runs: Vec<Vec<DescriptorFieldMeta>> = vec![Vec::new()];
+    let mut chain_items: Vec<(Vec<Ts2>, Ts2)> = Vec::new();
+
     for field in fields {
         match &field.attrs.kind {
-            MetricsFieldKind::Ignore(_)
-            | MetricsFieldKind::Flatten { .. }
-            | MetricsFieldKind::FlattenEntry(_) => continue,
+            MetricsFieldKind::Ignore(_) => continue,
             MetricsFieldKind::Timestamp(_) => {
                 let name = field.name.as_deref().unwrap_or("timestamp");
                 timestamp_descriptor = quote! {
@@ -126,31 +135,51 @@ fn generate_descriptor(
                 let names: [String; metrique_core::Styles::COUNT] =
                     std::array::from_fn(|i| metric_name(root_attrs, styles[i], field));
                 let resolved = resolve_field_flags(&field.attrs.flags, &root_attrs.default_flags);
-                field_metas.push(DescriptorFieldMeta {
-                    names,
-                    flags: resolved.flags,
-                    skipped_flags: resolved.skipped_flags,
-                    explicit_unit: unit.clone(),
-                    field_type: field.ty.clone(),
-                    close: field.attrs.close,
-                    format: format.clone(),
-                });
+                runs.last_mut()
+                    .expect("runs is never empty")
+                    .push(DescriptorFieldMeta {
+                        names,
+                        flags: resolved.flags,
+                        skipped_flags: resolved.skipped_flags,
+                        explicit_unit: unit.clone(),
+                        field_type: field.ty.clone(),
+                        close: field.attrs.close,
+                        format: format.clone(),
+                    });
+            }
+            MetricsFieldKind::Flatten { .. } | MetricsFieldKind::FlattenEntry(_) => {
+                // Close the current run; non-base runs chain in just before
+                // this flatten's child segments.
+                let run_index = runs.len() - 1;
+                if run_index > 0 && !runs[run_index].is_empty() {
+                    chain_items.push((
+                        vec![],
+                        own_run_segment_expr(entry_name, &own_style_ns, run_index),
+                    ));
+                }
+                runs.push(Vec::new());
+                chain_items.push(flatten_chain_item(field, root_attrs));
             }
         }
+    }
+    // Close the trailing run.
+    let last_run = runs.len() - 1;
+    if last_run > 0 && !runs[last_run].is_empty() {
+        chain_items.push((
+            vec![],
+            own_run_segment_expr(entry_name, &own_style_ns, last_run),
+        ));
     }
 
     let descriptor_impl = generate_descriptor_impl(
         entry_name,
         generics,
         &struct_name,
-        &field_metas,
+        &runs,
         &timestamp_descriptor,
     );
 
-    let own_style_ns = make_ns(root_attrs.rename_all, entry_name.span());
-    let flatten_chains = build_flatten_chains(fields, root_attrs);
-    let descriptors_method =
-        assemble_descriptors_method(entry_name, &own_style_ns, &flatten_chains);
+    let descriptors_method = assemble_descriptors_method(entry_name, &own_style_ns, &chain_items);
 
     super::DescriptorOutput {
         trait_impls: descriptor_impl,
@@ -158,125 +187,49 @@ fn generate_descriptor(
     }
 }
 
-/// Builds the flatten chain entries for the `descriptors()` method.
-///
-/// Each flatten field produces either:
-/// - A normal chain (`.chain(child.descriptors())`) for non-cfg fields
-/// - A cfg-gated let-rebinding (`#[cfg(...)] let __desc = __desc.chain(...)`) for cfg fields
-///
-/// Builds flatten chain entries for the descriptors() method.
-///
-/// Returns flatten_chains where each non-cfg chain is a full
-/// iterator expression (used with make_binary_tree_chain for balanced type nesting).
-/// Cfg-gated chains use let-rebinding and are applied after the tree.
-fn build_flatten_chains(
-    fields: &[MetricsField],
-    root_attrs: &RootAttributes,
-) -> Vec<(Vec<Ts2>, Ts2)> {
-    let mut flatten_chains: Vec<(Vec<Ts2>, Ts2)> = Vec::new();
-
-    for field in fields {
-        match &field.attrs.kind {
-            MetricsFieldKind::Flatten {
-                prefix,
-                default_flags: flatten_default_flags,
-                ..
-            } => {
-                let field_ident = &field.ident;
-                let cfg_attrs: Vec<_> = field.cfg_attrs().collect();
-                let ns = make_ns(root_attrs.rename_all, field.span);
-
-                let prefix_expr = prefix.as_ref().map(|pfx| {
-                    // Generate a per-style prefix array so the correct inflection
-                    // is selected at runtime based on the parent's propagated style.
-                    let inflected: Vec<String> = crate::inflect::NameStyle::ALL
-                        .iter()
-                        .map(|s| pfx.apply_prefix_only(*s))
-                        .collect();
-                    quote! {
-                        .with_prefix(
-                            [#(#inflected),*][<#ns as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX as usize]
-                        )
-                    }
-                });
-
-                let extra_flags_expr = if flatten_default_flags.is_empty() {
-                    None
-                } else {
-                    let flag_exprs: Vec<_> = flatten_default_flags
-                        .iter()
-                        .map(|f| {
-                            let path = &f.path;
-                            quote! { ::metrique::writer::core::FieldFlag::new::<#path>() }
-                        })
-                        .collect();
-                    let num_flags = flag_exprs.len();
-                    Some(quote! {
-                        .with_extra_flags({
-                            static __FLATTEN_FLAGS: [::metrique::writer::core::FieldFlag; #num_flags] = [
-                                #(#flag_exprs),*
-                            ];
-                            &__FLATTEN_FLAGS
-                        })
-                    })
-                };
-
-                let has_transforms = prefix_expr.is_some() || extra_flags_expr.is_some();
-                let child_expr = if has_transforms {
-                    quote! {
-                        ::metrique::InflectableEntry::<#ns>::descriptors(&self.#field_ident)
-                            .map_available(|d| d #prefix_expr #extra_flags_expr)
-                    }
-                } else {
-                    quote! {
-                        ::metrique::InflectableEntry::<#ns>::descriptors(&self.#field_ident)
-                    }
-                };
-
-                flatten_chains.push((
-                    cfg_attrs.iter().map(|a| quote! { #a }).collect(),
-                    child_expr,
-                ));
-            }
-            MetricsFieldKind::FlattenEntry(_) => {
-                let field_ident = &field.ident;
-                let cfg_attrs: Vec<_> = field.cfg_attrs().collect();
-                let child_expr = quote! {
-                    ::metrique::writer::Entry::descriptors(&self.#field_ident)
-                };
-                flatten_chains.push((
-                    cfg_attrs.iter().map(|a| quote! { #a }).collect(),
-                    child_expr,
-                ));
-            }
-            _ => {}
-        }
+/// A `Descriptors` expression yielding the segment for one of the entry's own
+/// field runs.
+fn own_run_segment_expr(entry_name: &Ident, own_style_ns: &Ts2, run: usize) -> Ts2 {
+    let method = super::descriptor_method_ident(run);
+    quote! {
+        ::metrique::writer::core::Descriptors::available(
+            ::std::iter::once(::metrique::writer::core::DescriptorRef::from_static(
+                #entry_name::#method(),
+                <#own_style_ns as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
+            ))
+        )
     }
-
-    flatten_chains
 }
 
-/// Assembles the `descriptors()` method body from the entry's own descriptor
-/// and any flatten chains.
+/// Builds the chain entry for a single flatten field in the `descriptors()`
+/// method.
 ///
-/// When all chains are non-cfg, generates a simple expression chain.
-/// When cfg-gated chains exist, uses let-rebinding so cfg-disabled fields
+/// Returns `(cfg_attrs, expr)` where `expr` yields the child's descriptor
+/// segments with any flatten-site modifiers (prefix, default_flags) applied.
+/// Cfg-gated fields are chained via let-rebinding by `build_descriptors_chain`.
+fn flatten_chain_item(field: &MetricsField, root_attrs: &RootAttributes) -> (Vec<Ts2>, Ts2) {
+    let field_ident = &field.ident;
+    let ns = make_ns(root_attrs.rename_all, field.span);
+    let binding = quote! { &self.#field_ident };
+    let child_expr = super::flatten_descriptors_expr(&field.attrs.kind, &binding, &ns);
+    let cfg_attrs = field.cfg_attrs().map(|a| quote! { #a }).collect();
+    (cfg_attrs, child_expr)
+}
+
+/// Assembles the `descriptors()` method body from the entry's base segment
+/// (own-field run 0) and the interleaved chain items (later own-field runs and
+/// flatten children, in declaration order).
+///
+/// When all chain items are non-cfg, generates a simple expression chain.
+/// When cfg-gated items exist, uses let-rebinding so cfg-disabled fields
 /// are excluded without affecting the iterator type.
 fn assemble_descriptors_method(
     entry_name: &Ident,
     own_style_ns: &Ts2,
-    flatten_chains: &[(Vec<Ts2>, Ts2)],
+    chain_items: &[(Vec<Ts2>, Ts2)],
 ) -> Ts2 {
-    let base_expr = quote! {
-        ::metrique::writer::core::Descriptors::available(
-            ::std::iter::once(::metrique::writer::core::DescriptorRef::from_static(
-                #entry_name::__metrique_descriptor(),
-                <#own_style_ns as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
-            ))
-        )
-    };
-
-    let chain_expr = super::build_descriptors_chain(base_expr, flatten_chains);
+    let base_expr = own_run_segment_expr(entry_name, own_style_ns, 0);
+    let chain_expr = super::build_descriptors_chain(base_expr, chain_items);
 
     quote! {
         fn descriptors(&self) -> ::metrique::writer::core::Descriptors<'_> {

--- a/metrique-macro/src/entry_impl/struct_impl.rs
+++ b/metrique-macro/src/entry_impl/struct_impl.rs
@@ -118,9 +118,28 @@ fn generate_descriptor(
 
     // Own-field runs split at flatten boundaries, and the chain items
     // (own-run segments and flatten children) following the base segment,
-    // in declaration order.
-    let mut runs: Vec<Vec<DescriptorFieldMeta>> = vec![Vec::new()];
+    // in declaration order. Cfg-gated plain fields get a single-field run of
+    // their own, gated the same way, so the descriptor only lists them when
+    // the write path emits them.
+    let mut runs: Vec<super::DescriptorRun> = vec![super::DescriptorRun {
+        cfg: vec![],
+        fields: vec![],
+    }];
     let mut chain_items: Vec<(Vec<Ts2>, Ts2)> = Vec::new();
+    let close_run = |runs: &mut Vec<super::DescriptorRun>,
+                     chain_items: &mut Vec<(Vec<Ts2>, Ts2)>| {
+        let run_index = runs.len() - 1;
+        if run_index > 0 && !runs[run_index].fields.is_empty() {
+            chain_items.push((
+                runs[run_index].cfg.clone(),
+                own_run_segment_expr(entry_name, &own_style_ns, run_index),
+            ));
+        }
+        runs.push(super::DescriptorRun {
+            cfg: vec![],
+            fields: vec![],
+        });
+    };
 
     for field in fields {
         match &field.attrs.kind {
@@ -135,38 +154,42 @@ fn generate_descriptor(
                 let names: [String; metrique_core::Styles::COUNT] =
                     std::array::from_fn(|i| metric_name(root_attrs, styles[i], field));
                 let resolved = resolve_field_flags(&field.attrs.flags, &root_attrs.default_flags);
-                runs.last_mut()
-                    .expect("runs is never empty")
-                    .push(DescriptorFieldMeta {
-                        names,
-                        flags: resolved.flags,
-                        skipped_flags: resolved.skipped_flags,
-                        explicit_unit: unit.clone(),
-                        field_type: field.ty.clone(),
-                        close: field.attrs.close,
-                        format: format.clone(),
-                    });
+                let meta = DescriptorFieldMeta {
+                    names,
+                    flags: resolved.flags,
+                    skipped_flags: resolved.skipped_flags,
+                    explicit_unit: unit.clone(),
+                    field_type: field.ty.clone(),
+                    close: field.attrs.close,
+                    format: format.clone(),
+                };
+                let cfg_attrs: Vec<Ts2> = field.cfg_attrs().map(|a| quote! { #a }).collect();
+                if cfg_attrs.is_empty() {
+                    runs.last_mut()
+                        .expect("runs is never empty")
+                        .fields
+                        .push(meta);
+                } else {
+                    close_run(&mut runs, &mut chain_items);
+                    let run = runs.last_mut().expect("runs is never empty");
+                    run.cfg = cfg_attrs;
+                    run.fields.push(meta);
+                    close_run(&mut runs, &mut chain_items);
+                }
             }
             MetricsFieldKind::Flatten { .. } | MetricsFieldKind::FlattenEntry(_) => {
                 // Close the current run; non-base runs chain in just before
                 // this flatten's child segments.
-                let run_index = runs.len() - 1;
-                if run_index > 0 && !runs[run_index].is_empty() {
-                    chain_items.push((
-                        vec![],
-                        own_run_segment_expr(entry_name, &own_style_ns, run_index),
-                    ));
-                }
-                runs.push(Vec::new());
+                close_run(&mut runs, &mut chain_items);
                 chain_items.push(flatten_chain_item(field, root_attrs));
             }
         }
     }
     // Close the trailing run.
     let last_run = runs.len() - 1;
-    if last_run > 0 && !runs[last_run].is_empty() {
+    if last_run > 0 && !runs[last_run].fields.is_empty() {
         chain_items.push((
-            vec![],
+            runs[last_run].cfg.clone(),
             own_run_segment_expr(entry_name, &own_style_ns, last_run),
         ));
     }

--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -686,6 +686,15 @@ impl Tag {
         }
     }
 
+    /// Get the tag field name as rendered under a propagated name style.
+    /// `name_exact` tags are style-invariant: the name is emitted verbatim.
+    pub(crate) fn styled_name(&self, root_attrs: &RootAttributes, style: NameStyle) -> String {
+        match self {
+            Tag::Inflectable { .. } => style.apply(&self.field_name(root_attrs)),
+            Tag::Exact { name, .. } => name.clone(),
+        }
+    }
+
     pub(crate) fn sample_group(&self) -> bool {
         match self {
             Tag::Inflectable { sample_group, .. } => *sample_group,

--- a/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__debug_derive_passthrough_struct.snap
@@ -20,7 +20,7 @@ const _: () = {
     impl MetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -102,7 +102,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        MetricsEntry::__metrique_descriptor(),
+                        MetricsEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
@@ -18,7 +18,7 @@ const _: () = {
     impl NestedEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -100,7 +100,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        NestedEntry::__metrique_descriptor(),
+                        NestedEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
@@ -314,10 +314,10 @@ const _: () = {
                                         ::metrique::writer::core::FieldDescriptor::builder(
                                                 "operation",
                                             )
-                                            .pascal("operation")
+                                            .pascal("Operation")
                                             .snake("operation")
                                             .kebab("operation")
-                                            .screaming_snake("operation")
+                                            .screaming_snake("OPERATION")
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
                                             .maybe_unit(
@@ -370,10 +370,10 @@ const _: () = {
                                             ::metrique::writer::core::FieldDescriptor::builder(
                                                     "operation",
                                                 )
-                                                .pascal("operation")
+                                                .pascal("Operation")
                                                 .snake("operation")
                                                 .kebab("operation")
-                                                .screaming_snake("operation")
+                                                .screaming_snake("OPERATION")
                                                 .flags(&__METRIQUE_V1_FLAGS_0)
                                                 .skipped_flags(&__METRIQUE_V1_SKIPPED_0)
                                                 .maybe_unit(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
@@ -18,7 +18,7 @@ const _: () = {
     impl NestedEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -100,7 +100,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        NestedEntry::__metrique_descriptor(),
+                        NestedEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag_sample_group.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag_sample_group.snap
@@ -165,10 +165,10 @@ const _: () = {
                                         ::metrique::writer::core::FieldDescriptor::builder(
                                                 "operation",
                                             )
-                                            .pascal("operation")
+                                            .pascal("Operation")
                                             .snake("operation")
                                             .kebab("operation")
-                                            .screaming_snake("operation")
+                                            .screaming_snake("OPERATION")
                                             .flags(&__METRIQUE_V0_FLAGS_0)
                                             .skipped_flags(&__METRIQUE_V0_SKIPPED_0)
                                             .maybe_unit(

--- a/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__exact_prefix_struct.snap
@@ -24,7 +24,7 @@ const _: () = {
     impl RequestMetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -157,7 +157,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        RequestMetricsEntry::__metrique_descriptor(),
+                        RequestMetricsEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
@@ -24,7 +24,7 @@ const _: () = {
     impl RequestMetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FIELDS: [::metrique::writer::core::FieldDescriptor; 0usize] = [];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -128,7 +128,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                     ::std::iter::once(
                         ::metrique::writer::core::DescriptorRef::from_static(
-                            RequestMetricsEntry::__metrique_descriptor(),
+                            RequestMetricsEntry::__metrique_descriptor_run_0(),
                             <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                         ),
                     ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_exact_prefix_struct.snap
@@ -26,6 +26,20 @@ const _: () = {
         #[inline(always)]
         fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
+                static __METRIQUE__FIELDS: [::metrique::writer::core::FieldDescriptor; 0usize] = [];
+                static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
+                        "RequestMetrics",
+                        &__METRIQUE__FIELDS,
+                    )
+                    .maybe_timestamp(None)
+                    .build();
+                &__METRIQUE__DESC
+            }
+        }
+        #[doc(hidden)]
+        #[inline(always)]
+        fn __metrique_descriptor_run_1() -> &'static ::metrique::writer::core::EntryDescriptor {
+            {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__FIELDS: [::metrique::writer::core::FieldDescriptor; 1usize] = [
@@ -134,6 +148,16 @@ const _: () = {
                                         as usize],
                                 )
                         }),
+                )
+                .chain(
+                    ::metrique::writer::core::Descriptors::available(
+                        ::std::iter::once(
+                            ::metrique::writer::core::DescriptorRef::from_static(
+                                RequestMetricsEntry::__metrique_descriptor_run_1(),
+                                <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
+                            ),
+                        ),
+                    ),
                 )
         }
     }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
@@ -26,6 +26,20 @@ const _: () = {
         #[inline(always)]
         fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
+                static __METRIQUE__FIELDS: [::metrique::writer::core::FieldDescriptor; 0usize] = [];
+                static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
+                        "RequestMetrics",
+                        &__METRIQUE__FIELDS,
+                    )
+                    .maybe_timestamp(None)
+                    .build();
+                &__METRIQUE__DESC
+            }
+        }
+        #[doc(hidden)]
+        #[inline(always)]
+        fn __metrique_descriptor_run_1() -> &'static ::metrique::writer::core::EntryDescriptor {
+            {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__FIELDS: [::metrique::writer::core::FieldDescriptor; 1usize] = [
@@ -153,6 +167,16 @@ const _: () = {
                                         as usize],
                                 )
                         }),
+                )
+                .chain(
+                    ::metrique::writer::core::Descriptors::available(
+                        ::std::iter::once(
+                            ::metrique::writer::core::DescriptorRef::from_static(
+                                RequestMetricsEntry::__metrique_descriptor_run_1(),
+                                <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
+                            ),
+                        ),
+                    ),
                 )
         }
     }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__field_inflectable_prefix_struct.snap
@@ -24,7 +24,7 @@ const _: () = {
     impl RequestMetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FIELDS: [::metrique::writer::core::FieldDescriptor; 0usize] = [];
                 static __METRIQUE__DESC: ::metrique::writer::core::EntryDescriptor = ::metrique::writer::core::EntryDescriptor::builder(
@@ -147,7 +147,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                     ::std::iter::once(
                         ::metrique::writer::core::DescriptorRef::from_static(
-                            RequestMetricsEntry::__metrique_descriptor(),
+                            RequestMetricsEntry::__metrique_descriptor_run_0(),
                             <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                         ),
                     ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_cow_lifetime.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_cow_lifetime.snap
@@ -24,7 +24,7 @@ const _: () = {
     impl<'a> FooEntry<'a> {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -161,7 +161,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        FooEntry::__metrique_descriptor(),
+                        FooEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_lifetime.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__metrics_with_lifetime.snap
@@ -24,7 +24,7 @@ const _: () = {
     impl<'a> FooEntry<'a> {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -155,7 +155,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        FooEntry::__metrique_descriptor(),
+                        FooEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
@@ -110,7 +110,7 @@ const _: () = {
     impl MetadataEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -270,7 +270,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        MetadataEntry::__metrique_descriptor(),
+                        MetadataEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_struct.snap
@@ -24,7 +24,7 @@ const _: () = {
     impl RequestMetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -185,7 +185,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        RequestMetricsEntry::__metrique_descriptor(),
+                        RequestMetricsEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_struct.snap
@@ -32,7 +32,7 @@ const _: () = {
     impl RequestMetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -211,7 +211,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        RequestMetricsEntry::__metrique_descriptor(),
+                        RequestMetricsEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_flags.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_flags.snap
@@ -30,7 +30,7 @@ const _: () = {
     impl FlaggedMetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 1usize] = [
                     ::metrique::writer::core::FieldFlag::new::<MyFlag>(),
@@ -227,7 +227,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        FlaggedMetricsEntry::__metrique_descriptor(),
+                        FlaggedMetricsEntry::__metrique_descriptor_run_0(),
                         <NS::PascalCase as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_timestamp_and_unit.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__struct_with_timestamp_and_unit.snap
@@ -32,7 +32,7 @@ const _: () = {
     impl TimestampMetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -172,7 +172,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        TimestampMetricsEntry::__metrique_descriptor(),
+                        TimestampMetricsEntry::__metrique_descriptor_run_0(),
                         <NS::PascalCase as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-macro/src/snapshots/metrique_macro__tests__subfield_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__subfield_struct.snap
@@ -18,7 +18,7 @@ const _: () = {
     impl NestedMetricsEntry {
         #[doc(hidden)]
         #[inline(always)]
-        fn __metrique_descriptor() -> &'static ::metrique::writer::core::EntryDescriptor {
+        fn __metrique_descriptor_run_0() -> &'static ::metrique::writer::core::EntryDescriptor {
             {
                 static __METRIQUE__FLAGS_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
                 static __METRIQUE__SKIPPED_0: [::metrique::writer::core::FieldFlag; 0usize] = [];
@@ -101,7 +101,7 @@ const _: () = {
             ::metrique::writer::core::Descriptors::available(
                 ::std::iter::once(
                     ::metrique::writer::core::DescriptorRef::from_static(
-                        NestedMetricsEntry::__metrique_descriptor(),
+                        NestedMetricsEntry::__metrique_descriptor_run_0(),
                         <NS as ::metrique::NameStyle>::DESCRIPTOR_STYLE_INDEX,
                     ),
                 ),

--- a/metrique-writer-core/src/descriptor.rs
+++ b/metrique-writer-core/src/descriptor.rs
@@ -283,7 +283,7 @@ pub struct DescriptorRef<'a> {
     id: DescriptorId,
     prefixes: SmallVec<[&'static str; 1]>,
     style_index: u8,
-    extra_flags: &'static [FieldFlag],
+    extra_flags: SmallVec<[&'static [FieldFlag]; 1]>,
 }
 
 impl<'a> DescriptorRef<'a> {
@@ -293,13 +293,13 @@ impl<'a> DescriptorRef<'a> {
         descriptor: &'static EntryDescriptor,
         style_index: u8,
     ) -> DescriptorRef<'static> {
-        let id = DescriptorId::compute(descriptor, &[]);
+        let id = DescriptorId::compute(descriptor, &[], &[]);
         DescriptorRef {
             descriptor,
             id,
             prefixes: SmallVec::new(),
             style_index,
-            extra_flags: &[],
+            extra_flags: SmallVec::new(),
         }
     }
 
@@ -308,16 +308,19 @@ impl<'a> DescriptorRef<'a> {
     #[doc(hidden)]
     pub fn with_prefix(mut self, prefix: &'static str) -> Self {
         self.prefixes.insert(0, prefix);
-        self.id = DescriptorId::compute(self.descriptor, &self.prefixes);
+        self.id = DescriptorId::compute(self.descriptor, &self.prefixes, &self.extra_flags);
         self
     }
 
     /// Add extra flags to all fields in this segment (from flatten-site `default_flags`).
-    /// These are merged with each field's own flags at access time, respecting
-    /// field-level skips (flags in a field's `skipped_flags` are never added).
+    /// Multiple calls accumulate, matching the write path where each flatten
+    /// site's `ForceFlagEntryWriter` wraps the next. Extra flags are merged
+    /// with each field's own flags at access time, respecting field-level
+    /// skips (flags in a field's `skipped_flags` are never added).
     #[doc(hidden)]
     pub fn with_extra_flags(mut self, flags: &'static [FieldFlag]) -> Self {
-        self.extra_flags = flags;
+        self.extra_flags.push(flags);
+        self.id = DescriptorId::compute(self.descriptor, &self.prefixes, &self.extra_flags);
         self
     }
 
@@ -379,6 +382,7 @@ impl<'a> FieldView<'a> {
             self.desc
                 .extra_flags
                 .iter()
+                .flat_map(|slice| slice.iter())
                 .filter(move |ef| !skipped.iter().any(|s| s.type_id() == ef.type_id())),
         )
     }
@@ -407,10 +411,17 @@ pub struct DescriptorId(u64);
 
 impl DescriptorId {
     // TODO: consider using fxhash instead to be a bit more collision resistant
-    fn compute(descriptor: &EntryDescriptor, prefixes: &[&'static str]) -> Self {
+    fn compute(
+        descriptor: &EntryDescriptor,
+        prefixes: &[&'static str],
+        extra_flags: &[&'static [FieldFlag]],
+    ) -> Self {
         let mut id = descriptor as *const EntryDescriptor as u64;
         for p in prefixes {
             id = id.wrapping_mul(31).wrapping_add(p.as_ptr() as u64);
+        }
+        for f in extra_flags {
+            id = id.wrapping_mul(31).wrapping_add(f.as_ptr() as u64);
         }
         DescriptorId(id)
     }
@@ -707,6 +718,52 @@ mod tests {
         let plain = DescriptorRef::from_static(&DESC, 0);
         let prefixed = DescriptorRef::from_static(&DESC, 0).with_prefix("Api");
         assert_ne!(plain.id(), prefixed.id());
+    }
+
+    #[test]
+    fn extra_flags_accumulate_and_change_id() {
+        use crate::value::{FlagConstructor, MetricFlags, MetricOptions};
+
+        #[derive(Debug)]
+        struct AOpt;
+        impl MetricOptions for AOpt {}
+        struct A;
+        impl FlagConstructor for A {
+            fn construct() -> MetricFlags<'static> {
+                MetricFlags::upcast(&AOpt)
+            }
+        }
+        #[derive(Debug)]
+        struct BOpt;
+        impl MetricOptions for BOpt {}
+        struct B;
+        impl FlagConstructor for B {
+            fn construct() -> MetricFlags<'static> {
+                MetricFlags::upcast(&BOpt)
+            }
+        }
+
+        static A_FLAGS: [FieldFlag; 1] = [FieldFlag::new::<A>()];
+        static B_FLAGS: [FieldFlag; 1] = [FieldFlag::new::<B>()];
+        static FIELDS: [FieldDescriptor; 1] = [FieldDescriptor::builder("F").build()];
+        static DESC: EntryDescriptor = EntryDescriptor::builder("T", &FIELDS).build();
+
+        // Inner flatten site applies B, outer applies A: both must survive.
+        let plain = DescriptorRef::from_static(&DESC, 0);
+        let stacked = DescriptorRef::from_static(&DESC, 0)
+            .with_extra_flags(&B_FLAGS)
+            .with_extra_flags(&A_FLAGS);
+        let flags: Vec<_> = stacked.fields().next().unwrap().flags().collect();
+        assert!(flags.iter().any(|f| f.is::<A>()));
+        assert!(flags.iter().any(|f| f.is::<B>()));
+
+        assert_ne!(plain.id(), stacked.id());
+        assert_ne!(
+            DescriptorRef::from_static(&DESC, 0)
+                .with_extra_flags(&B_FLAGS)
+                .id(),
+            stacked.id()
+        );
     }
 
     #[test]

--- a/metrique-writer-core/src/descriptor.rs
+++ b/metrique-writer-core/src/descriptor.rs
@@ -140,11 +140,6 @@ impl TimestampDescriptor {
 }
 
 /// Result of calling `Entry::descriptors()`.
-// Inline capacity for 4 segments makes the Available variant large, but values
-// are short-lived (built and consumed within a sink's descriptors() walk) and
-// staying inline avoids a per-entry heap allocation: run-splitting at flatten
-// boundaries makes 3-4 segments common.
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum Descriptors<'a> {
@@ -156,7 +151,7 @@ pub enum Descriptors<'a> {
 
 /// Opaque container of available descriptor segments.
 #[derive(Debug, Clone)]
-pub struct AvailableDescriptors<'a>(SmallVec<[DescriptorRef<'a>; 4]>);
+pub struct AvailableDescriptors<'a>(SmallVec<[DescriptorRef<'a>; 2]>);
 
 impl<'a> AvailableDescriptors<'a> {
     /// Iterate over the descriptor segments in write order.
@@ -192,7 +187,7 @@ impl<'a> IntoIterator for AvailableDescriptors<'a> {
 
 /// Owned iterator over descriptor segments. Returned by `AvailableDescriptors::into_iter()`.
 #[derive(Debug)]
-pub struct DescriptorIter<'a>(smallvec::IntoIter<[DescriptorRef<'a>; 4]>);
+pub struct DescriptorIter<'a>(smallvec::IntoIter<[DescriptorRef<'a>; 2]>);
 
 impl<'a> Iterator for DescriptorIter<'a> {
     type Item = DescriptorRef<'a>;
@@ -241,7 +236,7 @@ impl<'a> Descriptors<'a> {
     pub fn map_available(self, f: impl FnMut(DescriptorRef<'a>) -> DescriptorRef<'a>) -> Self {
         match self {
             Descriptors::Available(a) => {
-                let mapped: SmallVec<[DescriptorRef<'a>; 4]> = a.0.into_iter().map(f).collect();
+                let mapped: SmallVec<[DescriptorRef<'a>; 2]> = a.0.into_iter().map(f).collect();
                 Descriptors::Available(AvailableDescriptors(mapped))
             }
             Descriptors::Unavailable => Descriptors::Unavailable,

--- a/metrique-writer-core/src/descriptor.rs
+++ b/metrique-writer-core/src/descriptor.rs
@@ -140,6 +140,11 @@ impl TimestampDescriptor {
 }
 
 /// Result of calling `Entry::descriptors()`.
+// Inline capacity for 4 segments makes the Available variant large, but values
+// are short-lived (built and consumed within a sink's descriptors() walk) and
+// staying inline avoids a per-entry heap allocation: run-splitting at flatten
+// boundaries makes 3-4 segments common.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum Descriptors<'a> {
@@ -151,7 +156,7 @@ pub enum Descriptors<'a> {
 
 /// Opaque container of available descriptor segments.
 #[derive(Debug, Clone)]
-pub struct AvailableDescriptors<'a>(SmallVec<[DescriptorRef<'a>; 2]>);
+pub struct AvailableDescriptors<'a>(SmallVec<[DescriptorRef<'a>; 4]>);
 
 impl<'a> AvailableDescriptors<'a> {
     /// Iterate over the descriptor segments in write order.
@@ -187,7 +192,7 @@ impl<'a> IntoIterator for AvailableDescriptors<'a> {
 
 /// Owned iterator over descriptor segments. Returned by `AvailableDescriptors::into_iter()`.
 #[derive(Debug)]
-pub struct DescriptorIter<'a>(smallvec::IntoIter<[DescriptorRef<'a>; 2]>);
+pub struct DescriptorIter<'a>(smallvec::IntoIter<[DescriptorRef<'a>; 4]>);
 
 impl<'a> Iterator for DescriptorIter<'a> {
     type Item = DescriptorRef<'a>;
@@ -236,7 +241,7 @@ impl<'a> Descriptors<'a> {
     pub fn map_available(self, f: impl FnMut(DescriptorRef<'a>) -> DescriptorRef<'a>) -> Self {
         match self {
             Descriptors::Available(a) => {
-                let mapped: SmallVec<[DescriptorRef<'a>; 2]> = a.0.into_iter().map(f).collect();
+                let mapped: SmallVec<[DescriptorRef<'a>; 4]> = a.0.into_iter().map(f).collect();
                 Descriptors::Available(AvailableDescriptors(mapped))
             }
             Descriptors::Unavailable => Descriptors::Unavailable,

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -2077,9 +2077,5 @@ fn enum_tag_name_inflects_with_propagated_style() {
     // The enum has no rename_all, so the parent's PascalCase propagates to
     // the tag on the write path.
     assert_eq!(write_order(&entry), vec!["OperationType", "SomeField"]);
-
-    // FIXME: inverted assertion documenting the current bug: the descriptor
-    // reports the tag name uninflected ("operation_type") while write()
-    // emits "OperationType". Flip to assert_eq! with the fix.
-    assert_ne!(descriptor_order(&entry), write_order(&entry));
+    assert_eq!(descriptor_order(&entry), write_order(&entry));
 }

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -2011,3 +2011,49 @@ fn cfg_disabled_plain_field_excluded_from_descriptor() {
     let lens: Vec<_> = descriptors.iter().map(|d| d.fields_len()).collect();
     assert_eq!(lens, vec![1, 1, 1]);
 }
+
+#[metrics(subfield)]
+pub struct DeepFlagChild {
+    deep_value: u64,
+}
+
+#[metrics(subfield)]
+pub struct MidFlagChild {
+    mid_value: u64,
+    #[metrics(flatten, default_flags(Dial9Emit))]
+    deep: DeepFlagChild,
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct NestedFlagParent {
+    #[metrics(flatten, default_flags(AuditExport))]
+    mid: MidFlagChild,
+}
+
+#[test]
+fn nested_flatten_default_flags_accumulate() {
+    let m = NestedFlagParent {
+        mid: MidFlagChild {
+            mid_value: 1,
+            deep: DeepFlagChild { deep_value: 2 },
+        },
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+    let descriptors = entry.descriptors().unwrap();
+
+    // Segments: [parent (empty)], [mid], [deep]
+    let deep_seg = descriptors
+        .iter()
+        .find(|d| d.name() == "DeepFlagChild")
+        .unwrap();
+    let deep_flags: Vec<_> = deep_seg.fields().next().unwrap().flags().collect();
+
+    // The write path applies both flatten-site default_flags to the deep
+    // field (nested ForceFlagEntryWriters). The descriptor must agree.
+    // FIXME: inverted assertions documenting the current bug: the outer
+    // flatten's with_extra_flags replaces the inner's instead of merging.
+    // Flip with the fix.
+    assert!(deep_flags.iter().any(|f| f.is::<AuditExport>()));
+    assert!(!deep_flags.iter().any(|f| f.is::<Dial9Emit>()));
+}

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -2079,3 +2079,34 @@ fn enum_tag_name_inflects_with_propagated_style() {
     assert_eq!(write_order(&entry), vec!["OperationType", "SomeField"]);
     assert_eq!(descriptor_order(&entry), write_order(&entry));
 }
+
+#[metrics(subfield, tag(name_exact = "raw_name"))]
+pub enum ExactTagStyleEnum {
+    DoThing { some_field: u64 },
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct ExactTagStyleParent {
+    #[metrics(flatten)]
+    op: ExactTagStyleEnum,
+}
+
+#[test]
+fn enum_exact_tag_name_ignores_propagated_style() {
+    let m = ExactTagStyleParent {
+        op: ExactTagStyleEnum::DoThing { some_field: 1 },
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+
+    // `name_exact` promises the tag name is emitted verbatim, unaffected by
+    // any styling.
+    let expected = vec!["raw_name".to_owned(), "SomeField".to_owned()];
+
+    // FIXME: inverted assertions documenting the current bug: both the write
+    // path and the descriptor inflect the exact tag name through the
+    // propagated PascalCase style, emitting "RawName". Flip to assert_eq!
+    // with the fix.
+    assert_ne!(write_order(&entry), expected);
+    assert_ne!(descriptor_order(&entry), expected);
+}

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -1726,3 +1726,153 @@ mod shape_tests {
         assert_field_shape(&entry, 0, FieldShape::Opaque);
     }
 }
+
+// ─── Write order vs descriptor segment order ────────────────────────────────
+//
+// The `Entry::write` order contract (docs/entry-descriptors.md) requires that
+// walking `descriptors()` segments in sequence yields fields in exactly the
+// order `Entry::write` emits `EntryWriter::value` callbacks.
+
+/// Captures the order of `EntryWriter::value` callbacks.
+#[derive(Default)]
+struct ValueOrderWriter {
+    names: Vec<String>,
+}
+
+impl<'a> metrique::writer::EntryWriter<'a> for ValueOrderWriter {
+    fn timestamp(&mut self, _timestamp: SystemTime) {}
+
+    fn value(
+        &mut self,
+        name: impl Into<std::borrow::Cow<'a, str>>,
+        _value: &(impl metrique_writer_core::Value + ?Sized),
+    ) {
+        self.names.push(name.into().into_owned());
+    }
+
+    fn config(&mut self, _config: &'a dyn metrique_writer_core::EntryConfig) {}
+}
+
+/// Field names in the order `Entry::write` emits them.
+fn write_order(entry: &impl Entry) -> Vec<String> {
+    let mut writer = ValueOrderWriter::default();
+    entry.write(&mut writer);
+    writer.names
+}
+
+/// Field names in the order the descriptor segments list them.
+fn descriptor_order(entry: &impl Entry) -> Vec<String> {
+    entry
+        .descriptors()
+        .unwrap()
+        .iter()
+        .flat_map(|seg| {
+            seg.fields()
+                .map(|f| f.name_parts().collect::<String>())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+#[metrics(subfield, rename_all = "PascalCase")]
+pub struct OrderChild {
+    child_value: u64,
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct FlattenFirstParent {
+    #[metrics(flatten)]
+    child: OrderChild,
+    own_field: u64,
+}
+
+#[test]
+fn flatten_first_descriptor_order_matches_write_order() {
+    let m = FlattenFirstParent {
+        child: OrderChild { child_value: 1 },
+        own_field: 2,
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+
+    // Write order: ChildValue, OwnField.
+    assert_eq!(write_order(&entry), vec!["ChildValue", "OwnField"]);
+
+    // FIXME: inverted assertion documenting the current bug. descriptors()
+    // puts the parent segment ahead of the flattened child even though the
+    // child's fields are written first. Flip to assert_eq! with the fix.
+    assert_ne!(descriptor_order(&entry), write_order(&entry));
+}
+
+#[metrics(subfield, rename_all = "PascalCase")]
+struct SecondOrderChild {
+    other_value: u64,
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct InterleavedParent {
+    alpha: u64,
+    #[metrics(flatten, prefix = "first_")]
+    first: OrderChild,
+    beta: u64,
+    #[metrics(flatten, prefix = "second_")]
+    second: SecondOrderChild,
+    gamma: u64,
+}
+
+#[test]
+fn interleaved_flatten_descriptor_order_matches_write_order() {
+    let m = InterleavedParent {
+        alpha: 1,
+        first: OrderChild { child_value: 2 },
+        beta: 3,
+        second: SecondOrderChild { other_value: 4 },
+        gamma: 5,
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+
+    assert_eq!(
+        write_order(&entry),
+        vec![
+            "Alpha",
+            "FirstChildValue",
+            "Beta",
+            "SecondOtherValue",
+            "Gamma"
+        ]
+    );
+
+    // FIXME: inverted assertion documenting the current bug. Flip to
+    // assert_eq! with the fix.
+    assert_ne!(descriptor_order(&entry), write_order(&entry));
+}
+
+#[metrics(rename_all = "PascalCase", tag(name = "operation"))]
+enum OrderEnum {
+    FlattenFirst {
+        #[metrics(flatten)]
+        child: OrderChild,
+        own_field: u64,
+    },
+}
+
+#[test]
+fn enum_flatten_first_descriptor_order_matches_write_order() {
+    let m = OrderEnum::FlattenFirst {
+        child: OrderChild { child_value: 1 },
+        own_field: 2,
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+
+    // Tag writes first, then fields in declaration order.
+    assert_eq!(
+        write_order(&entry),
+        vec!["Operation", "ChildValue", "OwnField"]
+    );
+
+    // FIXME: inverted assertion documenting the current bug. Flip to
+    // assert_eq! with the fix.
+    assert_ne!(descriptor_order(&entry), write_order(&entry));
+}

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -2054,3 +2054,32 @@ fn nested_flatten_default_flags_accumulate() {
     assert!(deep_flags.iter().any(|f| f.is::<AuditExport>()));
     assert!(deep_flags.iter().any(|f| f.is::<Dial9Emit>()));
 }
+
+#[metrics(subfield, tag(name = "operation_type"))]
+pub enum TagStyleEnum {
+    DoThing { some_field: u64 },
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct TagStyleParent {
+    #[metrics(flatten)]
+    op: TagStyleEnum,
+}
+
+#[test]
+fn enum_tag_name_inflects_with_propagated_style() {
+    let m = TagStyleParent {
+        op: TagStyleEnum::DoThing { some_field: 1 },
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+
+    // The enum has no rename_all, so the parent's PascalCase propagates to
+    // the tag on the write path.
+    assert_eq!(write_order(&entry), vec!["OperationType", "SomeField"]);
+
+    // FIXME: inverted assertion documenting the current bug: the descriptor
+    // reports the tag name uninflected ("operation_type") while write()
+    // emits "OperationType". Flip to assert_eq! with the fix.
+    assert_ne!(descriptor_order(&entry), write_order(&entry));
+}

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -2003,9 +2003,11 @@ fn cfg_disabled_plain_field_excluded_from_descriptor() {
     let entry = metrique::RootEntry::new(closed);
 
     assert_eq!(write_order(&entry), vec!["Before", "TestOnly", "After"]);
+    assert_eq!(descriptor_order(&entry), write_order(&entry));
 
-    // FIXME: inverted assertion documenting the current bug. The descriptor
-    // lists cfg-disabled plain fields even though write() never emits them.
-    // Flip to assert_eq! with the fix.
-    assert_ne!(descriptor_order(&entry), write_order(&entry));
+    // The active cfg field gets its own gated segment; the disabled one
+    // leaves two adjacent parent runs behind.
+    let descriptors = entry.descriptors().unwrap();
+    let lens: Vec<_> = descriptors.iter().map(|d| d.fields_len()).collect();
+    assert_eq!(lens, vec![1, 1, 1]);
 }

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -2051,9 +2051,6 @@ fn nested_flatten_default_flags_accumulate() {
 
     // The write path applies both flatten-site default_flags to the deep
     // field (nested ForceFlagEntryWriters). The descriptor must agree.
-    // FIXME: inverted assertions documenting the current bug: the outer
-    // flatten's with_extra_flags replaces the inner's instead of merging.
-    // Flip with the fix.
     assert!(deep_flags.iter().any(|f| f.is::<AuditExport>()));
-    assert!(!deep_flags.iter().any(|f| f.is::<Dial9Emit>()));
+    assert!(deep_flags.iter().any(|f| f.is::<Dial9Emit>()));
 }

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -1981,3 +1981,31 @@ fn enum_flatten_default_flags_applied_to_child_descriptor() {
     assert_eq!(flags.len(), 1);
     assert_eq!(flags[0].type_id(), TypeId::of::<AuditExport>());
 }
+
+#[metrics(rename_all = "PascalCase")]
+struct CfgPlainFieldParent {
+    before: u64,
+    #[cfg(feature = "__metrique_nonexistent_feature")]
+    never_written: u64,
+    #[cfg(test)]
+    test_only: u64,
+    after: u64,
+}
+
+#[test]
+fn cfg_disabled_plain_field_excluded_from_descriptor() {
+    let m = CfgPlainFieldParent {
+        before: 1,
+        test_only: 2,
+        after: 3,
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+
+    assert_eq!(write_order(&entry), vec!["Before", "TestOnly", "After"]);
+
+    // FIXME: inverted assertion documenting the current bug. The descriptor
+    // lists cfg-disabled plain fields even though write() never emits them.
+    // Flip to assert_eq! with the fix.
+    assert_ne!(descriptor_order(&entry), write_order(&entry));
+}

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -658,17 +658,23 @@ fn enum_variant_field_order_matches_declaration() {
     let entry = metrique::RootEntry::new(closed);
     let descriptors = entry.descriptors().unwrap();
 
-    // Base descriptor has non-flatten fields in declaration order
+    // Own fields split into contiguous runs at the flatten boundary,
+    // in write order: [alpha, beta, gamma], [child], [delta]
+    assert_eq!(descriptors.len(), 3);
     let base_fields: Vec<_> = descriptors[0].fields().collect();
+    assert_eq!(base_fields.len(), 3);
     assert_eq!(base_fields[0].base_name(), "Alpha");
     assert_eq!(base_fields[1].base_name(), "Beta");
     assert_eq!(base_fields[2].base_name(), "Gamma");
-    assert_eq!(base_fields[3].base_name(), "Delta");
 
-    // Flatten child comes after base
-    assert_eq!(descriptors.len(), 2);
+    // Flatten child at its declaration position
     let child_fields: Vec<_> = descriptors[1].fields().collect();
     assert_eq!(child_fields[0].base_name(), "AVal");
+
+    // Trailing own-field run after the flatten
+    let trailing_fields: Vec<_> = descriptors[2].fields().collect();
+    assert_eq!(trailing_fields.len(), 1);
+    assert_eq!(trailing_fields[0].base_name(), "Delta");
 }
 
 #[metrics(subfield)]
@@ -1795,13 +1801,8 @@ fn flatten_first_descriptor_order_matches_write_order() {
     let closed = metrique::CloseValue::close(m);
     let entry = metrique::RootEntry::new(closed);
 
-    // Write order: ChildValue, OwnField.
     assert_eq!(write_order(&entry), vec!["ChildValue", "OwnField"]);
-
-    // FIXME: inverted assertion documenting the current bug. descriptors()
-    // puts the parent segment ahead of the flattened child even though the
-    // child's fields are written first. Flip to assert_eq! with the fix.
-    assert_ne!(descriptor_order(&entry), write_order(&entry));
+    assert_eq!(descriptor_order(&entry), write_order(&entry));
 }
 
 #[metrics(subfield, rename_all = "PascalCase")]
@@ -1843,9 +1844,7 @@ fn interleaved_flatten_descriptor_order_matches_write_order() {
         ]
     );
 
-    // FIXME: inverted assertion documenting the current bug. Flip to
-    // assert_eq! with the fix.
-    assert_ne!(descriptor_order(&entry), write_order(&entry));
+    assert_eq!(descriptor_order(&entry), write_order(&entry));
 }
 
 #[metrics(rename_all = "PascalCase", tag(name = "operation"))]
@@ -1872,7 +1871,113 @@ fn enum_flatten_first_descriptor_order_matches_write_order() {
         vec!["Operation", "ChildValue", "OwnField"]
     );
 
-    // FIXME: inverted assertion documenting the current bug. Flip to
-    // assert_eq! with the fix.
-    assert_ne!(descriptor_order(&entry), write_order(&entry));
+    assert_eq!(descriptor_order(&entry), write_order(&entry));
+}
+
+#[test]
+fn flatten_first_leading_parent_segment_is_empty() {
+    let m = FlattenFirstParent {
+        child: OrderChild { child_value: 1 },
+        own_field: 2,
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+    let descriptors = entry.descriptors().unwrap();
+
+    // The first segment always belongs to the parent so its canonical name
+    // stays discoverable; it consumes zero values.
+    assert_eq!(descriptors.len(), 3);
+    assert_eq!(descriptors[0].name(), "FlattenFirstParent");
+    assert_eq!(descriptors[0].fields_len(), 0);
+    assert_eq!(descriptors[1].name(), "OrderChild");
+    assert_eq!(descriptors[2].name(), "FlattenFirstParent");
+    assert_eq!(descriptors[2].fields_len(), 1);
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct TimestampAfterFlatten {
+    #[metrics(flatten)]
+    child: OrderChild,
+    #[metrics(timestamp)]
+    start: SystemTime,
+    own_field: u64,
+}
+
+#[test]
+fn timestamp_after_flatten_lives_on_first_segment() {
+    let m = TimestampAfterFlatten {
+        child: OrderChild { child_value: 1 },
+        start: SystemTime::UNIX_EPOCH,
+        own_field: 2,
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+    let descriptors = entry.descriptors().unwrap();
+
+    // The timestamp has no position in the value stream, so it lives on the
+    // first segment regardless of where the field is declared.
+    assert_eq!(descriptors[0].name(), "TimestampAfterFlatten");
+    assert_eq!(descriptors[0].timestamp().unwrap().name(), "start");
+    assert!(descriptors[2].timestamp().is_none());
+
+    assert_eq!(descriptor_order(&entry), write_order(&entry));
+}
+
+#[metrics(rename_all = "PascalCase")]
+struct CfgSplitParent {
+    before: u64,
+    #[cfg(feature = "__metrique_nonexistent_feature")]
+    #[metrics(flatten)]
+    never: OrderChild,
+    after: u64,
+}
+
+#[test]
+fn cfg_disabled_flatten_still_splits_own_field_runs() {
+    let m = CfgSplitParent {
+        before: 1,
+        after: 2,
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+    let descriptors = entry.descriptors().unwrap();
+
+    // Runs split at the flatten site even though it is compiled out; two
+    // adjacent parent segments still satisfy the order contract.
+    assert_eq!(descriptors.len(), 2);
+    assert_eq!(
+        descriptors[0].fields().next().unwrap().base_name(),
+        "Before"
+    );
+    assert_eq!(descriptors[1].fields().next().unwrap().base_name(), "After");
+
+    assert_eq!(descriptor_order(&entry), write_order(&entry));
+}
+
+#[metrics(subfield, rename_all = "PascalCase")]
+pub struct FlaggedOrderChild {
+    flagged_value: u64,
+}
+
+#[metrics(rename_all = "PascalCase")]
+enum EnumFlattenFlags {
+    Variant {
+        #[metrics(flatten, default_flags(AuditExport))]
+        child: FlaggedOrderChild,
+    },
+}
+
+#[test]
+fn enum_flatten_default_flags_applied_to_child_descriptor() {
+    let m = EnumFlattenFlags::Variant {
+        child: FlaggedOrderChild { flagged_value: 1 },
+    };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+    let descriptors = entry.descriptors().unwrap();
+
+    let child_fields: Vec<_> = descriptors[1].fields().collect();
+    let flags: Vec<_> = child_fields[0].flags().collect();
+    assert_eq!(flags.len(), 1);
+    assert_eq!(flags[0].type_id(), TypeId::of::<AuditExport>());
 }

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -2100,13 +2100,10 @@ fn enum_exact_tag_name_ignores_propagated_style() {
     let entry = metrique::RootEntry::new(closed);
 
     // `name_exact` promises the tag name is emitted verbatim, unaffected by
-    // any styling.
+    // any styling, including the parent's propagated style.
     let expected = vec!["raw_name".to_owned(), "SomeField".to_owned()];
-
-    // FIXME: inverted assertions documenting the current bug: both the write
-    // path and the descriptor inflect the exact tag name through the
-    // propagated PascalCase style, emitting "RawName". Flip to assert_eq!
-    // with the fix.
-    assert_ne!(write_order(&entry), expected);
-    assert_ne!(descriptor_order(&entry), expected);
+    assert_eq!(
+        (write_order(&entry), descriptor_order(&entry)),
+        (expected.clone(), expected)
+    );
 }


### PR DESCRIPTION
📬 *Issue #, if available:*

Closes https://github.com/awslabs/metrique/issues/345 (discovered while working on https://github.com/dial9-rs/dial9/pull/723)

✍️ *Description of changes:*

`docs/entry-descriptors.md` promises that walking `descriptors()` segments in sequence yields fields in exactly the order `Entry::write` emits `EntryWriter::value` callbacks, with each segment covering a contiguous slice of the write output. That contract broke whenever a flatten site preceded sibling fields: `Entry::write` visits child fields at their declaration position, but `descriptors()` put the whole parent segment ahead of every child segment. Descriptor-aware sinks could not consume positionally, even though the design doc presents that as the intended pattern.

### Summary

The macro now splits an entry's own (non-flatten) fields into contiguous runs at flatten boundaries and emits one descriptor segment per run, interleaved with the flattened children's segments in declaration order. For `Parent { a, flatten child, b }`, `descriptors()` yields `[Parent: a]`, `[Child: ...]`, `[Parent: b]` instead of the old `[Parent: a, b]`, `[Child: ...]`.

The first segment always belongs to the parent, even when no own fields precede the first flatten site (it then lists zero fields and consumes zero values). This keeps the parent's canonical name first and gives the timestamp descriptor a stable home: the timestamp flows through `EntryWriter::timestamp` rather than `value()`, so it has no position in the field stream. Later runs are emitted only when non-empty, so entries whose flattens all trail their own fields (the common layout) generate identical output to before. A cfg-disabled flatten site still splits the surrounding runs; two adjacent parent segments still satisfy the contract, which sidesteps needing cfg-conditional statics.

Enum variants get the same treatment, with the tag field anchoring the first run. As part of unifying the flatten chain generation between structs and enums, enums also pick up a fix for a pre-existing gap: flatten-site `default_flags` on enum variant fields were applied on the write path but never surfaced in the child's descriptor (`with_extra_flags` was only wired up for structs).

Review of the write path surfaced three more descriptor/write-path mismatches in the same class, fixed here as well:

- cfg-gated plain fields were listed in the descriptor unconditionally while `write()` only emits them when the cfg is active. They now get their own cfg-gated segment, so the descriptor tracks whatever the write path compiles to.
- `DescriptorRef::with_extra_flags` replaced rather than accumulated, so nested flatten sites that both carry `default_flags` dropped the inner site's flags from grandchild segments, diverging from the write path's nested `ForceFlagEntryWriter`s. Extra flag slices now stack, and `DescriptorId` incorporates them.
- Enum tag descriptor names were style-invariant while the write path inflects the tag through the propagated name style; a subfield enum without its own `rename_all` flattened into a `PascalCase` parent reported `operation_type` in the descriptor but wrote `OperationType`. The descriptor now carries per-style tag names.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
