### PR TITLE
feat: `AppendAndCloseOnDrop` now avoids allocations unless required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `AppendAndCloseOnDrop` no longer allocates on construction. Heap allocation is deferred until `flush_guard()` or `force_flush_guard()` is called. For the common case (no guards, no handles), construction is zero-allocation.
+
+### Added
+
+- `AppendAndCloseOnDrop::discard()`: drop without emitting, consistent with `TimerGuard::discard()`.
+
 ## [0.1.29](https://github.com/awslabs/metrique/compare/metrique-v0.1.28...metrique-v0.1.29) - 2026-07-27
 
 ### Fixed

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -96,6 +96,11 @@ use metrique_writer_core::EntrySink;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+#[cfg(all(shuttle, feature = "_shuttle"))]
+use shuttle::sync::Mutex;
+#[cfg(not(all(shuttle, feature = "_shuttle")))]
+use std::sync::Mutex;
+
 pub use metrique_core::{
     CloseValue, CloseValueRef, Counter, CounterGuard, InflectableEntry, NameStyle,
     OwnedCounterGuard,
@@ -180,7 +185,9 @@ pub type DefaultSink = metrique_writer_core::sink::BoxEntrySink;
 /// A wrapper that appends and closes an entry when dropped.
 ///
 /// This struct holds a metric entry and a sink. When the struct is dropped,
-/// it closes the entry and appends it to the sink.
+/// it closes the entry and appends it to the sink. Construction is
+/// allocation-free; heap allocation is deferred until [`flush_guard`](Self::flush_guard)
+/// or [`force_flush_guard`](Self::force_flush_guard) is called.
 ///
 /// The [`metrics`] macro generates a type alias to this type
 /// named `<metric struct name>Guard`, you should normally mention that instead
@@ -211,17 +218,46 @@ pub type DefaultSink = metrique_writer_core::sink::BoxEntrySink;
 /// # }
 /// ```
 pub struct AppendAndCloseOnDrop<E: CloseEntry, S: EntrySink<RootMetric<E>>> {
-    inner: Parent<AppendAndCloseOnDropInner<E, S>>,
+    inner: Option<(E, S)>,
+    promoted: Mutex<Option<Parent<PendingEmit<E, S>>>>,
 }
+
+// SAFETY: Mutex<T>: Sync requires T: Send, which would tighten this type's
+// Sync bound to E: Send + Sync. We preserve the pre-existing bound (Sync when
+// E: Sync, S: Sync) because the `promoted` field is only populated through
+// `flush_guard`/`force_flush_guard`, which live on an impl block bounded
+// E: Send + Sync + 'static, S: Send + Sync + 'static.
+//
+// INVARIANT: No method or trait impl outside that bounded impl block may
+// access `self.promoted` through `&self`. Any new `&self` accessor on the
+// unbounded impl blocks must carry Send + Sync bounds, or this impl becomes
+// unsound. `Drop` accesses `promoted` only via `get_mut(&mut self)`
+// (exclusive, no lock).
+unsafe impl<E: CloseEntry + Sync, S: EntrySink<RootMetric<E>> + Sync> Sync
+    for AppendAndCloseOnDrop<E, S>
+{
+}
+
+// E and S are stored inline, so auto-Unpin would be conditional on E: Unpin.
+// Nothing pin-projects into E or S, so unconditional Unpin is correct.
+impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> Unpin for AppendAndCloseOnDrop<E, S> {}
 
 impl<E: CloseEntry + Debug, S: EntrySink<RootMetric<E>> + Debug> Debug
     for AppendAndCloseOnDrop<E, S>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (entry, sink) = self.inner.as_ref().unwrap();
         f.debug_struct("AppendAndCloseOnDrop")
-            .field("value", &self.deref())
-            .field("sink", &self.inner.sink)
+            .field("value", entry)
+            .field("sink", sink)
             .finish()
+    }
+}
+
+impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> AppendAndCloseOnDrop<E, S> {
+    /// Drop without emitting. Any existing flush guards become no-ops.
+    pub fn discard(mut self) {
+        self.inner = None;
     }
 }
 
@@ -297,8 +333,10 @@ impl<E: CloseEntry + Send + Sync + 'static, S: EntrySink<RootMetric<E>> + Send +
     /// }
     /// ```
     pub fn flush_guard(&self) -> FlushGuard {
+        let mut promoted = self.promoted.lock().unwrap_or_else(|e| e.into_inner());
+        let parent = promoted.get_or_insert_with(|| Parent::new(PendingEmit { pending: None }));
         FlushGuard {
-            _drop_guard: self.inner.new_guard(),
+            _drop_guard: parent.new_guard(),
         }
     }
 
@@ -322,7 +360,9 @@ impl<E: CloseEntry + Send + Sync + 'static, S: EntrySink<RootMetric<E>> + Send +
     /// the metrics from the background task written after the timeout will not
     /// be emitted, but the rest the metric entry will be emitted.
     pub fn force_flush_guard(&self) -> ForceFlushGuard {
-        ForceFlushGuard::new(self.inner.force_drop_guard())
+        let mut promoted = self.promoted.lock().unwrap_or_else(|e| e.into_inner());
+        let parent = promoted.get_or_insert_with(|| Parent::new(PendingEmit { pending: None }));
+        ForceFlushGuard::new(parent.force_drop_guard())
     }
 
     /// Return a cloneable handle to the contents. The handle allows for cloneable,
@@ -378,45 +418,39 @@ impl<E: CloseEntry + Send + Sync + 'static, S: EntrySink<RootMetric<E>> + Send +
     }
 }
 
-#[derive(Debug)]
-struct AppendAndCloseOnDropInner<E: CloseEntry, S: EntrySink<RootMetric<E>>> {
-    entry: Option<E>,
-    sink: S,
-}
-
 impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> Deref for AppendAndCloseOnDrop<E, S> {
     type Target = E;
 
     fn deref(&self) -> &Self::Target {
-        self.inner.deref()
+        &self.inner.as_ref().unwrap().0
     }
 }
-//
+
 impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> DerefMut for AppendAndCloseOnDrop<E, S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.inner.deref_mut()
+        &mut self.inner.as_mut().unwrap().0
     }
 }
 
-impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> Deref for AppendAndCloseOnDropInner<E, S> {
-    type Target = E;
-
-    fn deref(&self) -> &Self::Target {
-        self.entry.as_ref().unwrap()
-    }
-}
-
-impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> DerefMut for AppendAndCloseOnDropInner<E, S> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.entry.as_mut().unwrap()
-    }
-}
-
-impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> Drop for AppendAndCloseOnDropInner<E, S> {
+impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> Drop for AppendAndCloseOnDrop<E, S> {
     fn drop(&mut self) {
-        let entry = self.entry.take().expect("only drop calls this");
-        let entry = entry.close();
-        self.sink.append(RootEntry::new(entry));
+        if let Some(inner) = self.inner.take() {
+            let promoted = self.promoted.get_mut().unwrap_or_else(|e| e.into_inner());
+            match promoted {
+                Some(parent) => {
+                    // CORRECTNESS: This transfers ownership of (E, S) into the
+                    // promoted PendingEmit so emission is deferred until the
+                    // last Guard/DropAll drops. Guard/DropAll never read Parent's
+                    // inner T. Happens-before to PendingEmit::drop comes from the
+                    // final Arc strong-count decrement (release/acquire pair).
+                    parent.pending = Some(inner);
+                }
+                None => {
+                    let (entry, sink) = inner;
+                    sink.append(RootEntry::new(entry.close()));
+                }
+            }
+        }
     }
 }
 
@@ -495,18 +529,25 @@ impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> std::ops::Deref
 /// // When `metrics` is dropped, it will be closed and appended to the sink
 /// # }
 /// ```
-pub fn append_and_close<
-    C: CloseEntry + Send + Sync + 'static,
-    S: EntrySink<RootMetric<C>> + Send + Sync + 'static,
->(
+pub fn append_and_close<C: CloseEntry, S: EntrySink<RootMetric<C>>>(
     base: C,
     sink: S,
 ) -> AppendAndCloseOnDrop<C, S> {
     AppendAndCloseOnDrop {
-        inner: Parent::new(AppendAndCloseOnDropInner {
-            entry: Some(base),
-            sink,
-        }),
+        inner: Some((base, sink)),
+        promoted: Mutex::new(None),
+    }
+}
+
+struct PendingEmit<E: CloseEntry, S: EntrySink<RootMetric<E>>> {
+    pending: Option<(E, S)>,
+}
+
+impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> Drop for PendingEmit<E, S> {
+    fn drop(&mut self) {
+        if let Some((entry, sink)) = self.pending.take() {
+            sink.append(RootEntry::new(entry.close()));
+        }
     }
 }
 
@@ -706,4 +747,80 @@ pub mod writer {
     // used by macros
     #[doc(hidden)]
     pub use metrique_writer::core;
+}
+
+#[cfg(all(test, shuttle, feature = "_shuttle"))]
+mod shuttle_promotion_tests {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use metrique_writer_core::shuttle_test;
+
+    use super::*;
+
+    // Minimal entry that satisfies CloseEntry without the #[metrics] macro
+    // (which has crate-version conflicts under the shuttle cfg).
+    #[derive(Default)]
+    struct MinimalEntry;
+
+    impl CloseValue for MinimalEntry {
+        type Closed = MinimalClosed;
+        fn close(self) -> Self::Closed {
+            MinimalClosed
+        }
+    }
+
+    struct MinimalClosed;
+
+    impl InflectableEntry for MinimalClosed {
+        fn write<'a>(&'a self, _w: &mut impl metrique_writer_core::EntryWriter<'a>) {}
+    }
+
+    // Non-locking sink that counts appends via AtomicUsize.
+    #[derive(Clone)]
+    struct CountingSink(Arc<AtomicUsize>);
+
+    impl EntrySink<RootEntry<MinimalClosed>> for CountingSink {
+        fn append(&self, _entry: RootEntry<MinimalClosed>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn flush_async(&self) -> metrique_writer_core::sink::FlushWait {
+            metrique_writer_core::sink::FlushWait::ready()
+        }
+    }
+
+    shuttle_test! {
+        num_iters = 2_000, depth = 4;
+        /// Multiple threads concurrently calling `flush_guard()` on a shared
+        /// `AppendAndCloseOnDrop` must result in exactly one emission.
+        fn shuttle_concurrent_flush_guard_emits_exactly_once() {
+            let emit_count = Arc::new(AtomicUsize::new(0));
+            let sink = CountingSink(emit_count.clone());
+
+            let guard = Arc::new(append_and_close(MinimalEntry, sink));
+
+            let mut handles = vec![];
+            for _ in 0..4 {
+                let g = guard.clone();
+                handles.push(shuttle::thread::spawn(move || {
+                    let _fg = g.flush_guard();
+                    // flush guard dropped at end of scope
+                }));
+            }
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            // All flush guards dropped. Drop the last Arc ref to trigger emission.
+            drop(guard);
+
+            assert_eq!(
+                emit_count.load(Ordering::SeqCst),
+                1,
+                "entry must be emitted exactly once regardless of promotion race"
+            );
+        }
+    }
 }

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -219,23 +219,7 @@ pub type DefaultSink = metrique_writer_core::sink::BoxEntrySink;
 /// ```
 pub struct AppendAndCloseOnDrop<E: CloseEntry, S: EntrySink<RootMetric<E>>> {
     inner: Option<(E, S)>,
-    promoted: Mutex<Option<Parent<PendingEmit<E, S>>>>,
-}
-
-// SAFETY: Mutex<T>: Sync requires T: Send, which would tighten this type's
-// Sync bound to E: Send + Sync. We preserve the pre-existing bound (Sync when
-// E: Sync, S: Sync) because the `promoted` field is only populated through
-// `flush_guard`/`force_flush_guard`, which live on an impl block bounded
-// E: Send + Sync + 'static, S: Send + Sync + 'static.
-//
-// INVARIANT: No method or trait impl outside that bounded impl block may
-// access `self.promoted` through `&self`. Any new `&self` accessor on the
-// unbounded impl blocks must carry Send + Sync bounds, or this impl becomes
-// unsound. `Drop` accesses `promoted` only via `get_mut(&mut self)`
-// (exclusive, no lock).
-unsafe impl<E: CloseEntry + Sync, S: EntrySink<RootMetric<E>> + Sync> Sync
-    for AppendAndCloseOnDrop<E, S>
-{
+    promoted: LazyPromotionSlot<Parent<PendingEmit<E, S>>>,
 }
 
 // E and S are stored inline, so auto-Unpin would be conditional on E: Unpin.
@@ -333,11 +317,12 @@ impl<E: CloseEntry + Send + Sync + 'static, S: EntrySink<RootMetric<E>> + Send +
     /// }
     /// ```
     pub fn flush_guard(&self) -> FlushGuard {
-        let mut promoted = self.promoted.lock().unwrap_or_else(|e| e.into_inner());
-        let parent = promoted.get_or_insert_with(|| Parent::new(PendingEmit { pending: None }));
-        FlushGuard {
-            _drop_guard: parent.new_guard(),
-        }
+        self.promoted.with_init(
+            || Parent::new(PendingEmit { pending: None }),
+            |parent| FlushGuard {
+                _drop_guard: parent.new_guard(),
+            },
+        )
     }
 
     /// <div class="warning">
@@ -360,9 +345,10 @@ impl<E: CloseEntry + Send + Sync + 'static, S: EntrySink<RootMetric<E>> + Send +
     /// the metrics from the background task written after the timeout will not
     /// be emitted, but the rest the metric entry will be emitted.
     pub fn force_flush_guard(&self) -> ForceFlushGuard {
-        let mut promoted = self.promoted.lock().unwrap_or_else(|e| e.into_inner());
-        let parent = promoted.get_or_insert_with(|| Parent::new(PendingEmit { pending: None }));
-        ForceFlushGuard::new(parent.force_drop_guard())
+        self.promoted.with_init(
+            || Parent::new(PendingEmit { pending: None }),
+            |parent| ForceFlushGuard::new(parent.force_drop_guard()),
+        )
     }
 
     /// Return a cloneable handle to the contents. The handle allows for cloneable,
@@ -435,7 +421,7 @@ impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> DerefMut for AppendAndCloseOnDr
 impl<E: CloseEntry, S: EntrySink<RootMetric<E>>> Drop for AppendAndCloseOnDrop<E, S> {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.take() {
-            let promoted = self.promoted.get_mut().unwrap_or_else(|e| e.into_inner());
+            let promoted = self.promoted.get_mut();
             match promoted {
                 Some(parent) => {
                     // CORRECTNESS: This transfers ownership of (E, S) into the
@@ -535,9 +521,55 @@ pub fn append_and_close<C: CloseEntry, S: EntrySink<RootMetric<C>>>(
 ) -> AppendAndCloseOnDrop<C, S> {
     AppendAndCloseOnDrop {
         inner: Some((base, sink)),
-        promoted: Mutex::new(None),
+        promoted: LazyPromotionSlot::new(),
     }
 }
+
+/// A `Mutex<Option<T>>` wrapper that is unconditionally `Sync` by
+/// constraining population to `T: Send` contexts. The slot can only be
+/// filled via `lock_and_init` (bounded on `T: Send`), while `get_mut`
+/// requires `&mut self` (exclusive access, no cross-thread concern).
+///
+/// This encodes the safety invariant structurally: a `!Send` `T` cannot
+/// enter the slot because `lock_and_init` won't compile without `T: Send`.
+struct LazyPromotionSlot<T> {
+    inner: Mutex<Option<T>>,
+}
+
+impl<T> LazyPromotionSlot<T> {
+    fn new() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+
+    fn get_mut(&mut self) -> &mut Option<T> {
+        // Ignore poison: &mut self guarantees exclusivity, so the data is
+        // safe to access regardless of whether a prior lock holder panicked.
+        self.inner.get_mut().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl<T: Send> LazyPromotionSlot<T> {
+    /// Initialize the slot (if empty) and access its contents while the lock
+    /// is held. `init` creates the value on first call; `f` receives a
+    /// reference to the stored value and its return value is forwarded.
+    /// The closure pattern is required because the `MutexGuard` cannot outlive
+    /// the method — returning `&T` directly would dangle.
+    fn with_init<R>(&self, init: impl FnOnce() -> T, f: impl FnOnce(&T) -> R) -> R {
+        // Ignore poison: the only code under the lock is `get_or_insert_with`
+        // which cannot observe inconsistent state from a prior panic.
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let value = guard.get_or_insert_with(init);
+        f(value)
+    }
+}
+
+// SAFETY: The only &self method that accesses the Mutex contents is
+// `with_init`, which requires T: Send. For !Send T, the slot can never be
+// populated through &self — it remains None for the struct's lifetime.
+// `get_mut` requires &mut self (exclusive access, no Sync concern).
+unsafe impl<T> Sync for LazyPromotionSlot<T> {}
 
 struct PendingEmit<E: CloseEntry, S: EntrySink<RootMetric<E>>> {
     pending: Option<(E, S)>,

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -525,13 +525,10 @@ pub fn append_and_close<C: CloseEntry, S: EntrySink<RootMetric<C>>>(
     }
 }
 
-/// A `Mutex<Option<T>>` wrapper that is unconditionally `Sync` by
-/// constraining population to `T: Send` contexts. The slot can only be
-/// filled via `lock_and_init` (bounded on `T: Send`), while `get_mut`
-/// requires `&mut self` (exclusive access, no cross-thread concern).
+/// A `Mutex<Option<T>>` wrapper that is unconditionally `Sync`.
 ///
-/// This encodes the safety invariant structurally: a `!Send` `T` cannot
-/// enter the slot because `lock_and_init` won't compile without `T: Send`.
+/// INVARIANT: Any `&self` method that accesses `T` must require `T: Send` in
+/// order for this type  to soundly implement `Sync`.
 struct LazyPromotionSlot<T> {
     inner: Mutex<Option<T>>,
 }
@@ -565,10 +562,10 @@ impl<T: Send> LazyPromotionSlot<T> {
     }
 }
 
-// SAFETY: The only &self method that accesses the Mutex contents is
-// `with_init`, which requires T: Send. For !Send T, the slot can never be
-// populated through &self — it remains None for the struct's lifetime.
-// `get_mut` requires &mut self (exclusive access, no Sync concern).
+// SAFETY: Any `&self` method that accesses `T` requires `T: Send` (currently
+// only `with_init`). `get_mut` requires `&mut self` (exclusive access, not a
+// Sync concern). Therefore `&LazyPromotionSlot<T>` cannot provide cross-thread
+// access to a `!Send` T.
 unsafe impl<T> Sync for LazyPromotionSlot<T> {}
 
 struct PendingEmit<E: CloseEntry, S: EntrySink<RootMetric<E>>> {

--- a/metrique/tests/allocation-count.rs
+++ b/metrique/tests/allocation-count.rs
@@ -46,8 +46,16 @@ fn allocation_counts() {
     // Warm up: first Mutex::lock() allocates on some platforms (e.g. macOS).
     // Run each path once so subsequent measurements are stable.
     drop(TestMetrics::default().append_on_drop(DevNullSink::new()));
-    drop(TestMetrics::default().append_on_drop(DevNullSink::new()).flush_guard());
-    drop(TestMetrics::default().append_on_drop(DevNullSink::new()).handle());
+    drop(
+        TestMetrics::default()
+            .append_on_drop(DevNullSink::new())
+            .flush_guard(),
+    );
+    drop(
+        TestMetrics::default()
+            .append_on_drop(DevNullSink::new())
+            .handle(),
+    );
 
     // --- Common path: construct + mutate + drop = 0 allocations ---
     reset_count();

--- a/metrique/tests/allocation-count.rs
+++ b/metrique/tests/allocation-count.rs
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Verifies that `AppendAndCloseOnDrop` construction and drop are
+//! zero-allocation in the common case (no flush guard, no handle).
+//!
+//! This test uses a global allocator counter, so all assertions must run
+//! sequentially in a single test to avoid cross-contamination.
+
+use metrique::unit_of_work::metrics;
+use metrique::writer::sink::DevNullSink;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct CountingAllocator;
+
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+#[metrics]
+#[derive(Default)]
+struct TestMetrics {
+    value: u32,
+    name: &'static str,
+}
+
+fn reset_count() -> usize {
+    ALLOC_COUNT.swap(0, Ordering::SeqCst)
+}
+
+#[test]
+fn allocation_counts() {
+    // Warm up: first Mutex::lock() allocates on some platforms (e.g. macOS).
+    // Run each path once so subsequent measurements are stable.
+    drop(TestMetrics::default().append_on_drop(DevNullSink::new()));
+    drop(TestMetrics::default().append_on_drop(DevNullSink::new()).flush_guard());
+    drop(TestMetrics::default().append_on_drop(DevNullSink::new()).handle());
+
+    // --- Common path: construct + mutate + drop = 0 allocations ---
+    reset_count();
+    let mut guard = TestMetrics {
+        value: 42,
+        name: "test",
+    }
+    .append_on_drop(DevNullSink::new());
+    guard.value = 99;
+    drop(guard);
+    let allocs = reset_count();
+    assert_eq!(
+        allocs, 0,
+        "common path: expected 0 allocations, got {allocs}"
+    );
+
+    // --- flush_guard path: bounded allocations ---
+    reset_count();
+    let guard = TestMetrics::default().append_on_drop(DevNullSink::new());
+    let fg = guard.flush_guard();
+    drop(guard);
+    drop(fg);
+    let allocs = reset_count();
+    assert!(
+        allocs >= 3,
+        "flush_guard path: expected at least 3 allocations, got {allocs}"
+    );
+    assert!(
+        allocs <= 5,
+        "flush_guard path: expected at most 5 allocations, got {allocs}"
+    );
+
+    // --- handle path: exactly 1 allocation ---
+    reset_count();
+    let guard = TestMetrics::default().append_on_drop(DevNullSink::new());
+    let h = guard.handle();
+    drop(h);
+    let allocs = reset_count();
+    assert_eq!(
+        allocs, 1,
+        "handle path: expected 1 allocation, got {allocs}"
+    );
+}

--- a/metrique/tests/lazy-promotion.rs
+++ b/metrique/tests/lazy-promotion.rs
@@ -1,0 +1,322 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use assert2::check;
+use metrique::test_util::{TestEntrySink, test_entry_sink};
+use metrique::unit_of_work::metrics;
+
+#[metrics]
+#[derive(Default)]
+struct Simple {
+    value: u32,
+    name: &'static str,
+}
+
+#[test]
+fn drop_without_promotion_emits_once() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple {
+        value: 42,
+        name: "hello",
+    }
+    .append_on_drop(sink);
+    guard.value = 99;
+    drop(guard);
+
+    let entries = inspector.entries();
+    check!(entries.len() == 1);
+    check!(entries[0].metrics["value"] == 99);
+    check!(entries[0].values["name"] == "hello");
+}
+
+#[test]
+fn discard_without_promotion_does_not_emit() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let guard = Simple {
+        value: 1,
+        name: "discarded",
+    }
+    .append_on_drop(sink);
+    guard.discard();
+
+    let entries = inspector.entries();
+    check!(entries.is_empty());
+}
+
+#[test]
+fn discard_after_flush_guard_does_not_emit() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let guard = Simple::default().append_on_drop(sink);
+    let flush = guard.flush_guard();
+    guard.discard();
+    drop(flush);
+
+    let entries = inspector.entries();
+    check!(entries.is_empty());
+}
+
+#[test]
+fn flush_guard_then_drop_parent_then_drop_guard() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple {
+        value: 10,
+        name: "deferred",
+    }
+    .append_on_drop(sink);
+    guard.value = 20;
+
+    let flush = guard.flush_guard();
+
+    drop(guard);
+    // Not yet emitted — flush guard alive
+    check!(inspector.entries().is_empty());
+
+    drop(flush);
+    // Now emitted
+    let entries = inspector.entries();
+    check!(entries.len() == 1);
+    check!(entries[0].metrics["value"] == 20);
+}
+
+#[test]
+fn flush_guard_dropped_before_parent() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple {
+        value: 5,
+        name: "immediate",
+    }
+    .append_on_drop(sink);
+    guard.value = 55;
+
+    let flush = guard.flush_guard();
+    drop(flush);
+
+    // Flush guard gone, but parent still alive — no emission yet
+    check!(inspector.entries().is_empty());
+
+    drop(guard);
+    // Now emitted at parent drop
+    let entries = inspector.entries();
+    check!(entries.len() == 1);
+    check!(entries[0].metrics["value"] == 55);
+}
+
+#[test]
+fn multiple_flush_guards_all_must_drop() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let guard = Simple::default().append_on_drop(sink);
+
+    let f1 = guard.flush_guard();
+    let f2 = guard.flush_guard();
+    let f3 = guard.flush_guard();
+
+    drop(guard);
+    check!(inspector.entries().is_empty());
+
+    drop(f1);
+    check!(inspector.entries().is_empty());
+
+    drop(f2);
+    check!(inspector.entries().is_empty());
+
+    drop(f3);
+    check!(inspector.entries().len() == 1);
+}
+
+#[test]
+fn force_flush_guard_dropped_before_parent() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple {
+        value: 7,
+        name: "force",
+    }
+    .append_on_drop(sink);
+    guard.value = 77;
+
+    let force = guard.force_flush_guard();
+    drop(force);
+    // Force flush guard gone, parent still alive
+    check!(inspector.entries().is_empty());
+
+    drop(guard);
+    let entries = inspector.entries();
+    check!(entries.len() == 1);
+    check!(entries[0].metrics["value"] == 77);
+}
+
+#[test]
+fn force_flush_overrides_flush_guard() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let guard = Simple::default().append_on_drop(sink);
+
+    let flush = guard.flush_guard();
+    let force = guard.force_flush_guard();
+
+    drop(guard);
+    // Flush guard still alive, but force flush will override
+    check!(inspector.entries().is_empty());
+
+    drop(force);
+    // Force flush dropped — emits regardless of flush guard
+    check!(inspector.entries().len() == 1);
+
+    drop(flush);
+    // No double-emit
+    check!(inspector.entries().len() == 1);
+}
+
+#[test]
+fn handle_without_promotion_emits_on_last_drop() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple {
+        value: 3,
+        name: "handled",
+    }
+    .append_on_drop(sink);
+    guard.value = 33;
+
+    let handle = guard.handle();
+    check!(inspector.entries().is_empty());
+
+    let h2 = handle.clone();
+    drop(handle);
+    check!(inspector.entries().is_empty());
+
+    drop(h2);
+    let entries = inspector.entries();
+    check!(entries.len() == 1);
+    check!(entries[0].metrics["value"] == 33);
+}
+
+#[test]
+fn deref_mut_mutations_reflected() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple::default().append_on_drop(sink);
+    guard.value = 123;
+    guard.name = "mutated";
+    drop(guard);
+
+    let entries = inspector.entries();
+    check!(entries[0].metrics["value"] == 123);
+    check!(entries[0].values["name"] == "mutated");
+}
+
+#[test]
+fn flush_guard_then_handle_emits_on_last_guard_drop() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple {
+        value: 1,
+        name: "two-stage",
+    }
+    .append_on_drop(sink);
+    guard.value = 11;
+
+    let flush = guard.flush_guard();
+    let handle = guard.handle();
+
+    let h2 = handle.clone();
+    drop(handle);
+    check!(inspector.entries().is_empty());
+
+    drop(h2);
+    // Handle clones all gone, but flush guard still alive
+    check!(inspector.entries().is_empty());
+
+    drop(flush);
+    let entries = inspector.entries();
+    check!(entries.len() == 1);
+    check!(entries[0].metrics["value"] == 11);
+}
+
+#[test]
+fn mutation_after_promotion_reflected_in_emitted_entry() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple {
+        value: 1,
+        name: "before",
+    }
+    .append_on_drop(sink);
+
+    let flush = guard.flush_guard();
+    // Mutate *after* promotion
+    guard.value = 999;
+    guard.name = "after";
+
+    drop(guard);
+    drop(flush);
+
+    let entries = inspector.entries();
+    check!(entries.len() == 1);
+    check!(entries[0].metrics["value"] == 999);
+    check!(entries[0].values["name"] == "after");
+}
+
+#[test]
+fn cross_thread_flush_guard_emits_once() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let mut guard = Simple {
+        value: 7,
+        name: "threaded",
+    }
+    .append_on_drop(sink);
+    guard.value = 77;
+
+    let flush = guard.flush_guard();
+    drop(guard);
+    // Not emitted — flush guard alive
+    check!(inspector.entries().is_empty());
+
+    // Move flush guard to another thread
+    std::thread::spawn(move || drop(flush)).join().unwrap();
+
+    let entries = inspector.entries();
+    check!(entries.len() == 1);
+    check!(entries[0].metrics["value"] == 77);
+}
+
+#[test]
+fn discard_after_force_flush_guard_does_not_emit() {
+    let TestEntrySink { inspector, sink } = test_entry_sink();
+    let guard = Simple::default().append_on_drop(sink);
+    let force = guard.force_flush_guard();
+    guard.discard();
+    drop(force);
+
+    let entries = inspector.entries();
+    check!(entries.is_empty());
+}
+
+// Compile-time assertions: use narrow types that actually exercise the impls
+fn _assert_send_sync_unpin() {
+    use std::marker::PhantomData;
+    use std::marker::PhantomPinned;
+    use std::sync::MutexGuard;
+
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+    fn assert_unpin<T: Unpin>() {}
+
+    // Basic case
+    assert_send::<metrique::AppendAndCloseOnDrop<Simple, metrique::DefaultSink>>();
+    assert_sync::<metrique::AppendAndCloseOnDrop<Simple, metrique::DefaultSink>>();
+    assert_unpin::<metrique::AppendAndCloseOnDrop<Simple, metrique::DefaultSink>>();
+
+    // Sync+!Send entry — exercises the unsafe impl Sync
+    #[metrics]
+    struct SyncNotSend {
+        value: u32,
+        #[metrics(ignore)]
+        _p: PhantomData<MutexGuard<'static, ()>>,
+    }
+    assert_sync::<metrique::AppendAndCloseOnDrop<SyncNotSend, metrique::writer::sink::DevNullSink>>(
+    );
+
+    // !Unpin entry — exercises the impl Unpin
+    #[metrics]
+    struct NotUnpin {
+        value: u32,
+        #[metrics(ignore)]
+        _p: PhantomPinned,
+    }
+    assert_unpin::<metrique::AppendAndCloseOnDrop<NotUnpin, metrique::writer::sink::DevNullSink>>();
+}


### PR DESCRIPTION
`AppendAndCloseOnDrop` now skips allocations unless a `.flush_guard()` is created

📬 *Issue #, if available:*

None that I'm aware of. I think this is a simple enough change that one is probably not required, but I can make one if you prefer.

✍️ *Description of changes:*

`AppendAndCloseOnDrop` now lazily allocates

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
