### PR TITLE
feat(metrique-writer-core): add metric quantization

### DIFF
--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -59,7 +59,7 @@ use crate::inflect::{name_contains_dot, name_contains_uninflectables, name_ends_
 /// | `name` | String | Overrides the field name in metrics | `#[metrics(name = "CustomName")]` |
 /// | `unit` | Path | Specifies the unit for the metric value | `#[metrics(unit = Millisecond)]` |
 /// | `format` | Path | Specifies the formatter (`ValueFormatter`) for the metric value | `#[metrics(format=EpochSeconds)]` |
-/// | `quantize` | List | Reduces the precision of the metric value to `bits` significant bits, with a bounded relative error. `rounding` is one of `floor`, `ceil`, or `midpoint` (the default). See [`metrique::writer::quantize`] | `#[metrics(quantize(bits = 8, rounding = floor))]` |
+/// | `quantize` | List | Reduces the precision of the metric value to `bits` significant bits, with a bounded relative error. `rounding` is one of `floor`, `ceil`, or `midpoint` (the default). See the [`quantize`] module for the error bound at each bit count | `#[metrics(quantize(bits = 8, rounding = floor))]` |
 /// | `timestamp` | Flag | Marks a field as the canonical timestamp | `#[metrics(timestamp)]` |
 /// | `sample_group` | Flag | Marks a field as a sample group - it will still be emitted as a value | `#[metrics(sample_group)]` |
 /// | `prefix` | String | Adds a prefix to flattened entries. Prefix will get inflected to the right case style | `#[metrics(flatten, prefix="prefix-")]` |
@@ -70,6 +70,8 @@ use crate::inflect::{name_contains_dot, name_contains_uninflectables, name_ends_
 /// | `ignore` | Flag | Excludes the field from metrics | `#[metrics(ignore)]` |
 /// | `flags` | Path(s) | Applies a flag to this field for format and sink usage. Use `skip(T)` to explicitly exclude. | `#[metrics(flags(my_crate::flags::Export, skip(OtherFlag)))]` |
 /// | `default_flags` | Path(s) | On a flatten field, applies flags to all child fields. Child field-level skips take precedence. | `#[metrics(flatten, default_flags(my_crate::flags::Export))]` |
+///
+/// [`quantize`]: https://docs.rs/metrique-writer/0.1/metrique_writer/quantize/
 ///
 /// # Variant Attributes
 ///

--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -59,6 +59,7 @@ use crate::inflect::{name_contains_dot, name_contains_uninflectables, name_ends_
 /// | `name` | String | Overrides the field name in metrics | `#[metrics(name = "CustomName")]` |
 /// | `unit` | Path | Specifies the unit for the metric value | `#[metrics(unit = Millisecond)]` |
 /// | `format` | Path | Specifies the formatter (`ValueFormatter`) for the metric value | `#[metrics(format=EpochSeconds)]` |
+/// | `quantize` | List | Reduces the precision of the metric value to `bits` significant bits, with a bounded relative error. `rounding` is one of `floor`, `ceil`, or `midpoint` (the default). See [`metrique::writer::quantize`] | `#[metrics(quantize(bits = 8, rounding = floor))]` |
 /// | `timestamp` | Flag | Marks a field as the canonical timestamp | `#[metrics(timestamp)]` |
 /// | `sample_group` | Flag | Marks a field as a sample group - it will still be emitted as a value | `#[metrics(sample_group)]` |
 /// | `prefix` | String | Adds a prefix to flattened entries. Prefix will get inflected to the right case style | `#[metrics(flatten, prefix="prefix-")]` |
@@ -760,6 +761,198 @@ impl From<RawTag> for Tag {
     }
 }
 
+/// A parsed `quantize(bits = N)` or `quantize(bits = N, rounding = mode)` attribute.
+#[derive(Debug, Clone)]
+pub(crate) struct QuantizeAttr {
+    /// Significant bits to retain. Validated to be in `1..=52` at parse time.
+    pub(crate) bits: u8,
+    /// The rounding mode, defaulting to midpoint.
+    pub(crate) rounding: QuantizeRounding,
+    pub(crate) span: Span,
+}
+
+/// The rounding mode named by a `quantize(..)` attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QuantizeRounding {
+    Floor,
+    Ceil,
+    Midpoint,
+}
+
+impl QuantizeRounding {
+    fn tag_path(self) -> Ts2 {
+        match self {
+            QuantizeRounding::Floor => {
+                quote! { ::metrique::writer::quantize::rounding::Floor }
+            }
+            QuantizeRounding::Ceil => {
+                quote! { ::metrique::writer::quantize::rounding::Ceil }
+            }
+            QuantizeRounding::Midpoint => {
+                quote! { ::metrique::writer::quantize::rounding::Midpoint }
+            }
+        }
+    }
+}
+
+impl QuantizeAttr {
+    /// The `Bits<N, R>` type this attribute denotes.
+    pub(crate) fn tag_type(&self) -> Ts2 {
+        let bits = proc_macro2::Literal::u8_suffixed(self.bits);
+        let rounding = self.rounding.tag_path();
+        quote_spanned! { self.span=> ::metrique::writer::quantize::Bits<#bits, #rounding> }
+    }
+}
+
+impl FromMeta for QuantizeAttr {
+    fn from_meta(item: &syn::Meta) -> darling::Result<Self> {
+        // Parsed by hand rather than via darling's nested derive: a custom `FromMeta` using
+        // `from_list` is silently dropped when it sits alongside darling `Flag` fields in the
+        // same attribute, which is the same limitation `FlagsList` works around above.
+        let list = match item {
+            syn::Meta::List(list) => list,
+            _ => {
+                return Err(darling::Error::custom(
+                    "expected quantize(bits = N) or quantize(bits = N, rounding = floor|ceil|midpoint)",
+                )
+                .with_span(item));
+            }
+        };
+
+        let parsed: syn::punctuated::Punctuated<syn::Meta, syn::Token![,]> = list
+            .parse_args_with(syn::punctuated::Punctuated::parse_terminated)
+            .map_err(|e| darling::Error::custom(e.to_string()).with_span(list))?;
+
+        let mut bits: Option<(u8, Span)> = None;
+        let mut rounding: Option<QuantizeRounding> = None;
+
+        for meta in &parsed {
+            let name_value = match meta {
+                syn::Meta::NameValue(name_value) => name_value,
+                _ => {
+                    return Err(darling::Error::custom(
+                        "expected `bits = N` or `rounding = floor|ceil|midpoint`",
+                    )
+                    .with_span(meta));
+                }
+            };
+
+            if name_value.path.is_ident("bits") {
+                bits = Some(parse_quantize_bits(&name_value.value)?);
+            } else if name_value.path.is_ident("rounding") {
+                rounding = Some(parse_quantize_rounding(&name_value.value)?);
+            } else if name_value.path.is_ident("digits") {
+                // Readers who think in decimal significant digits will reach for this first.
+                // Point them at the bit count that delivers the precision they asked for
+                // rather than leaving them with an "unknown key" error.
+                let suggestion = parse_quantize_digits_suggestion(&name_value.value);
+                return Err(darling::Error::custom(format!(
+                    "quantize takes a bit count, not decimal digits. {suggestion}"
+                ))
+                .with_span(&name_value.path));
+            } else {
+                let key = name_value
+                    .path
+                    .get_ident()
+                    .map(|ident| ident.to_string())
+                    .unwrap_or_else(|| "?".to_string());
+                return Err(darling::Error::custom(format!(
+                    "unknown quantize option `{key}`, expected `bits` or `rounding`"
+                ))
+                .with_span(&name_value.path));
+            }
+        }
+
+        let (bits, span) = bits.ok_or_else(|| {
+            darling::Error::custom("quantize requires `bits = N`, for example quantize(bits = 8)")
+                .with_span(list)
+        })?;
+
+        Ok(QuantizeAttr {
+            bits,
+            rounding: rounding.unwrap_or(QuantizeRounding::Midpoint),
+            span,
+        })
+    }
+}
+
+/// Parse and range-check `bits = N`.
+fn parse_quantize_bits(value: &syn::Expr) -> darling::Result<(u8, Span)> {
+    let lit = match value {
+        syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Int(lit),
+            ..
+        }) => lit,
+        _ => {
+            return Err(
+                darling::Error::custom("expected an integer literal for `bits`").with_span(value),
+            );
+        }
+    };
+
+    let parsed: u64 = lit.base10_parse().map_err(|_| {
+        darling::Error::custom("expected an integer literal for `bits`").with_span(lit)
+    })?;
+
+    // Mirrors `SignificantBits::new`, but reported at expansion time so the diagnostic points
+    // at the attribute rather than at generated code.
+    if !(1..=52).contains(&parsed) {
+        return Err(darling::Error::custom(format!(
+            "quantize bits must be in 1..=52, got {parsed}. \
+             The ceiling is 52 because metric values are carried as f64 in places and an f64 \
+             significand holds 53 bits"
+        ))
+        .with_span(lit));
+    }
+
+    Ok((parsed as u8, lit.span()))
+}
+
+/// Parse `rounding = floor|ceil|midpoint`.
+fn parse_quantize_rounding(value: &syn::Expr) -> darling::Result<QuantizeRounding> {
+    let ident = match value {
+        syn::Expr::Path(path) => path.path.get_ident().cloned().ok_or_else(|| {
+            darling::Error::custom("expected floor, ceil, or midpoint").with_span(value)
+        })?,
+        _ => {
+            return Err(
+                darling::Error::custom("expected floor, ceil, or midpoint").with_span(value)
+            );
+        }
+    };
+
+    match ident.to_string().as_str() {
+        "floor" => Ok(QuantizeRounding::Floor),
+        "ceil" => Ok(QuantizeRounding::Ceil),
+        "midpoint" => Ok(QuantizeRounding::Midpoint),
+        other => Err(darling::Error::custom(format!(
+            "unknown rounding mode `{other}`, expected floor, ceil, or midpoint"
+        ))
+        .with_span(&ident)),
+    }
+}
+
+/// Build the "use bits = N instead" half of the `digits = N` diagnostic.
+fn parse_quantize_digits_suggestion(value: &syn::Expr) -> String {
+    let digits = match value {
+        syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Int(lit),
+            ..
+        }) => lit.base10_parse::<u32>().ok(),
+        _ => None,
+    };
+
+    match digits {
+        // ceil(log2(2 * 10^digits)) is the smallest bit count whose relative error is below
+        // 10^-digits.
+        Some(digits) if (1..=6).contains(&digits) => {
+            let bits = (2.0 * 10f64.powi(digits as i32)).log2().ceil() as u32;
+            format!("For {digits} significant decimal digits, use `bits = {bits}`")
+        }
+        _ => "Use `bits = N`; 8 bits is roughly 2 significant decimal digits".to_string(),
+    }
+}
+
 /// A parsed `flags(Path)` or `flags(skip(Path))` attribute.
 #[derive(Debug, Clone)]
 pub(crate) struct FieldTagAttr {
@@ -1039,6 +1232,9 @@ struct RawMetricsFieldAttrs {
     format: Option<SpannedKv<syn::Path>>,
 
     #[darling(default)]
+    quantize: Option<QuantizeAttr>,
+
+    #[darling(default)]
     name: Option<SpannedKv<String>>,
 
     #[darling(default)]
@@ -1210,6 +1406,15 @@ impl RawMetricsFieldAttrs {
         let name = get_field_option("name", &out, &name)?;
         let unit = get_field_option("unit", &out, &self.unit)?;
         let format = get_field_option("format", &out, &self.format)?;
+        // `get_field_option` wants a `SpannedKv`; `QuantizeAttr` carries its own span, so the
+        // same exclusivity check is spelled out here.
+        let quantize = match (&self.quantize, &out) {
+            (Some(attr), Some((_, other))) => {
+                return Err(cannot_combine_error(other, "quantize", attr.span));
+            }
+            (Some(attr), None) => Some(attr.clone()),
+            _ => None,
+        };
         let sample_group = get_field_flag("sample_group", &out, &self.sample_group)?;
         let close = !self.no_close.is_present();
         if let (false, Some((MetricsFieldKind::Ignore(span), _))) = (close, &out) {
@@ -1283,6 +1488,7 @@ impl RawMetricsFieldAttrs {
                     name: name.cloned(),
                     unit: unit.cloned(),
                     format: format.cloned(),
+                    quantize,
                 },
             },
             flags: {
@@ -1373,6 +1579,15 @@ impl MetricsField {
                 <#base_type as ::metrique::unit::AttachUnit>::Output<#expr>
             }
         }
+        // Applied after the unit wrapper, so the error bound describes the value in the unit it
+        // is emitted in. Quantizing first and converting afterwards would apply the bound in
+        // the source unit and then scale the result off the target unit's lattice.
+        if let Some(quantize) = self.quantize() {
+            let tag = quantize.tag_type();
+            base_type = quote_spanned! { quantize.span=>
+                ::metrique::writer::value::Quantized<#base_type, #tag>
+            }
+        }
         let inner = if named {
             quote! { #ident: #base_type }
         } else {
@@ -1392,6 +1607,33 @@ impl MetricsField {
             MetricsFieldKind::Field { unit, .. } => unit.as_ref(),
             _ => None,
         }
+    }
+
+    fn quantize(&self) -> Option<&QuantizeAttr> {
+        match &self.attrs.kind {
+            MetricsFieldKind::Field { quantize, .. } => quantize.as_ref(),
+            _ => None,
+        }
+    }
+
+    /// The field's type after closing and after any unit conversion, but before quantization.
+    ///
+    /// Used to annotate the intermediate binding when a field carries both `unit` and
+    /// `quantize`: `Quantized::<_, Tag>::from(expr.into())` would otherwise leave the `.into()`
+    /// target ambiguous, since both conversions are generic.
+    fn closed_unit_type(&self) -> Ts2 {
+        let MetricsField { ty, span, .. } = self;
+        let mut base = if self.attrs.close {
+            quote_spanned! { *span=> <#ty as metrique::CloseValue>::Closed }
+        } else {
+            quote_spanned! { *span=> #ty }
+        };
+        if let Some(unit) = self.unit() {
+            base = quote_spanned! { unit.span()=>
+                <#base as ::metrique::unit::AttachUnit>::Output<#unit>
+            };
+        }
+        base
     }
 
     pub(crate) fn close_value(&self, ownership_kind: OwnershipKind) -> Ts2 {
@@ -1416,6 +1658,24 @@ impl MetricsField {
         let base = if let Some(unit) = self.unit() {
             quote_spanned! { unit.span() =>
                 #base.into()
+            }
+        } else {
+            base
+        };
+
+        // `Quantized::<_, Tag>::from` rather than a bare `.into()`, and via an explicitly typed
+        // binding: with a unit conversion also in play, two chained generic conversions would
+        // leave the intermediate type ambiguous.
+        let base = if let Some(quantize) = self.quantize() {
+            let tag = quantize.tag_type();
+            let intermediate = self.closed_unit_type();
+            quote_spanned! { quantize.span =>
+                {
+                    let __metrique_quantize_input: #intermediate = #base;
+                    ::metrique::writer::value::Quantized::<_, #tag>::from(
+                        __metrique_quantize_input,
+                    )
+                }
             }
         } else {
             base
@@ -1579,6 +1839,7 @@ enum MetricsFieldKind {
         unit: Option<syn::Path>,
         name: Option<String>,
         format: Option<syn::Path>,
+        quantize: Option<QuantizeAttr>,
         sample_group: Option<Span>,
     },
 }

--- a/metrique-macro/src/value_impl.rs
+++ b/metrique-macro/src/value_impl.rs
@@ -60,6 +60,7 @@ pub fn validate_value_impl_for_struct(
             sample_group,
             name,
             format: _,
+            quantize: _,
         } = &field.attrs.kind
         {
             if sample_group.is_some() {
@@ -134,6 +135,7 @@ pub(crate) fn generate_value_impl_for_struct(
                 sample_group: _,
                 name: _,
                 format,
+                quantize: _,
             } => {
                 let ident = &field.ident;
                 let value = format_value(

--- a/metrique-writer-core/src/lib.rs
+++ b/metrique-writer-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod descriptor;
 pub mod entry;
 pub mod format;
 pub mod global;
+pub mod quantize;
 pub mod sample;
 pub mod sink;
 pub mod stream;

--- a/metrique-writer-core/src/quantize.rs
+++ b/metrique-writer-core/src/quantize.rs
@@ -1,0 +1,1817 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reduce the precision of metric values, trading a bounded amount of accuracy for a
+//! smaller set of distinct values.
+//!
+//! Emitting values at full precision produces a large set of distinct values. Quantization
+//! shrinks that set: nearby values collapse onto a shared representative, so a stream of
+//! metrics contains fewer unique numbers and compresses better, at the cost of a precisely
+//! bounded amount of accuracy.
+//!
+//! Quantization is always opt-in. Nothing in this module changes how a value is written
+//! unless you explicitly ask for it.
+//!
+//! # How it works
+//!
+//! A [`Quantizer`] retains the leading `N` significant bits of a value and clears the rest.
+//! Equivalently, it rounds the value to the nearest value representable with an `N`-bit
+//! significand — quantizing to `N` bits is exactly the operation of storing the number as a
+//! tiny floating-point value and reading it back.
+//!
+//! Consider `1000` (`0b11_1110_1000`) quantized to 4 significant bits. The value is 10 bits
+//! wide, so the low 6 bits are discarded:
+//!
+//! ```text
+//! 1000 = 0b1111101000
+//!          ^^^^          the 4 bits that are kept
+//!              ^^^^^^    the 6 bits that are discarded
+//!
+//! floor    -> 0b01111000000 =  960
+//! midpoint -> 0b01111100000 =  992
+//! ceil     -> 0b10000000000 = 1024
+//! ```
+//!
+//! Because the discarded bits are always the *least* significant ones, the spacing between
+//! adjacent representable values scales with the magnitude of the value. Small values are
+//! quantized finely and large values coarsely: at 4 bits, `1000` moves by at most 64, while
+//! `1_000_000` moves by at most 65536.
+//!
+//! # Bounded relative error
+//!
+//! The consequence of magnitude-scaled spacing is that error is bounded *relative* to the
+//! value rather than in absolute terms. This is what makes the scheme suitable for
+//! quantities that span many orders of magnitude, such as latencies and byte sizes, where a
+//! fixed absolute error would be far too coarse for small values and pointlessly fine for
+//! large ones.
+//!
+//! For `N` significant bits, the bound is:
+//!
+//! - [`Rounding::Floor`] and [`Rounding::Ceil`]: relative error is strictly less than
+//!   `2^(1-N)`.
+//! - [`Rounding::Midpoint`]: absolute relative error is at most `2^-N`.
+//!
+//! Every bound is a power of two, so the table below is exact rather than rounded:
+//!
+//! | significant bits | `Floor` / `Ceil` (`< 2^(1-N)`) | `Midpoint` (`<= 2^-N`) | exact below |
+//! |---|---|---|---|
+//! | 1 | 100% | 50% | 2 |
+//! | 2 | 50% | 25% | 4 |
+//! | 3 | 25% | 12.5% | 8 |
+//! | 4 | 12.5% | 6.25% | 16 |
+//! | 5 | 6.25% | 3.125% | 32 |
+//! | 6 | 3.125% | 1.5625% | 64 |
+//! | 7 | 1.5625% | 0.78125% | 128 |
+//! | 8 (default) | 0.78125% | 0.390625% | 256 |
+//! | 10 | 0.1953125% | 0.09765625% | 1024 |
+//! | 11 | 0.09765625% | 0.048828125% | 2048 |
+//! | 12 | 0.048828125% | 0.0244140625% | 4096 |
+//! | 16 | 0.0030517578125% | 0.00152587890625% | 65536 |
+//! | 24 | 0.0000119209289550781% | 0.0000059604644775391% | 16777216 |
+//! | 32 | 0.0000000465661287308% | 0.0000000232830643654% | 4294967296 |
+//! | 52 | 0.0000000000000444089% | 0.0000000000000222045% | 2^52 |
+//!
+//! [`SignificantBits::max_relative_error`] returns these values programmatically.
+//!
+//! ## Choosing a bit count
+//!
+//! The `exact below` column is the practical lever. Values narrower than `N` bits are
+//! returned completely unchanged, so `N = 8` leaves every value below 256 exactly as it was.
+//! That is good for correctness — small counters are never disturbed — but it also means
+//! those values contribute nothing to the reduction in distinct values. Lowering `N` widens
+//! the range of values that are actually affected.
+//!
+//! `4..=11` is the practical tuning band. Below 4, the error becomes large enough
+//! (12.5% and up) that only order-of-magnitude questions can be answered. Above about 12,
+//! the value set barely shrinks. Values outside that band are supported, but they are
+//! deliberate extremes rather than defaults.
+//!
+//! The number of distinct values falls off steeply, because each binade is reduced to
+//! `2^(N-1)` representatives regardless of how many distinct inputs landed in it. On a stream
+//! of latencies and byte sizes spanning several orders of magnitude, dropping to 8 bits
+//! typically collapses tens of thousands of distinct values into a few thousand; 4 bits takes
+//! that into the low hundreds. Going below 4 continues to help, but each additional bit
+//! removed roughly doubles the error while yielding progressively less, which is why the
+//! recommended band bottoms out there.
+//!
+//! If you think in decimal significant digits, `N = ceil(log2(2 * 10^digits))` is the
+//! smallest bit count whose relative error is below `10^-digits`:
+//!
+//! | decimal digits | significant bits |
+//! |---|---|
+//! | 1 | 5 |
+//! | 2 | 8 |
+//! | 3 | 11 |
+//! | 4 | 15 |
+//!
+//! # The bucket lattice
+//!
+//! The set of representable values forms a lattice that is uniform within each binade — each
+//! band between consecutive powers of two — and doubles in spacing at every binade boundary.
+//! This makes the layout a piecewise-linear approximation of a logarithmic scale, a
+//! structure usually called *log-linear quantization*.
+//!
+//! Each binade holds exactly `2^(N-1)` representable values, so `N` controls how finely each
+//! power-of-two band is subdivided:
+//!
+//! ```text
+//! N = 3 significant bits, so 4 representable values per binade
+//!
+//! binade [8, 16):    8   10   12   14        spacing 2
+//! binade [16, 32):  16   20   24   28        spacing 4
+//! binade [32, 64):  32   40   48   56        spacing 8
+//! ```
+//!
+//! At `N = 1` each binade collapses to the single power of two that starts it, which is why
+//! one significant bit means 100% worst-case error.
+//!
+//! # Relation to other schemes
+//!
+//! Schemes that hold relative error *exactly* constant place bucket boundaries at `γ^i` for
+//! a fixed base `γ`. OpenTelemetry exponential histograms, Prometheus native histograms, and
+//! DDSketch all work this way.
+//!
+//! The log-linear lattice used here instead *bounds* relative error. Error is largest at the
+//! bottom of each binade, where the spacing has just doubled, and smallest at the top, just
+//! before it doubles again. In exchange, quantizing is a shift and a mask rather than a
+//! logarithm, which is what makes it cheap enough to run on every value at emission time.
+//!
+//! The same segment-and-mantissa structure — an exponent selecting a segment, a mantissa
+//! interpolating linearly within it — has been in continuous use since µ-law and A-law
+//! companding were standardized in ITU-T G.711 in the 1960s.
+//!
+//! # Applying it
+//!
+//! There are three ways to turn quantization on, in increasing order of blast radius.
+//!
+//! ## One field, declared in the struct
+//!
+//! The usual choice. The settings live next to the field they affect, so anyone reading the
+//! struct can see which metrics are approximate and by how much.
+//!
+//! ```
+//! use metrique::unit_of_work::metrics;
+//!
+//! #[metrics(rename_all = "PascalCase")]
+//! struct RequestMetrics {
+//!     // Within 0.390625% of the true value.
+//!     #[metrics(quantize(bits = 8))]
+//!     latency_nanos: u64,
+//!
+//!     // Within 6.25%, and never above the true value.
+//!     #[metrics(quantize(bits = 4, rounding = floor))]
+//!     payload_bytes: u64,
+//!
+//!     // Left exact: a count that has to reconcile.
+//!     request_count: u64,
+//! }
+//! ```
+//!
+//! ## One value, configured at runtime
+//!
+//! When the bit count comes from configuration rather than being fixed at compile time, wrap
+//! the value with [`MetricValue::quantized`](crate::value::MetricValue::quantized).
+//!
+//! ```
+//! use metrique_writer_core::quantize::{Rounding, SignificantBits};
+//! use metrique_writer_core::value::MetricValue;
+//!
+//! # fn configured_bits() -> u8 { 8 }
+//! let bits = SignificantBits::new(configured_bits())?;
+//! let latency = 1_234_567u64.quantized(bits, Rounding::Midpoint);
+//! # Ok::<(), metrique_writer_core::quantize::SignificantBitsError>(())
+//! ```
+//!
+//! ## A whole stream, without touching field declarations
+//!
+//! `metrique-writer` provides `with_quantization`, which applies a quantizer to every entry
+//! passing through a stream. It takes a policy naming the metrics to quantize — there is
+//! deliberately no "quantize everything" option, because a stream almost always carries some
+//! values whose precision matters. See `metrique_writer::stream::QuantizationPolicy`.
+//!
+//! # Behaviour under aggregation
+//!
+//! Metric backends sum and average these values across many records, so the *direction* of the
+//! error matters as much as its size.
+//!
+//! [`Rounding::Floor`] and [`Rounding::Ceil`] move every value the same way. That bias does not
+//! cancel as more records arrive: an average computed from floor-quantized values is
+//! persistently low, by roughly the mean distance from a value to the bottom of its bucket, no
+//! matter how many samples contribute.
+//!
+//! [`Rounding::Midpoint`] moves values in both directions, so the errors largely cancel. The
+//! cancellation is not perfect — values are not uniformly distributed inside a bucket, so the
+//! mean of a bucket's contents does not sit exactly at its midpoint — but the residual bias is
+//! far smaller than either one-sided mode's.
+//!
+//! Prefer [`Rounding::Midpoint`] (the default) for anything that feeds an average, a
+//! percentile, or a sum. Reach for a one-sided mode when a single record's value has to carry a
+//! guarantee on its own.
+//!
+//! # What not to quantize
+//!
+//! Quantization is lossy and must not be applied to values whose exact magnitude carries
+//! meaning:
+//!
+//! - **Timestamps.** Quantizing a Unix epoch value moves it by hours or days.
+//! - **Counts used for exact accounting**, such as billing quantities or request totals
+//!   that must reconcile.
+//! - **Identifiers and enumerations** that happen to be numeric.
+//!
+//! Small counters are a softer case: they are left exact below `exact_below()` anyway, so
+//! quantizing them is usually harmless but also usually pointless.
+
+use std::fmt;
+
+/// The smallest number of significant bits a [`SignificantBits`] may hold.
+pub const MIN_SIGNIFICANT_BITS: u8 = 1;
+
+/// The largest number of significant bits a [`SignificantBits`] may hold.
+///
+/// The ceiling is 52 because metric values are carried as `f64` in several places and an
+/// `f64` significand holds 53 bits. Asking to retain more than 52 significant bits would
+/// silently do nothing to those values while still altering integer ones, which would make
+/// the documented error bound untrue for some values but not others. Rejecting the request
+/// keeps the bound uniform.
+pub const MAX_SIGNIFICANT_BITS: u8 = 52;
+
+/// The error returned when a significant bit count is outside `1..=52`.
+///
+/// See [`MAX_SIGNIFICANT_BITS`] for why the upper bound is 52.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SignificantBitsError {
+    requested: u8,
+}
+
+impl SignificantBitsError {
+    /// The out-of-range bit count that was requested.
+    pub const fn requested(&self) -> u8 {
+        self.requested
+    }
+}
+
+impl fmt::Display for SignificantBitsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "significant bits must be in {MIN_SIGNIFICANT_BITS}..={MAX_SIGNIFICANT_BITS}, got {}",
+            self.requested
+        )
+    }
+}
+
+impl std::error::Error for SignificantBitsError {}
+
+/// The number of leading significant bits a [`Quantizer`] retains.
+///
+/// Valid values are `1..=52`; see [`MAX_SIGNIFICANT_BITS`] for the reason behind the ceiling.
+/// Larger values keep more precision and shrink the set of distinct values less.
+///
+/// ```
+/// use metrique_writer_core::quantize::{Rounding, SignificantBits};
+///
+/// let bits = SignificantBits::new(8).unwrap();
+/// assert_eq!(bits.get(), 8);
+///
+/// // Values narrower than 8 bits are never modified.
+/// assert_eq!(bits.exact_below(), 256);
+///
+/// // Exactly 2^-8 for midpoint rounding.
+/// assert_eq!(bits.max_relative_error(Rounding::Midpoint), 0.00390625);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SignificantBits(u8);
+
+impl Default for SignificantBits {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl SignificantBits {
+    /// Eight significant bits: relative error below 0.78125%, or 0.390625% with
+    /// [`Rounding::Midpoint`]. Values below 256 are left exact.
+    ///
+    /// This is a deliberately conservative default. It sits at the precise end of the
+    /// practical `4..=11` band, so turning quantization on with the default is unlikely to
+    /// disturb anything that was previously graphed, while still collapsing the long tail of
+    /// large values.
+    pub const DEFAULT: Self = Self(8);
+
+    /// Retain `bits` leading significant bits.
+    ///
+    /// Returns [`SignificantBitsError`] if `bits` is outside `1..=52`. Out-of-range input is
+    /// rejected rather than clamped, so a mistaken configuration surfaces immediately
+    /// instead of silently emitting values with a different error bound than intended.
+    ///
+    /// ```
+    /// use metrique_writer_core::quantize::SignificantBits;
+    ///
+    /// assert!(SignificantBits::new(8).is_ok());
+    /// assert!(SignificantBits::new(0).is_err());
+    /// assert!(SignificantBits::new(53).is_err());
+    /// ```
+    pub const fn new(bits: u8) -> Result<Self, SignificantBitsError> {
+        if bits < MIN_SIGNIFICANT_BITS || bits > MAX_SIGNIFICANT_BITS {
+            Err(SignificantBitsError { requested: bits })
+        } else {
+            Ok(Self(bits))
+        }
+    }
+
+    /// The number of significant bits retained.
+    pub const fn get(self) -> u8 {
+        self.0
+    }
+
+    /// Values strictly below this threshold are returned unchanged by a [`Quantizer`].
+    ///
+    /// This is `2^bits`: any value that fits within the retained bits has nothing to
+    /// discard.
+    ///
+    /// ```
+    /// use metrique_writer_core::quantize::SignificantBits;
+    ///
+    /// assert_eq!(SignificantBits::new(1).unwrap().exact_below(), 2);
+    /// assert_eq!(SignificantBits::new(8).unwrap().exact_below(), 256);
+    /// ```
+    pub const fn exact_below(self) -> u64 {
+        1u64 << self.0
+    }
+
+    /// The largest relative error quantizing can introduce, as a fraction of the true value.
+    ///
+    /// For [`Rounding::Floor`] and [`Rounding::Ceil`] this is `2^(1-bits)` and the true error
+    /// is strictly less than the returned value. For [`Rounding::Midpoint`] it is `2^-bits`
+    /// and the true error can reach it exactly.
+    ///
+    /// ```
+    /// use metrique_writer_core::quantize::{Rounding, SignificantBits};
+    ///
+    /// let bits = SignificantBits::new(4).unwrap();
+    /// assert_eq!(bits.max_relative_error(Rounding::Floor), 0.125);
+    /// assert_eq!(bits.max_relative_error(Rounding::Ceil), 0.125);
+    /// assert_eq!(bits.max_relative_error(Rounding::Midpoint), 0.0625);
+    /// ```
+    pub fn max_relative_error(self, rounding: Rounding) -> f64 {
+        let exponent = match rounding {
+            Rounding::Floor | Rounding::Ceil => 1 - i32::from(self.0),
+            Rounding::Midpoint => -i32::from(self.0),
+        };
+        f64::from(exponent).exp2()
+    }
+}
+
+/// Which value within a bucket a [`Quantizer`] emits.
+///
+/// The choice determines what you can promise about the emitted value relative to the true
+/// one. [`Midpoint`](Rounding::Midpoint) is the default because it halves the worst-case
+/// error at no cost to the number of distinct values produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[non_exhaustive]
+pub enum Rounding {
+    /// Emit the bottom of the bucket. The emitted value is always less than or equal to the
+    /// true value, and the relative error is strictly less than `2^(1-bits)`.
+    ///
+    /// Choose this when a value must never overstate the truth — for instance a figure
+    /// feeding a headroom or capacity calculation that should err toward caution.
+    ///
+    /// Because every value in a bucket maps to the bucket's lower edge, the emitted numbers
+    /// have trailing zero bits. Note that the error is one-directional: an average taken
+    /// over many `Floor`-quantized values is biased low, and that bias does not cancel out
+    /// with more samples. Prefer [`Midpoint`](Rounding::Midpoint) for values that are
+    /// aggregated.
+    Floor,
+
+    /// Emit the top of the bucket. The emitted value is always greater than or equal to the
+    /// true value, and the relative error is strictly less than `2^(1-bits)`.
+    ///
+    /// Choose this when a value must never understate the truth. As with
+    /// [`Floor`](Rounding::Floor), the error is one-directional and biases aggregates —
+    /// upward, in this case.
+    Ceil,
+
+    /// Emit the middle of the bucket. The absolute relative error is at most `2^-bits`, but
+    /// the emitted value may be either above or below the true value.
+    ///
+    /// This is the default. Like [`Floor`](Rounding::Floor), it maps an entire bucket onto a
+    /// single representative, so it produces exactly as many distinct values and exactly the
+    /// same value-histogram entropy — while halving the worst-case error and largely
+    /// cancelling the directional bias the one-sided modes introduce into aggregates. Its
+    /// representatives sit mid-bucket rather than on a power-of-two-aligned edge, so the
+    /// encoded form tends to be a percent or two larger than `Floor`'s after compression;
+    /// the number of distinct values, which dominates, is identical.
+    ///
+    /// The tradeoff is that no one-sided promise holds: an emitted value may exceed the true
+    /// value. If a consumer depends on the value never overstating, use
+    /// [`Floor`](Rounding::Floor) explicitly.
+    #[default]
+    Midpoint,
+}
+
+impl Rounding {
+    /// A short, stable name for this mode, suitable for logs and diagnostics.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Rounding::Floor => "floor",
+            Rounding::Ceil => "ceil",
+            Rounding::Midpoint => "midpoint",
+        }
+    }
+}
+
+impl fmt::Display for Rounding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Type-level [`Rounding`] markers, for specifying a mode in a type parameter.
+///
+/// These mirror the [`Rounding`] variants and exist so that quantization settings can be
+/// carried in a type rather than a value, as [`Bits`] does.
+pub mod rounding {
+    use super::Rounding;
+
+    /// A [`Rounding`] mode known at compile time.
+    pub trait RoundingTag {
+        /// The mode this tag denotes.
+        const ROUNDING: Rounding;
+    }
+
+    /// Type-level [`Rounding::Floor`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub struct Floor;
+
+    /// Type-level [`Rounding::Ceil`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub struct Ceil;
+
+    /// Type-level [`Rounding::Midpoint`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub struct Midpoint;
+
+    impl RoundingTag for Floor {
+        const ROUNDING: Rounding = Rounding::Floor;
+    }
+
+    impl RoundingTag for Ceil {
+        const ROUNDING: Rounding = Rounding::Ceil;
+    }
+
+    impl RoundingTag for Midpoint {
+        const ROUNDING: Rounding = Rounding::Midpoint;
+    }
+}
+
+use rounding::RoundingTag;
+
+/// Quantization settings expressed as a type rather than a value.
+///
+/// `Bits<N>` denotes `N` significant bits with the default [`Rounding::Midpoint`];
+/// `Bits<N, R>` denotes `N` bits with the mode named by the [`RoundingTag`] `R`. The bit
+/// count is validated at compile time, so an out-of-range `N` fails to build rather than
+/// failing at runtime.
+///
+/// ```
+/// use metrique_writer_core::quantize::{Bits, Rounding, rounding};
+///
+/// assert_eq!(Bits::<8>::BITS.get(), 8);
+/// assert_eq!(Bits::<8>::ROUNDING, Rounding::Midpoint);
+/// assert_eq!(Bits::<11, rounding::Floor>::ROUNDING, Rounding::Floor);
+/// ```
+///
+/// `Bits::<53>::BITS` does not compile, because 53 is above [`MAX_SIGNIFICANT_BITS`]:
+///
+/// ```compile_fail
+/// use metrique_writer_core::quantize::Bits;
+///
+/// let _ = Bits::<53>::BITS;
+/// ```
+///
+/// Neither does `Bits::<0>::BITS`:
+///
+/// ```compile_fail
+/// use metrique_writer_core::quantize::Bits;
+///
+/// let _ = Bits::<0>::BITS;
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Bits<const N: u8, R: RoundingTag = rounding::Midpoint>(std::marker::PhantomData<R>);
+
+impl<const N: u8, R: RoundingTag> Bits<N, R> {
+    /// The significant bit count `N`, validated at compile time.
+    pub const BITS: SignificantBits = match SignificantBits::new(N) {
+        Ok(bits) => bits,
+        Err(_) => panic!("significant bits must be in 1..=52"),
+    };
+
+    /// The rounding mode denoted by `R`.
+    pub const ROUNDING: Rounding = R::ROUNDING;
+
+    /// The [`Quantizer`] these settings describe.
+    pub const QUANTIZER: Quantizer = Quantizer::new(Self::BITS, Self::ROUNDING);
+}
+
+/// Reduces values to a bounded number of significant bits.
+///
+/// A `Quantizer` pairs a [`SignificantBits`] count with a [`Rounding`] mode. Given a value, it
+/// discards the bits below the leading `N` significant ones and returns the representative of
+/// the resulting bucket selected by the rounding mode.
+///
+/// # Semantics
+///
+/// For a value `v` of bit width `w` retaining `b` bits, where `shift = w - b`,
+/// `low = (v >> shift) << shift` is the bottom of `v`'s bucket, and `step = 1 << shift` is
+/// the bucket's width:
+///
+/// | mode | result | guarantee |
+/// |---|---|---|
+/// | [`Rounding::Floor`] | `low` | `q(v) <= v`, error `< 2^(1-b) * v` |
+/// | [`Rounding::Ceil`] | `low` if `low == v`, else `low + step` | `q(v) >= v`, error `< 2^(1-b) * v` |
+/// | [`Rounding::Midpoint`] | `low + step / 2` | `abs(q(v) - v) <= 2^-b * v` |
+///
+/// When `w <= b` there is nothing to discard and `v` is returned unchanged. This is why
+/// values below [`SignificantBits::exact_below`] always survive intact.
+///
+/// # Properties
+///
+/// - **Idempotent.** `q(q(v)) == q(v)` in every mode, so a value that has already been
+///   quantized is not disturbed by quantizing it again with the same settings.
+/// - **Monotonic.** `a <= b` implies `q(a) <= q(b)`.
+/// - **Never panics.** Arithmetic saturates at [`u64::MAX`], which still satisfies the
+///   [`Rounding::Ceil`] guarantee.
+/// - **Zero is a fixed point** in every mode.
+///
+/// [`Rounding::Midpoint`] is applied unconditionally, including to values that already sit
+/// exactly on a bucket floor. Returning such a value untouched would reduce its error to
+/// zero, but it would also make the bucket produce two distinct outputs instead of one, which
+/// works against the goal of shrinking the set of distinct values. [`Rounding::Ceil`], by
+/// contrast, must leave them alone, both to keep its error tight and to stay idempotent.
+///
+/// # Examples
+///
+/// ```
+/// use metrique_writer_core::quantize::{Quantizer, Rounding, SignificantBits};
+///
+/// let bits = SignificantBits::new(4).unwrap();
+///
+/// let floor = Quantizer::new(bits, Rounding::Floor);
+/// let midpoint = Quantizer::new(bits, Rounding::Midpoint);
+/// let ceil = Quantizer::new(bits, Rounding::Ceil);
+///
+/// // 1000 is 0b1111101000: keep the top 4 bits, discard the low 6.
+/// assert_eq!(floor.quantize_u64(1000), 960);
+/// assert_eq!(midpoint.quantize_u64(1000), 992);
+/// assert_eq!(ceil.quantize_u64(1000), 1024);
+///
+/// // Small values are untouched in every mode.
+/// assert_eq!(floor.quantize_u64(15), 15);
+/// assert_eq!(midpoint.quantize_u64(15), 15);
+/// assert_eq!(ceil.quantize_u64(15), 15);
+/// ```
+///
+/// The error always stays within the documented bound:
+///
+/// ```
+/// use metrique_writer_core::quantize::{Quantizer, Rounding, SignificantBits};
+///
+/// let bits = SignificantBits::new(8).unwrap();
+/// let quantizer = Quantizer::new(bits, Rounding::Midpoint);
+///
+/// let value = 1_234_567u64;
+/// let quantized = quantizer.quantize_u64(value);
+///
+/// let error = (quantized as f64 - value as f64).abs() / value as f64;
+/// assert!(error <= bits.max_relative_error(Rounding::Midpoint));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Quantizer {
+    bits: SignificantBits,
+    rounding: Rounding,
+}
+
+impl Default for Quantizer {
+    /// [`SignificantBits::DEFAULT`] with [`Rounding::Midpoint`]: relative error at most
+    /// 0.390625%, values below 256 untouched.
+    fn default() -> Self {
+        Self::new(SignificantBits::DEFAULT, Rounding::Midpoint)
+    }
+}
+
+impl Quantizer {
+    /// Build a quantizer retaining `bits` significant bits, using `rounding` to pick each
+    /// bucket's representative.
+    pub const fn new(bits: SignificantBits, rounding: Rounding) -> Self {
+        Self { bits, rounding }
+    }
+
+    /// The number of significant bits retained.
+    pub const fn significant_bits(self) -> SignificantBits {
+        self.bits
+    }
+
+    /// The rounding mode used to pick a bucket's representative.
+    pub const fn rounding(self) -> Rounding {
+        self.rounding
+    }
+
+    /// The largest relative error this quantizer can introduce.
+    ///
+    /// Shorthand for [`SignificantBits::max_relative_error`] with this quantizer's mode.
+    pub fn max_relative_error(self) -> f64 {
+        self.bits.max_relative_error(self.rounding)
+    }
+
+    /// Quantize an unsigned integer.
+    ///
+    /// Values below [`SignificantBits::exact_below`] are returned unchanged. See the
+    /// [type-level docs](Quantizer#semantics) for the exact rule applied to larger values.
+    ///
+    /// ```
+    /// use metrique_writer_core::quantize::{Quantizer, Rounding, SignificantBits};
+    ///
+    /// let quantizer = Quantizer::new(SignificantBits::new(3).unwrap(), Rounding::Floor);
+    ///
+    /// // Within a binade the lattice is uniform: [8, 16) has spacing 2.
+    /// assert_eq!(quantizer.quantize_u64(8), 8);
+    /// assert_eq!(quantizer.quantize_u64(9), 8);
+    /// assert_eq!(quantizer.quantize_u64(10), 10);
+    /// assert_eq!(quantizer.quantize_u64(11), 10);
+    ///
+    /// // Crossing into [16, 32) doubles the spacing to 4.
+    /// assert_eq!(quantizer.quantize_u64(16), 16);
+    /// assert_eq!(quantizer.quantize_u64(19), 16);
+    /// assert_eq!(quantizer.quantize_u64(20), 20);
+    /// ```
+    pub const fn quantize_u64(self, value: u64) -> u64 {
+        let bits = self.bits.get() as u32;
+        // Bit width of `value`; 0 when `value` is 0.
+        let width = u64::BITS - value.leading_zeros();
+
+        if width <= bits {
+            // Nothing to discard: the value is already representable exactly.
+            return value;
+        }
+
+        // `width > bits` guarantees `shift >= 1`, so `shift - 1` below cannot underflow.
+        let shift = width - bits;
+        let low = (value >> shift) << shift;
+
+        match self.rounding {
+            Rounding::Floor => low,
+            Rounding::Ceil => {
+                if low == value {
+                    // Already on the lattice. Returning `value` rather than the next point up
+                    // keeps the error at zero and keeps the operation idempotent.
+                    value
+                } else {
+                    // Saturates instead of wrapping near `u64::MAX`. `u64::MAX >= value`
+                    // holds, so the `Ceil` guarantee survives saturation.
+                    low.saturating_add(1u64 << shift)
+                }
+            }
+            // `low + step / 2` cannot exceed `u64::MAX` (the largest possible `low` is
+            // `2^64 - step`, leaving room for `step / 2`), but saturate anyway so that this
+            // can never panic on a metrics path.
+            Rounding::Midpoint => low.saturating_add(1u64 << (shift - 1)),
+        }
+    }
+
+    /// Quantize a floating point value.
+    ///
+    /// This is the same operation as [`quantize_u64`](Quantizer::quantize_u64), applied to the
+    /// significand instead of to an integer: the low `53 - bits` significand bits are cleared,
+    /// and the rounding mode selects a representative from the resulting bucket.
+    ///
+    /// # Values that are passed through unchanged
+    ///
+    /// - Zero, in either sign.
+    /// - Infinities and `NaN`, which have no significand to reduce.
+    /// - Subnormals, whose magnitude is below [`f64::MIN_POSITIVE`]. A subnormal already
+    ///   carries fewer than 53 significant bits, so masking could discard it entirely and
+    ///   report a 100% error. Passing them through keeps the documented bound true of every
+    ///   value this function actually modifies. Subnormals are smaller than `1e-307`, so no
+    ///   realistic metric value is affected.
+    ///
+    /// # Negative values
+    ///
+    /// The mode's promise is about the value, not its magnitude, so the two one-sided modes
+    /// swap when the input is negative: making a negative number's magnitude larger makes the
+    /// number smaller. [`Rounding::Floor`] on `-1000.0` therefore returns `-1024.0`, which is
+    /// still less than or equal to the input.
+    ///
+    /// Note that most metric formats reject negative observations regardless.
+    ///
+    /// # Relationship to [`quantize_u64`](Quantizer::quantize_u64)
+    ///
+    /// For a magnitude at or above [`SignificantBits::exact_below`], the two functions agree
+    /// exactly: both see the same binade and the same bucket width.
+    ///
+    /// Below that threshold they differ, and deliberately so. An integer smaller than the
+    /// retained bit width has no bits to discard, so `quantize_u64` returns it untouched. A
+    /// float has all 53 significand bits available at every magnitude, so there is no
+    /// equivalent regime — the lattice keeps subdividing, and `quantize_f64(3.0)` at 2
+    /// significant bits lands on `3.5` rather than staying at `3.0`. Both results are inside
+    /// the documented error bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use metrique_writer_core::quantize::{Quantizer, Rounding, SignificantBits};
+    ///
+    /// let bits = SignificantBits::new(4).unwrap();
+    ///
+    /// // The same buckets as the integer path, for values above `exact_below`.
+    /// assert_eq!(Quantizer::new(bits, Rounding::Floor).quantize_f64(1000.0), 960.0);
+    /// assert_eq!(Quantizer::new(bits, Rounding::Midpoint).quantize_f64(1000.0), 992.0);
+    /// assert_eq!(Quantizer::new(bits, Rounding::Ceil).quantize_f64(1000.0), 1024.0);
+    ///
+    /// // Fractional values work the same way, one binade at a time.
+    /// assert_eq!(Quantizer::new(bits, Rounding::Floor).quantize_f64(0.1), 0.09375);
+    ///
+    /// // Special values are left alone.
+    /// let quantizer = Quantizer::new(bits, Rounding::Midpoint);
+    /// assert!(quantizer.quantize_f64(f64::NAN).is_nan());
+    /// assert_eq!(quantizer.quantize_f64(f64::INFINITY), f64::INFINITY);
+    /// assert_eq!(quantizer.quantize_f64(0.0), 0.0);
+    /// ```
+    ///
+    /// One-sided modes keep their promise across the sign change:
+    ///
+    /// ```
+    /// use metrique_writer_core::quantize::{Quantizer, Rounding, SignificantBits};
+    ///
+    /// let bits = SignificantBits::new(4).unwrap();
+    ///
+    /// assert_eq!(Quantizer::new(bits, Rounding::Floor).quantize_f64(-1000.0), -1024.0);
+    /// assert_eq!(Quantizer::new(bits, Rounding::Ceil).quantize_f64(-1000.0), -960.0);
+    /// ```
+    pub fn quantize_f64(self, value: f64) -> f64 {
+        // `NaN` and the infinities have no significand to reduce; zero has nothing to discard.
+        if !value.is_finite() || value == 0.0 {
+            return value;
+        }
+
+        let magnitude = value.abs();
+
+        // Subnormals hold fewer than 53 significant bits, so the mask below could erase them
+        // outright and blow past the documented bound. See the doc comment.
+        if magnitude < f64::MIN_POSITIVE {
+            return value;
+        }
+
+        let bits = u32::from(self.bits.get());
+        // Retain the implicit leading one plus `bits - 1` explicit significand bits.
+        // `bits <= 52` guarantees `drop >= 1`, so `drop - 1` below cannot underflow, and
+        // `drop <= 52` guarantees the mask never reaches the exponent field.
+        let drop = 53 - bits;
+        let mask = u64::MAX << drop;
+
+        let raw = magnitude.to_bits();
+        let low_bits = raw & mask;
+        let already_on_lattice = low_bits == raw;
+
+        // The promise is about the value, not the magnitude. For a negative input, growing the
+        // magnitude shrinks the value, so the one-sided modes exchange roles.
+        let rounding = if value.is_sign_negative() {
+            match self.rounding {
+                Rounding::Floor => Rounding::Ceil,
+                Rounding::Ceil => Rounding::Floor,
+                Rounding::Midpoint => Rounding::Midpoint,
+            }
+        } else {
+            self.rounding
+        };
+
+        // Incrementing the raw bit pattern by `1 << drop` advances exactly one lattice step.
+        // IEEE-754 orders positive finite values monotonically by bit pattern, and a carry out
+        // of the significand lands on the first value of the next binade, which is where the
+        // step doubles.
+        let quantized = match rounding {
+            Rounding::Floor => low_bits,
+            Rounding::Ceil => {
+                if already_on_lattice {
+                    raw
+                } else {
+                    low_bits + (1u64 << drop)
+                }
+            }
+            Rounding::Midpoint => low_bits + (1u64 << (drop - 1)),
+        };
+
+        let quantized = f64::from_bits(quantized);
+
+        // `Ceil` inside the largest binade can carry into the exponent encoding for infinity.
+        // Clamping to the largest finite value still satisfies `q(v) >= v` and keeps the result
+        // usable by formats that reject infinities.
+        let quantized = if quantized.is_finite() {
+            quantized
+        } else {
+            f64::MAX
+        };
+
+        if value.is_sign_negative() {
+            -quantized
+        } else {
+            quantized
+        }
+    }
+}
+
+/// Supplies the [`Quantizer`] that a wrapper such as
+/// [`Quantized`](crate::value::Quantized) should apply.
+///
+/// Two kinds of implementation exist. [`Quantizer`] itself carries its settings as data, which
+/// is what you want when the bit count comes from configuration. [`Bits`] carries them in the
+/// type, which lets the settings be named in a struct field's type and validated at compile
+/// time.
+///
+/// ```
+/// use metrique_writer_core::quantize::{Bits, Quantizer, QuantizerSource, Rounding, SignificantBits, rounding};
+///
+/// // Settings as data.
+/// let runtime = Quantizer::new(SignificantBits::new(8).unwrap(), Rounding::Floor);
+/// assert_eq!(runtime.quantizer(), runtime);
+///
+/// // The same settings as a type. `Bits` is zero-sized, so it costs nothing to carry.
+/// let type_level = Bits::<8, rounding::Floor>::default();
+/// assert_eq!(type_level.quantizer(), runtime);
+/// assert_eq!(std::mem::size_of_val(&type_level), 0);
+/// ```
+pub trait QuantizerSource {
+    /// The quantizer to apply.
+    fn quantizer(&self) -> Quantizer;
+}
+
+impl QuantizerSource for Quantizer {
+    fn quantizer(&self) -> Quantizer {
+        *self
+    }
+}
+
+impl<const N: u8, R: RoundingTag> QuantizerSource for Bits<N, R> {
+    fn quantizer(&self) -> Quantizer {
+        Self::QUANTIZER
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A deliberately naive quantizer, written to be obviously correct rather than fast, used
+    /// to check the shift-and-mask implementation.
+    ///
+    /// This computes the bit width with a division loop and the bucket with `u128`
+    /// division and multiplication, so it shares no arithmetic with the real implementation.
+    /// Note that computing the width as `log2(value).floor() + 1` would be a trap: `u64`
+    /// values above `2^53` are not exactly representable as `f64`, so the conversion can
+    /// round across a power-of-two boundary and yield a width that is off by one.
+    fn reference_quantize_u64(value: u64, bits: u8, rounding: Rounding) -> u64 {
+        if value == 0 {
+            return 0;
+        }
+
+        let mut width = 0u32;
+        let mut remaining = value;
+        while remaining > 0 {
+            width += 1;
+            remaining /= 2;
+        }
+
+        if width <= u32::from(bits) {
+            return value;
+        }
+
+        let shift = width - u32::from(bits);
+        let step = 2u128.pow(shift);
+        let value = u128::from(value);
+        let low = (value / step) * step;
+
+        let result = match rounding {
+            Rounding::Floor => low,
+            Rounding::Ceil => {
+                if low == value {
+                    low
+                } else {
+                    low + step
+                }
+            }
+            Rounding::Midpoint => low + step / 2,
+        };
+
+        if result > u128::from(u64::MAX) {
+            u64::MAX
+        } else {
+            result as u64
+        }
+    }
+
+    /// Deterministic xorshift64*, so a failure is always reproducible.
+    struct Rng(u64);
+
+    impl Rng {
+        fn new(seed: u64) -> Self {
+            Self(seed)
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x >> 12;
+            x ^= x << 25;
+            x ^= x >> 27;
+            self.0 = x;
+            x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        }
+    }
+
+    const ALL_MODES: [Rounding; 3] = [Rounding::Floor, Rounding::Ceil, Rounding::Midpoint];
+
+    /// Values chosen to stress binade boundaries, the extremes, and dense small numbers.
+    fn interesting_values() -> Vec<u64> {
+        let mut values = vec![0, u64::MAX, u64::MAX - 1];
+
+        // Dense small values, which should mostly be left exact.
+        values.extend(0..512u64);
+
+        // Every power of two and its immediate neighbours.
+        for exponent in 0..64u32 {
+            let power = 1u64 << exponent;
+            values.push(power);
+            values.push(power.saturating_sub(1));
+            values.push(power.saturating_add(1));
+        }
+
+        // Values just below the top of each binade, where `Ceil` must carry into the next.
+        for exponent in 1..64u32 {
+            values.push((1u64 << exponent) - 1);
+        }
+
+        values.sort_unstable();
+        values.dedup();
+        values
+    }
+
+    fn quantizer(bits: u8, rounding: Rounding) -> Quantizer {
+        Quantizer::new(SignificantBits::new(bits).unwrap(), rounding)
+    }
+
+    #[test]
+    fn matches_reference_on_interesting_values() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                let quantizer = quantizer(bits, rounding);
+                for value in interesting_values() {
+                    assert_eq!(
+                        quantizer.quantize_u64(value),
+                        reference_quantize_u64(value, bits, rounding),
+                        "bits={bits} rounding={rounding} value={value}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn matches_reference_on_random_values() {
+        let mut rng = Rng::new(0x5EED_1234_ABCD_0001);
+        for _ in 0..20_000 {
+            let value = rng.next_u64();
+            // Also exercise smaller magnitudes, which a uniform u64 rarely produces.
+            let shifted = value >> (rng.next_u64() % 64);
+
+            for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+                for rounding in ALL_MODES {
+                    let quantizer = quantizer(bits, rounding);
+                    for candidate in [value, shifted] {
+                        assert_eq!(
+                            quantizer.quantize_u64(candidate),
+                            reference_quantize_u64(candidate, bits, rounding),
+                            "bits={bits} rounding={rounding} value={candidate}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn floor_never_overstates_and_ceil_never_understates() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for value in interesting_values() {
+                assert!(
+                    quantizer(bits, Rounding::Floor).quantize_u64(value) <= value,
+                    "floor overstated: bits={bits} value={value}"
+                );
+                assert!(
+                    quantizer(bits, Rounding::Ceil).quantize_u64(value) >= value,
+                    "ceil understated: bits={bits} value={value}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn relative_error_stays_within_documented_bound() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let significant = SignificantBits::new(bits).unwrap();
+            for rounding in ALL_MODES {
+                let quantizer = Quantizer::new(significant, rounding);
+                let bound = significant.max_relative_error(rounding);
+
+                for value in interesting_values() {
+                    if value == 0 {
+                        continue;
+                    }
+                    // u64::MAX saturation is the one case where `Ceil` cannot reach the next
+                    // lattice point; it clamps downward, which stays within the bound anyway.
+                    let quantized = quantizer.quantize_u64(value);
+                    let error = (quantized as f64 - value as f64).abs() / value as f64;
+
+                    match rounding {
+                        // The one-sided bound is strict, but allow equality for the
+                        // saturating edge case at u64::MAX.
+                        Rounding::Floor | Rounding::Ceil => assert!(
+                            error <= bound,
+                            "bits={bits} rounding={rounding} value={value} error={error} bound={bound}"
+                        ),
+                        Rounding::Midpoint => assert!(
+                            error <= bound,
+                            "bits={bits} rounding={rounding} value={value} error={error} bound={bound}"
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn all_modes_are_idempotent() {
+        let mut rng = Rng::new(0xD1CE_0000_0000_0007);
+        let mut values = interesting_values();
+        for _ in 0..5_000 {
+            values.push(rng.next_u64() >> (rng.next_u64() % 64));
+        }
+
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                let quantizer = quantizer(bits, rounding);
+                for &value in &values {
+                    let once = quantizer.quantize_u64(value);
+                    let twice = quantizer.quantize_u64(once);
+                    assert_eq!(
+                        once, twice,
+                        "not idempotent: bits={bits} rounding={rounding} value={value}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn values_below_exact_below_are_untouched() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let significant = SignificantBits::new(bits).unwrap();
+            let threshold = significant.exact_below();
+
+            for rounding in ALL_MODES {
+                let quantizer = Quantizer::new(significant, rounding);
+                // Check the whole range for small bit counts, a sample for large ones.
+                let limit = threshold.min(4096);
+                for value in 0..limit {
+                    assert_eq!(
+                        quantizer.quantize_u64(value),
+                        value,
+                        "bits={bits} rounding={rounding} value={value}"
+                    );
+                }
+                // And the largest exact value, just below the threshold.
+                assert_eq!(quantizer.quantize_u64(threshold - 1), threshold - 1);
+            }
+        }
+    }
+
+    #[test]
+    fn ceil_saturates_instead_of_overflowing() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let quantizer = quantizer(bits, Rounding::Ceil);
+            // u64::MAX has every bit set, so it is never on the lattice for bits < 64 and
+            // the naive `low + step` would overflow.
+            assert_eq!(quantizer.quantize_u64(u64::MAX), u64::MAX);
+            assert_eq!(quantizer.quantize_u64(u64::MAX - 1), u64::MAX);
+        }
+    }
+
+    #[test]
+    fn zero_is_a_fixed_point() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                assert_eq!(quantizer(bits, rounding).quantize_u64(0), 0);
+            }
+        }
+    }
+
+    #[test]
+    fn quantizing_is_monotonic() {
+        let mut rng = Rng::new(0xA5A5_0000_1111_2222);
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                let quantizer = quantizer(bits, rounding);
+                for _ in 0..2_000 {
+                    let a = rng.next_u64() >> (rng.next_u64() % 64);
+                    let b = rng.next_u64() >> (rng.next_u64() % 64);
+                    let (low, high) = if a <= b { (a, b) } else { (b, a) };
+                    assert!(
+                        quantizer.quantize_u64(low) <= quantizer.quantize_u64(high),
+                        "not monotonic: bits={bits} rounding={rounding} {low} vs {high}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn floor_and_midpoint_produce_one_representative_per_bucket() {
+        // The claim behind Midpoint being the default at no cost: Floor and Midpoint map a
+        // whole bucket to a single value, so they yield the same number of distinct outputs.
+        use std::collections::BTreeSet;
+
+        for bits in [1u8, 2, 3, 4, 8] {
+            let mut floor_outputs = BTreeSet::new();
+            let mut midpoint_outputs = BTreeSet::new();
+            let mut ceil_outputs = BTreeSet::new();
+
+            for value in 0..100_000u64 {
+                floor_outputs.insert(quantizer(bits, Rounding::Floor).quantize_u64(value));
+                midpoint_outputs.insert(quantizer(bits, Rounding::Midpoint).quantize_u64(value));
+                ceil_outputs.insert(quantizer(bits, Rounding::Ceil).quantize_u64(value));
+            }
+
+            assert_eq!(
+                floor_outputs.len(),
+                midpoint_outputs.len(),
+                "floor and midpoint should have equal alphabet size at {bits} bits"
+            );
+            // Ceil keeps lattice-exact values as themselves *and* rounds others up, so it
+            // produces strictly more distinct values.
+            assert!(
+                ceil_outputs.len() >= floor_outputs.len(),
+                "ceil alphabet should not be smaller at {bits} bits"
+            );
+        }
+    }
+
+    #[test]
+    fn quantizer_accessors_round_trip() {
+        let bits = SignificantBits::new(11).unwrap();
+        let quantizer = Quantizer::new(bits, Rounding::Ceil);
+        assert_eq!(quantizer.significant_bits(), bits);
+        assert_eq!(quantizer.rounding(), Rounding::Ceil);
+        assert_eq!(
+            quantizer.max_relative_error(),
+            bits.max_relative_error(Rounding::Ceil)
+        );
+    }
+
+    #[test]
+    fn quantizer_default_is_eight_bit_midpoint() {
+        let quantizer = Quantizer::default();
+        assert_eq!(quantizer.significant_bits(), SignificantBits::DEFAULT);
+        assert_eq!(quantizer.rounding(), Rounding::Midpoint);
+    }
+
+    #[test]
+    fn bits_tag_produces_matching_quantizer() {
+        assert_eq!(
+            Bits::<8>::QUANTIZER,
+            Quantizer::new(SignificantBits::new(8).unwrap(), Rounding::Midpoint)
+        );
+        assert_eq!(
+            Bits::<11, rounding::Floor>::QUANTIZER,
+            Quantizer::new(SignificantBits::new(11).unwrap(), Rounding::Floor)
+        );
+    }
+
+    #[test]
+    fn worked_example_from_module_docs() {
+        // 1000 = 0b1111101000 at 4 significant bits.
+        let bits = SignificantBits::new(4).unwrap();
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Floor).quantize_u64(1000),
+            960
+        );
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Midpoint).quantize_u64(1000),
+            992
+        );
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Ceil).quantize_u64(1000),
+            1024
+        );
+    }
+
+    #[test]
+    fn binade_spacing_doubles() {
+        // The lattice diagram in the module docs, at 3 significant bits.
+        let quantizer = quantizer(3, Rounding::Floor);
+        let representatives = |range: std::ops::Range<u64>| {
+            range
+                .map(|v| quantizer.quantize_u64(v))
+                .collect::<std::collections::BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(representatives(8..16), vec![8, 10, 12, 14]);
+        assert_eq!(representatives(16..32), vec![16, 20, 24, 28]);
+        assert_eq!(representatives(32..64), vec![32, 40, 48, 56]);
+    }
+
+    #[test]
+    fn each_binade_holds_two_to_the_bits_minus_one_values() {
+        // The module docs claim `2^(N-1)` representable values per binade.
+        for bits in 1u8..=8 {
+            let quantizer = quantizer(bits, Rounding::Floor);
+            let expected = 1usize << (bits - 1);
+
+            // Check several binades well above `exact_below`, where quantizing actually bites.
+            for exponent in u32::from(bits)..u32::from(bits) + 6 {
+                let start = 1u64 << exponent;
+                let end = start * 2;
+                let distinct = (start..end)
+                    .map(|v| quantizer.quantize_u64(v))
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .len();
+                assert_eq!(
+                    distinct, expected,
+                    "bits={bits} binade=[{start}, {end}) should hold {expected} values"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn one_bit_collapses_each_binade_to_its_power_of_two() {
+        // The docs' explanation for why 1 bit means 100% worst-case error.
+        let quantizer = quantizer(1, Rounding::Floor);
+        for exponent in 1..20u32 {
+            let start = 1u64 << exponent;
+            for value in start..start * 2 {
+                assert_eq!(quantizer.quantize_u64(value), start, "value={value}");
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------
+    // quantize_f64
+    // ---------------------------------------------------------------------------------
+
+    /// Independent f64 reference: derive the bucket from the exponent with `powi`, rather than
+    /// by masking the significand, so it shares no arithmetic with the implementation.
+    ///
+    /// # Precondition
+    ///
+    /// Only valid for magnitudes within `REFERENCE_EXPONENT_RANGE`. Outside it, `2f64.powi()`
+    /// is not a usable way to build the lattice step: `powi` computes a negative exponent by
+    /// reciprocating the positive one, so `2f64.powi(-1024)` evaluates `1.0 / inf` and
+    /// underflows to zero, and a step of zero turns the division below into `NaN`. The
+    /// extremes are covered instead by the bound, idempotence, saturation, and subnormal
+    /// tests, and by `f64_agrees_with_u64_at_or_above_exact_below`, which checks the f64 path
+    /// against the independently verified integer path.
+    fn reference_quantize_f64(value: f64, bits: u8, rounding: Rounding) -> f64 {
+        if !value.is_finite() || value == 0.0 {
+            return value;
+        }
+        let magnitude = value.abs();
+        if magnitude < f64::MIN_POSITIVE {
+            return value;
+        }
+
+        let rounding = if value.is_sign_negative() {
+            match rounding {
+                Rounding::Floor => Rounding::Ceil,
+                Rounding::Ceil => Rounding::Floor,
+                Rounding::Midpoint => Rounding::Midpoint,
+            }
+        } else {
+            rounding
+        };
+
+        // The binade of `magnitude`, and the lattice step inside it.
+        //
+        // `log2().floor()` is not trustworthy on its own: `f64::MAX.log2()` rounds to exactly
+        // 1024.0, which would put the value one binade too high and make `step` infinite.
+        // Correct the estimate by comparison instead. The `exponent < 1024` guard keeps the
+        // second loop from evaluating `powi(1025)` forever once `powi` saturates to infinity.
+        let mut exponent = magnitude.log2().floor() as i32;
+        while 2f64.powi(exponent) > magnitude {
+            exponent -= 1;
+        }
+        while exponent < 1024 && 2f64.powi(exponent + 1) <= magnitude {
+            exponent += 1;
+        }
+        let step = 2f64.powi(exponent - i32::from(bits) + 1);
+
+        let low = (magnitude / step).floor() * step;
+        let quantized = match rounding {
+            Rounding::Floor => low,
+            Rounding::Ceil => {
+                if low == magnitude {
+                    magnitude
+                } else {
+                    low + step
+                }
+            }
+            Rounding::Midpoint => low + step / 2.0,
+        };
+
+        let quantized = if quantized.is_finite() {
+            quantized
+        } else {
+            f64::MAX
+        };
+        if value.is_sign_negative() {
+            -quantized
+        } else {
+            quantized
+        }
+    }
+
+    /// The magnitude range over which `reference_quantize_f64` is trustworthy. Chosen so that
+    /// `2f64.powi(exponent - bits + 1)` stays comfortably inside the normal range for every
+    /// supported bit count: the smallest step it ever builds is `2^(-500 - 52 + 1)`.
+    const REFERENCE_EXPONENT_RANGE: std::ops::RangeInclusive<i32> = -500..=500;
+
+    fn reference_is_valid_for(value: f64) -> bool {
+        if !value.is_finite() || value == 0.0 {
+            return false;
+        }
+        let magnitude = value.abs();
+        if magnitude < f64::MIN_POSITIVE {
+            return false;
+        }
+        let exponent = magnitude.log2().floor() as i32;
+        REFERENCE_EXPONENT_RANGE.contains(&exponent)
+    }
+
+    fn interesting_floats() -> Vec<f64> {
+        let mut values = vec![
+            0.1,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            100.0,
+            1000.0,
+            1e6,
+            1e15,
+            1e100,
+            1e-100,
+            f64::MIN_POSITIVE,
+            f64::MAX,
+            std::f64::consts::PI,
+            std::f64::consts::E,
+        ];
+
+        // Powers of two and their neighbours across a wide exponent range.
+        for exponent in -60..60i32 {
+            let power = 2f64.powi(exponent);
+            values.push(power);
+            // Just below the top of the binade, where `Ceil` must carry into the next.
+            values.push(power * 1.9999999999999998);
+            values.push(power * 1.5);
+        }
+
+        // Integral values, to compare against the integer path.
+        for v in 1..2048u64 {
+            values.push(v as f64);
+        }
+
+        values.retain(|v| v.is_finite() && *v != 0.0);
+        values
+    }
+
+    #[test]
+    fn f64_matches_reference() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                let quantizer = quantizer(bits, rounding);
+                for value in interesting_floats() {
+                    for signed in [value, -value] {
+                        if !reference_is_valid_for(signed) {
+                            continue;
+                        }
+                        let actual = quantizer.quantize_f64(signed);
+                        let expected = reference_quantize_f64(signed, bits, rounding);
+                        assert_eq!(
+                            actual.to_bits(),
+                            expected.to_bits(),
+                            "bits={bits} rounding={rounding} value={signed:e}: {actual:e} != {expected:e}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn f64_matches_reference_on_random_values() {
+        let mut rng = Rng::new(0xBEEF_0F64_0000_0001);
+        let mut checked = 0u32;
+
+        while checked < 20_000 {
+            let candidate = f64::from_bits(rng.next_u64());
+            if !reference_is_valid_for(candidate) {
+                continue;
+            }
+            checked += 1;
+
+            for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+                for rounding in ALL_MODES {
+                    let quantizer = quantizer(bits, rounding);
+                    let actual = quantizer.quantize_f64(candidate);
+                    let expected = reference_quantize_f64(candidate, bits, rounding);
+                    assert_eq!(
+                        actual.to_bits(),
+                        expected.to_bits(),
+                        "bits={bits} rounding={rounding} value={candidate:e}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn f64_agrees_with_u64_at_or_above_exact_below() {
+        // At or above `exact_below` both paths see the same binade and the same bucket width,
+        // so they must produce identical results.
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let significant = SignificantBits::new(bits).unwrap();
+            let threshold = significant.exact_below();
+
+            for rounding in ALL_MODES {
+                let quantizer = Quantizer::new(significant, rounding);
+
+                let mut candidates: Vec<u64> = (threshold..threshold.saturating_mul(4))
+                    .take(4096)
+                    .collect();
+                // A few large integral values that are still exact in f64.
+                for exponent in 20..53u32 {
+                    candidates.push(1u64 << exponent);
+                    candidates.push((1u64 << exponent) + 1);
+                    candidates.push((1u64 << exponent) - 1);
+                }
+                candidates.retain(|v| *v < (1u64 << 53) && *v >= threshold);
+
+                for value in candidates {
+                    let via_u64 = quantizer.quantize_u64(value);
+                    let via_f64 = quantizer.quantize_f64(value as f64);
+                    assert_eq!(
+                        via_u64 as f64, via_f64,
+                        "bits={bits} rounding={rounding} value={value}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn f64_passes_through_special_values() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                let quantizer = quantizer(bits, rounding);
+
+                assert!(quantizer.quantize_f64(f64::NAN).is_nan());
+                assert_eq!(quantizer.quantize_f64(f64::INFINITY), f64::INFINITY);
+                assert_eq!(quantizer.quantize_f64(f64::NEG_INFINITY), f64::NEG_INFINITY);
+
+                // Both signed zeros survive, sign included.
+                assert_eq!(quantizer.quantize_f64(0.0).to_bits(), 0.0f64.to_bits());
+                assert_eq!(quantizer.quantize_f64(-0.0).to_bits(), (-0.0f64).to_bits());
+            }
+        }
+    }
+
+    #[test]
+    fn f64_passes_through_subnormals() {
+        let subnormals = [
+            f64::from_bits(1),
+            f64::from_bits(2),
+            f64::from_bits(0x000F_FFFF_FFFF_FFFF),
+            -f64::from_bits(1),
+        ];
+
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                let quantizer = quantizer(bits, rounding);
+                for value in subnormals {
+                    assert_eq!(
+                        quantizer.quantize_f64(value).to_bits(),
+                        value.to_bits(),
+                        "bits={bits} rounding={rounding} subnormal={value:e}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn f64_one_sided_modes_bracket_the_true_value() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for value in interesting_floats() {
+                for signed in [value, -value] {
+                    let floor = quantizer(bits, Rounding::Floor).quantize_f64(signed);
+                    let ceil = quantizer(bits, Rounding::Ceil).quantize_f64(signed);
+
+                    assert!(
+                        floor <= signed,
+                        "floor overstated: bits={bits} value={signed:e} -> {floor:e}"
+                    );
+                    // `f64::MAX` saturation is the one case where `Ceil` cannot reach the next
+                    // lattice point.
+                    if ceil != f64::MAX && ceil != -f64::MAX {
+                        assert!(
+                            ceil >= signed,
+                            "ceil understated: bits={bits} value={signed:e} -> {ceil:e}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn f64_relative_error_stays_within_documented_bound() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let significant = SignificantBits::new(bits).unwrap();
+            for rounding in ALL_MODES {
+                let quantizer = Quantizer::new(significant, rounding);
+                let bound = significant.max_relative_error(rounding);
+
+                for value in interesting_floats() {
+                    for signed in [value, -value] {
+                        let quantized = quantizer.quantize_f64(signed);
+                        if !quantized.is_finite() {
+                            continue;
+                        }
+                        let error = (quantized - signed).abs() / signed.abs();
+                        assert!(
+                            error <= bound * (1.0 + 1e-12),
+                            "bits={bits} rounding={rounding} value={signed:e} error={error:e} bound={bound:e}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn f64_is_idempotent() {
+        let mut rng = Rng::new(0xF10A_7000_0000_0001);
+        let mut values = interesting_floats();
+        for _ in 0..5_000 {
+            // Random finite floats spanning the whole exponent range.
+            let candidate = f64::from_bits(rng.next_u64());
+            if candidate.is_finite() && candidate != 0.0 {
+                values.push(candidate);
+            }
+        }
+
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                let quantizer = quantizer(bits, rounding);
+                for &value in &values {
+                    let once = quantizer.quantize_f64(value);
+                    let twice = quantizer.quantize_f64(once);
+                    assert_eq!(
+                        once.to_bits(),
+                        twice.to_bits(),
+                        "not idempotent: bits={bits} rounding={rounding} value={value:e}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn f64_is_monotonic() {
+        let mut rng = Rng::new(0x0FEE_1111_2222_3333);
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            for rounding in ALL_MODES {
+                let quantizer = quantizer(bits, rounding);
+                for _ in 0..2_000 {
+                    let a = f64::from_bits(rng.next_u64());
+                    let b = f64::from_bits(rng.next_u64());
+                    if !a.is_finite() || !b.is_finite() {
+                        continue;
+                    }
+                    let (low, high) = if a <= b { (a, b) } else { (b, a) };
+                    assert!(
+                        quantizer.quantize_f64(low) <= quantizer.quantize_f64(high),
+                        "not monotonic: bits={bits} rounding={rounding} {low:e} vs {high:e}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn f64_ceil_saturates_at_max_instead_of_going_infinite() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let quantizer = quantizer(bits, Rounding::Ceil);
+            // f64::MAX has every significand bit set, so it is never on the lattice and the
+            // naive `low + step` would carry into the infinity encoding.
+            let quantized = quantizer.quantize_f64(f64::MAX);
+            assert!(quantized.is_finite(), "bits={bits} produced {quantized:e}");
+            assert_eq!(quantized, f64::MAX);
+        }
+    }
+
+    #[test]
+    fn f64_binade_crossing_is_exact() {
+        // Just below a power of two, `Ceil` must land exactly on it.
+        let quantizer = quantizer(4, Rounding::Ceil);
+        for exponent in -20..20i32 {
+            let power = 2f64.powi(exponent);
+            let just_below = power * 1.9999999999999998;
+            let quantized = quantizer.quantize_f64(just_below);
+            assert_eq!(
+                quantized,
+                power * 2.0,
+                "exponent={exponent} value={just_below:e}"
+            );
+        }
+    }
+
+    #[test]
+    fn f64_one_bit_collapses_to_powers_of_two() {
+        let quantizer = quantizer(1, Rounding::Floor);
+        for exponent in -30..30i32 {
+            let power = 2f64.powi(exponent);
+            assert_eq!(quantizer.quantize_f64(power), power);
+            assert_eq!(quantizer.quantize_f64(power * 1.5), power);
+            assert_eq!(quantizer.quantize_f64(power * 1.99), power);
+        }
+    }
+
+    #[test]
+    fn f64_worked_examples_from_docs() {
+        let bits = SignificantBits::new(4).unwrap();
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Floor).quantize_f64(1000.0),
+            960.0
+        );
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Midpoint).quantize_f64(1000.0),
+            992.0
+        );
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Ceil).quantize_f64(1000.0),
+            1024.0
+        );
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Floor).quantize_f64(0.1),
+            0.09375
+        );
+        // Sign flips the one-sided modes.
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Floor).quantize_f64(-1000.0),
+            -1024.0
+        );
+        assert_eq!(
+            Quantizer::new(bits, Rounding::Ceil).quantize_f64(-1000.0),
+            -960.0
+        );
+    }
+
+    #[test]
+    fn rejects_out_of_range_bits() {
+        assert_eq!(SignificantBits::new(0).unwrap_err().requested(), 0);
+        assert_eq!(SignificantBits::new(53).unwrap_err().requested(), 53);
+        assert_eq!(SignificantBits::new(255).unwrap_err().requested(), 255);
+    }
+
+    #[test]
+    fn accepts_full_valid_range() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let parsed = SignificantBits::new(bits).expect("in range");
+            assert_eq!(parsed.get(), bits);
+        }
+    }
+
+    #[test]
+    fn default_is_eight_bits() {
+        assert_eq!(SignificantBits::DEFAULT.get(), 8);
+        assert_eq!(SignificantBits::default(), SignificantBits::DEFAULT);
+    }
+
+    #[test]
+    fn default_rounding_is_midpoint() {
+        assert_eq!(Rounding::default(), Rounding::Midpoint);
+    }
+
+    #[test]
+    fn exact_below_is_two_to_the_bits() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let parsed = SignificantBits::new(bits).unwrap();
+            assert_eq!(parsed.exact_below(), 1u64 << bits, "bits={bits}");
+        }
+    }
+
+    #[test]
+    fn max_relative_error_matches_powers_of_two() {
+        for bits in MIN_SIGNIFICANT_BITS..=MAX_SIGNIFICANT_BITS {
+            let parsed = SignificantBits::new(bits).unwrap();
+            let one_sided = f64::from(1 - i32::from(bits)).exp2();
+            let midpoint = f64::from(-i32::from(bits)).exp2();
+
+            assert_eq!(parsed.max_relative_error(Rounding::Floor), one_sided);
+            assert_eq!(parsed.max_relative_error(Rounding::Ceil), one_sided);
+            assert_eq!(parsed.max_relative_error(Rounding::Midpoint), midpoint);
+            // The midpoint bound is exactly half the one-sided bound.
+            assert_eq!(midpoint * 2.0, one_sided);
+        }
+    }
+
+    #[test]
+    fn documented_error_table_is_exact() {
+        // Every entry in the module-level table, verified against the documented value.
+        let cases: &[(u8, f64, f64)] = &[
+            (1, 1.0, 0.5),
+            (2, 0.5, 0.25),
+            (3, 0.25, 0.125),
+            (4, 0.125, 0.0625),
+            (5, 0.0625, 0.03125),
+            (6, 0.03125, 0.015625),
+            (7, 0.015625, 0.0078125),
+            (8, 0.0078125, 0.00390625),
+            (10, 0.001953125, 0.0009765625),
+            (11, 0.0009765625, 0.00048828125),
+            (12, 0.00048828125, 0.000244140625),
+            (16, 0.000030517578125, 0.0000152587890625),
+        ];
+
+        for &(bits, one_sided, midpoint) in cases {
+            let parsed = SignificantBits::new(bits).unwrap();
+            assert_eq!(
+                parsed.max_relative_error(Rounding::Floor),
+                one_sided,
+                "one-sided bound for {bits} bits"
+            );
+            assert_eq!(
+                parsed.max_relative_error(Rounding::Midpoint),
+                midpoint,
+                "midpoint bound for {bits} bits"
+            );
+        }
+    }
+
+    #[test]
+    fn decimal_digit_equivalence_table_is_correct() {
+        // `ceil(log2(2 * 10^digits))` is the smallest bit count whose one-sided relative
+        // error is below 10^-digits, as the module docs claim.
+        for (digits, expected_bits) in [(1u32, 5u8), (2, 8), (3, 11), (4, 15)] {
+            let derived = (2.0 * 10f64.powi(digits as i32)).log2().ceil() as u8;
+            assert_eq!(derived, expected_bits, "digits={digits}");
+
+            let bits = SignificantBits::new(expected_bits).unwrap();
+            let target = 10f64.powi(-(digits as i32));
+            assert!(
+                bits.max_relative_error(Rounding::Floor) < target,
+                "{expected_bits} bits should beat 10^-{digits}"
+            );
+            // One bit fewer should not be sufficient, confirming minimality.
+            let weaker = SignificantBits::new(expected_bits - 1).unwrap();
+            assert!(
+                weaker.max_relative_error(Rounding::Floor) >= target,
+                "{} bits should not beat 10^-{digits}",
+                expected_bits - 1
+            );
+        }
+    }
+
+    #[test]
+    fn bits_tag_carries_settings() {
+        assert_eq!(Bits::<8>::BITS.get(), 8);
+        assert_eq!(Bits::<8>::ROUNDING, Rounding::Midpoint);
+        assert_eq!(Bits::<1, rounding::Floor>::BITS.get(), 1);
+        assert_eq!(Bits::<1, rounding::Floor>::ROUNDING, Rounding::Floor);
+        assert_eq!(Bits::<52, rounding::Ceil>::BITS.get(), 52);
+        assert_eq!(Bits::<52, rounding::Ceil>::ROUNDING, Rounding::Ceil);
+    }
+
+    #[test]
+    fn rounding_display_is_stable() {
+        assert_eq!(Rounding::Floor.to_string(), "floor");
+        assert_eq!(Rounding::Ceil.to_string(), "ceil");
+        assert_eq!(Rounding::Midpoint.to_string(), "midpoint");
+    }
+
+    #[test]
+    fn error_message_names_the_valid_range() {
+        let message = SignificantBits::new(53).unwrap_err().to_string();
+        assert_eq!(message, "significant bits must be in 1..=52, got 53");
+    }
+}

--- a/metrique-writer-core/src/value/mod.rs
+++ b/metrique-writer-core/src/value/mod.rs
@@ -11,10 +11,12 @@ mod flags;
 mod force;
 mod formatter;
 mod primitive;
+mod quantized;
 
 pub use dimensions::{WithDimension, WithDimensions, WithVecDimensions};
 pub use force::{FlagConstructor, ForceFlag, ForceFlagEntryWriter};
 pub use formatter::{FormattedValue, Lifted, NotLifted, ToString, ValueFormatter};
+pub use quantized::{Quantized, QuantizingValueWriter, quantize_observation};
 use std::{borrow::Cow, fmt::Write, sync::Arc};
 
 pub use flags::{Distribution, MetricFlags, MetricOptions};
@@ -283,6 +285,37 @@ pub trait MetricValue: Value {
         I: Into<CowStr>,
     {
         WithDimensions::new_with_dimensions(self, dimensions)
+    }
+
+    /// Reduce the precision of this value when it is written, retaining `bits` significant
+    /// bits and using `rounding` to pick each bucket's representative.
+    ///
+    /// This trades a bounded amount of accuracy for a smaller set of distinct emitted values.
+    /// See the [`quantize`](crate::quantize) module for the error bound at each bit count and
+    /// for guidance on which values should not be quantized.
+    ///
+    /// If a unit conversion is also needed, convert first: the error bound applies to the
+    /// value as emitted.
+    ///
+    /// ```
+    /// use metrique_writer_core::quantize::{Rounding, SignificantBits};
+    /// use metrique_writer_core::value::MetricValue;
+    ///
+    /// let bits = SignificantBits::new(8).unwrap();
+    ///
+    /// // At 8 bits the emitted value is within 0.390625% of the true one.
+    /// let latency = 1_234_567u64.quantized(bits, Rounding::Midpoint);
+    /// assert_eq!(*latency, 1_234_567);
+    /// ```
+    fn quantized(
+        self,
+        bits: crate::quantize::SignificantBits,
+        rounding: crate::quantize::Rounding,
+    ) -> Quantized<Self, crate::quantize::Quantizer>
+    where
+        Self: Sized,
+    {
+        Quantized::new(self, crate::quantize::Quantizer::new(bits, rounding))
     }
 }
 

--- a/metrique-writer-core/src/value/quantized.rs
+++ b/metrique-writer-core/src/value/quantized.rs
@@ -1,0 +1,886 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Applying a [`Quantizer`] to values as they are written.
+
+use std::ops::{Deref, DerefMut};
+
+use smallvec::SmallVec;
+
+use crate::{
+    MetricFlags, Observation, Unit, ValidationError, Value, ValueWriter,
+    quantize::{Quantizer, QuantizerSource},
+    value::{MetricValue, VALUES_INLINE_CAPACITY},
+};
+
+/// Reduce the precision of a single [`Observation`].
+///
+/// [`Observation::Unsigned`] goes through [`Quantizer::quantize_u64`] and
+/// [`Observation::Floating`] through [`Quantizer::quantize_f64`].
+///
+/// For [`Observation::Repeated`], only `total` is quantized; `occurrences` is passed through
+/// untouched. `occurrences` is a count of how many measurements were summed into `total`, and
+/// formats divide by it to recover an average. Quantizing it would corrupt that average by an
+/// amount unrelated to the quantizer's error bound, so it is always left exact.
+///
+/// ```
+/// use metrique_writer_core::Observation;
+/// use metrique_writer_core::quantize::{Quantizer, Rounding, SignificantBits};
+/// use metrique_writer_core::value::quantize_observation;
+///
+/// let quantizer = Quantizer::new(SignificantBits::new(4).unwrap(), Rounding::Floor);
+///
+/// assert_eq!(
+///     quantize_observation(Observation::Unsigned(1000), quantizer),
+///     Observation::Unsigned(960),
+/// );
+///
+/// // `occurrences` survives; only the total is reduced.
+/// assert_eq!(
+///     quantize_observation(
+///         Observation::Repeated { total: 1000.0, occurrences: 7 },
+///         quantizer,
+///     ),
+///     Observation::Repeated { total: 960.0, occurrences: 7 },
+/// );
+/// ```
+pub fn quantize_observation(observation: Observation, quantizer: Quantizer) -> Observation {
+    // Matched exhaustively on purpose. `Observation` is `#[non_exhaustive]`, but within this
+    // crate that does not force a wildcard arm, and a wildcard would let a future numeric
+    // variant slip through unquantized without anyone noticing. Breaking the build is the
+    // outcome we want if a variant is added.
+    match observation {
+        Observation::Unsigned(value) => Observation::Unsigned(quantizer.quantize_u64(value)),
+        Observation::Floating(value) => Observation::Floating(quantizer.quantize_f64(value)),
+        Observation::Repeated { total, occurrences } => Observation::Repeated {
+            total: quantizer.quantize_f64(total),
+            occurrences,
+        },
+    }
+}
+
+/// A [`ValueWriter`] that reduces the precision of every observation passed through it.
+///
+/// This is the mechanism behind [`Quantized`](super::Quantized) and is public so that
+/// formats, sinks, and other writer wrappers can apply the same reduction. String properties,
+/// units, dimensions, and validation errors are forwarded unchanged; only numeric
+/// observations are altered.
+///
+/// # Examples
+///
+/// ```
+/// use metrique_writer_core::{Observation, Unit, Value, ValueWriter, MetricFlags};
+/// use metrique_writer_core::quantize::{Quantizer, Rounding, SignificantBits};
+/// use metrique_writer_core::value::QuantizingValueWriter;
+///
+/// // A writer that records whatever it is handed.
+/// struct Recorder<'a>(&'a mut Vec<u64>);
+///
+/// impl ValueWriter for Recorder<'_> {
+///     fn string(self, _: &str) {}
+///     fn metric<'a>(
+///         self,
+///         distribution: impl IntoIterator<Item = Observation>,
+///         _: Unit,
+///         _: impl IntoIterator<Item = (&'a str, &'a str)>,
+///         _: MetricFlags<'_>,
+///     ) {
+///         for observation in distribution {
+///             if let Observation::Unsigned(value) = observation {
+///                 self.0.push(value);
+///             }
+///         }
+///     }
+///     fn error(self, _: metrique_writer_core::ValidationError) {}
+/// }
+///
+/// let quantizer = Quantizer::new(SignificantBits::new(4).unwrap(), Rounding::Floor);
+///
+/// let mut recorded = Vec::new();
+/// 1000u64.write(QuantizingValueWriter::new(Recorder(&mut recorded), quantizer));
+/// assert_eq!(recorded, [960]);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct QuantizingValueWriter<W> {
+    inner: W,
+    quantizer: Quantizer,
+}
+
+impl<W> QuantizingValueWriter<W> {
+    /// Wrap `inner` so that observations written through it are reduced by `quantizer`.
+    pub fn new(inner: W, quantizer: Quantizer) -> Self {
+        Self { inner, quantizer }
+    }
+
+    /// The quantizer being applied.
+    pub fn quantizer(&self) -> Quantizer {
+        self.quantizer
+    }
+}
+
+impl<W: ValueWriter> ValueWriter for QuantizingValueWriter<W> {
+    fn string(self, value: &str) {
+        // String properties have no numeric precision to reduce.
+        self.inner.string(value)
+    }
+
+    fn metric<'a>(
+        self,
+        distribution: impl IntoIterator<Item = Observation>,
+        unit: Unit,
+        dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
+        flags: MetricFlags<'_>,
+    ) {
+        let quantizer = self.quantizer;
+        // Mapped lazily, so a distribution of any length is quantized without allocating.
+        self.inner.metric(
+            distribution
+                .into_iter()
+                .map(move |observation| quantize_observation(observation, quantizer)),
+            unit,
+            dimensions,
+            flags,
+        )
+    }
+
+    fn error(self, error: ValidationError) {
+        self.inner.error(error)
+    }
+
+    fn values<'a, V: Value + 'a>(self, values: impl IntoIterator<Item = &'a V>) {
+        // Forwarded rather than left to the default implementation, which would comma-join the
+        // elements into a single string and never call `metric()` on them. Each element is
+        // re-wrapped so its own observations are quantized too.
+        let quantizer = self.quantizer;
+        let wrapped: SmallVec<[QuantizingValue<&'a V>; VALUES_INLINE_CAPACITY]> = values
+            .into_iter()
+            .map(|value| QuantizingValue { value, quantizer })
+            .collect();
+        self.inner.values(wrapped.iter())
+    }
+}
+
+/// Pairs a value with a quantizer so that lists can be forwarded element by element.
+///
+/// Kept private: [`Quantized`] is the public way to attach a quantizer to a value, and this
+/// exists only so [`QuantizingValueWriter::values`] has something to hand to the writer it
+/// wraps.
+#[derive(Debug, Clone, Copy)]
+struct QuantizingValue<V> {
+    value: V,
+    quantizer: Quantizer,
+}
+
+impl<V: Value> Value for QuantizingValue<V> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = V::SHAPE;
+    const UNIT: crate::Unit = V::UNIT;
+
+    fn write(&self, writer: impl ValueWriter) {
+        self.value
+            .write(QuantizingValueWriter::new(writer, self.quantizer))
+    }
+}
+
+/// Reduces the precision of a [`Value`] when it is written.
+///
+/// The wrapped value is emitted with the leading `N` significant bits of each observation
+/// retained and the rest discarded. Everything else about the value — its unit, its
+/// dimensions, its [`Value::SHAPE`] — is preserved, so wrapping a field changes only the
+/// numbers.
+///
+/// The quantizer can be supplied either as data or as a type, via [`QuantizerSource`]:
+///
+/// - `Quantized<V>` holds a [`Quantizer`] as a field, which is what
+///   [`MetricValue::quantized`] produces. Use this when the settings come from configuration.
+/// - `Quantized<V, Bits<N>>` carries the settings in the type, costs no space at runtime, and
+///   rejects an out-of-range `N` at compile time.
+///
+/// # Composing with units
+///
+/// Order matters when combining with [`MetricValue::with_unit`]. Convert first, then quantize:
+///
+/// ```
+/// use std::time::Duration;
+/// use metrique_writer_core::quantize::{Rounding, SignificantBits};
+/// use metrique_writer_core::unit::Microsecond;
+/// use metrique_writer_core::value::MetricValue;
+///
+/// let bits = SignificantBits::new(8).unwrap();
+///
+/// // Correct: the error bound applies to the value as emitted, in microseconds.
+/// let value = Duration::from_millis(3).with_unit::<Microsecond>().quantized(bits, Rounding::Midpoint);
+/// # let _ = value;
+/// ```
+///
+/// Quantizing before converting would apply the bound in the source unit and then scale the
+/// result, leaving the emitted number off the target unit's lattice.
+///
+/// # Examples
+///
+/// Attaching a quantizer as data:
+///
+/// ```
+/// use metrique_writer_core::quantize::{Rounding, SignificantBits};
+/// use metrique_writer_core::value::MetricValue;
+///
+/// let bits = SignificantBits::new(4).unwrap();
+/// let quantized = 1000u64.quantized(bits, Rounding::Floor);
+///
+/// // `Deref` reaches the value that was wrapped, unchanged.
+/// assert_eq!(*quantized, 1000);
+/// ```
+///
+/// Attaching it as a type, which is what a field declaration usually wants:
+///
+/// ```
+/// use metrique_writer_core::quantize::{Bits, rounding};
+/// use metrique_writer_core::value::Quantized;
+///
+/// // 8 significant bits with the default midpoint rounding.
+/// let latency: Quantized<u64, Bits<8>> = 1000u64.into();
+///
+/// // 11 significant bits, never overstating.
+/// let conservative: Quantized<u64, Bits<11, rounding::Floor>> = 1000u64.into();
+/// # let _ = (latency, conservative);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Quantized<V, Q = Quantizer> {
+    value: V,
+    quantizer: Q,
+}
+
+impl<V> Quantized<V, Quantizer> {
+    /// Wrap `value` so that it is reduced by `quantizer` when written.
+    pub fn new(value: V, quantizer: Quantizer) -> Self {
+        Self { value, quantizer }
+    }
+}
+
+impl<V, Q> Quantized<V, Q> {
+    /// Wrap `value` with a quantizer supplied as either data or a type.
+    pub fn with_source(value: V, quantizer: Q) -> Self {
+        Self { value, quantizer }
+    }
+
+    /// The quantizer settings attached to this value.
+    pub fn source(&self) -> &Q {
+        &self.quantizer
+    }
+
+    /// Return the value that was wrapped, discarding the quantizer.
+    pub fn into_inner(self) -> V {
+        self.value
+    }
+
+    /// Map the value within this [`Quantized`], keeping the same quantizer.
+    pub fn map_value<U>(self, f: impl FnOnce(V) -> U) -> Quantized<U, Q> {
+        Quantized {
+            value: f(self.value),
+            quantizer: self.quantizer,
+        }
+    }
+}
+
+impl<V, Q: Default> From<V> for Quantized<V, Q> {
+    fn from(value: V) -> Self {
+        Self {
+            value,
+            quantizer: Q::default(),
+        }
+    }
+}
+
+impl<V, Q> Deref for Quantized<V, Q> {
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<V, Q> DerefMut for Quantized<V, Q> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl<V: Value, Q: QuantizerSource> Value for Quantized<V, Q> {
+    const SHAPE: crate::descriptor::FieldShape<'static> = V::SHAPE;
+    const UNIT: crate::Unit = V::UNIT;
+
+    fn write(&self, writer: impl ValueWriter) {
+        self.value.write(QuantizingValueWriter::new(
+            writer,
+            self.quantizer.quantizer(),
+        ))
+    }
+}
+
+impl<V: MetricValue, Q: QuantizerSource> MetricValue for Quantized<V, Q> {
+    type Unit = V::Unit;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quantize::{Rounding, SignificantBits};
+
+    fn quantizer(bits: u8, rounding: Rounding) -> Quantizer {
+        Quantizer::new(SignificantBits::new(bits).unwrap(), rounding)
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum Event {
+        String(String),
+        ValuesStart,
+        Metric {
+            distribution: Vec<Observation>,
+            unit: Unit,
+            dimensions: Vec<(String, String)>,
+        },
+        Error(String),
+    }
+
+    struct Recorder<'a>(&'a mut Vec<Event>);
+
+    impl ValueWriter for Recorder<'_> {
+        fn string(self, value: &str) {
+            self.0.push(Event::String(value.to_string()));
+        }
+
+        fn metric<'a>(
+            self,
+            distribution: impl IntoIterator<Item = Observation>,
+            unit: Unit,
+            dimensions: impl IntoIterator<Item = (&'a str, &'a str)>,
+            _flags: MetricFlags<'_>,
+        ) {
+            self.0.push(Event::Metric {
+                distribution: distribution.into_iter().collect(),
+                unit,
+                dimensions: dimensions
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            });
+        }
+
+        fn error(self, error: ValidationError) {
+            self.0.push(Event::Error(error.to_string()));
+        }
+
+        // Overridden so a forwarded `values()` call is distinguishable from the default
+        // comma-joined `string()` fallback.
+        fn values<'a, V: Value + 'a>(self, values: impl IntoIterator<Item = &'a V>) {
+            self.0.push(Event::ValuesStart);
+            for value in values {
+                value.write(Recorder(self.0));
+            }
+        }
+    }
+
+    fn record(value: &(impl Value + ?Sized), quantizer: Quantizer) -> Vec<Event> {
+        let mut events = Vec::new();
+        value.write(QuantizingValueWriter::new(Recorder(&mut events), quantizer));
+        events
+    }
+
+    /// Record a value that already carries its own quantizer, with no extra wrapping.
+    fn record_plain(value: &(impl Value + ?Sized)) -> Vec<Event> {
+        let mut events = Vec::new();
+        value.write(Recorder(&mut events));
+        events
+    }
+
+    fn distribution(events: &[Event]) -> &[Observation] {
+        match &events[0] {
+            Event::Metric { distribution, .. } => distribution,
+            other => panic!("expected a metric, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quantizes_unsigned_observations() {
+        let events = record(&1000u64, quantizer(4, Rounding::Floor));
+        assert_eq!(distribution(&events), &[Observation::Unsigned(960)]);
+    }
+
+    #[test]
+    fn quantizes_floating_observations() {
+        let events = record(&1000.0f64, quantizer(4, Rounding::Floor));
+        assert_eq!(distribution(&events), &[Observation::Floating(960.0)]);
+    }
+
+    #[test]
+    fn quantizes_repeated_total_but_not_occurrences() {
+        let observation = Observation::Repeated {
+            total: 1000.0,
+            occurrences: 7,
+        };
+        let events = record(&observation, quantizer(4, Rounding::Floor));
+        assert_eq!(
+            distribution(&events),
+            &[Observation::Repeated {
+                total: 960.0,
+                occurrences: 7,
+            }]
+        );
+    }
+
+    #[test]
+    fn repeated_occurrences_survive_every_mode_and_width() {
+        for bits in 1..=52u8 {
+            for rounding in [Rounding::Floor, Rounding::Ceil, Rounding::Midpoint] {
+                let observation = Observation::Repeated {
+                    total: 123_456.0,
+                    occurrences: 999,
+                };
+                let events = record(&observation, quantizer(bits, rounding));
+                match &distribution(&events)[0] {
+                    Observation::Repeated { occurrences, .. } => {
+                        assert_eq!(*occurrences, 999, "bits={bits} rounding={rounding}")
+                    }
+                    other => panic!("expected Repeated, got {other:?}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn leaves_strings_untouched() {
+        let events = record("1000", quantizer(4, Rounding::Floor));
+        assert_eq!(events, [Event::String("1000".to_string())]);
+    }
+
+    #[test]
+    fn forwards_units_and_dimensions_unchanged() {
+        use crate::unit::{Millisecond, UnitTag as _};
+        use crate::value::MetricValue;
+
+        let value = std::time::Duration::from_millis(1000).with_dimension("Operation", "Ducks");
+        let events = record(&value, quantizer(4, Rounding::Floor));
+
+        match &events[0] {
+            Event::Metric {
+                distribution,
+                unit,
+                dimensions,
+            } => {
+                assert_eq!(distribution, &[Observation::Floating(960.0)]);
+                assert_eq!(*unit, Millisecond::UNIT);
+                assert_eq!(
+                    dimensions,
+                    &[("Operation".to_string(), "Ducks".to_string())]
+                );
+            }
+            other => panic!("expected a metric, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forwards_errors_unchanged() {
+        let mut events = Vec::new();
+        QuantizingValueWriter::new(Recorder(&mut events), quantizer(4, Rounding::Floor))
+            .error(ValidationError::invalid("something was wrong"));
+
+        assert_eq!(
+            events,
+            [Event::Error(
+                ValidationError::invalid("something was wrong").to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn forwards_invalid_reason_unchanged() {
+        let mut events = Vec::new();
+        QuantizingValueWriter::new(Recorder(&mut events), quantizer(4, Rounding::Floor))
+            .invalid("bad value");
+
+        assert!(
+            matches!(events.as_slice(), [Event::Error(message)] if message.contains("bad value")),
+            "expected the reason to survive, got {events:?}"
+        );
+    }
+
+    #[test]
+    fn non_finite_observations_pass_through_unchanged() {
+        // The `f64` value impl writes `NaN` and the infinities as observations and leaves it to
+        // the format to validate them. Quantizing must not disturb them, so that whatever
+        // diagnostic the format would have produced is unchanged.
+        for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let events = record(&value, quantizer(4, Rounding::Floor));
+            match &distribution(&events)[0] {
+                Observation::Floating(written) => {
+                    assert_eq!(
+                        written.to_bits(),
+                        value.to_bits(),
+                        "expected {value} to pass through"
+                    );
+                }
+                other => panic!("expected a floating observation, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn forwards_values_as_a_native_list_with_each_element_quantized() {
+        let events = record(&vec![1000u64, 2000u64], quantizer(4, Rounding::Floor));
+
+        assert_eq!(
+            events,
+            [
+                // `ValuesStart` proves `values()` was forwarded rather than falling back to
+                // the comma-joined string representation.
+                Event::ValuesStart,
+                Event::Metric {
+                    distribution: vec![Observation::Unsigned(960)],
+                    unit: Unit::None,
+                    dimensions: vec![],
+                },
+                Event::Metric {
+                    distribution: vec![Observation::Unsigned(1920)],
+                    unit: Unit::None,
+                    dimensions: vec![],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn forwards_empty_lists() {
+        let events = record(&Vec::<u64>::new(), quantizer(4, Rounding::Floor));
+        assert_eq!(events, [Event::ValuesStart]);
+    }
+
+    #[test]
+    fn nested_lists_quantize_every_element() {
+        let nested = vec![vec![1000u64, 2000u64], vec![3000u64]];
+        let events = record(&nested, quantizer(4, Rounding::Floor));
+
+        let totals: Vec<u64> = events
+            .iter()
+            .filter_map(|event| match event {
+                Event::Metric { distribution, .. } => match distribution[0] {
+                    Observation::Unsigned(value) => Some(value),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(totals, [960, 1920, 2816]);
+    }
+
+    #[test]
+    fn passes_through_values_that_write_nothing() {
+        let events = record(&Option::<u64>::None, quantizer(4, Rounding::Floor));
+        assert_eq!(events, []);
+    }
+
+    #[test]
+    fn quantizer_is_readable() {
+        let quantizer = quantizer(11, Rounding::Ceil);
+        let writer = QuantizingValueWriter::new((), quantizer);
+        assert_eq!(writer.quantizer(), quantizer);
+    }
+
+    #[test]
+    fn multi_observation_distributions_are_all_quantized() {
+        // A value that writes several observations at once.
+        let observations = vec![
+            Observation::Unsigned(1000),
+            Observation::Unsigned(2000),
+            Observation::Floating(3000.0),
+        ];
+        let mut events = Vec::new();
+        QuantizingValueWriter::new(Recorder(&mut events), quantizer(4, Rounding::Floor)).metric(
+            observations,
+            Unit::None,
+            [],
+            MetricFlags::empty(),
+        );
+
+        assert_eq!(
+            distribution(&events),
+            &[
+                Observation::Unsigned(960),
+                Observation::Unsigned(1920),
+                Observation::Floating(2816.0),
+            ]
+        );
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Quantized
+    // ---------------------------------------------------------------------------------
+
+    #[test]
+    fn quantized_wrapper_reduces_the_value() {
+        let bits = SignificantBits::new(4).unwrap();
+        let value = 1000u64.quantized(bits, Rounding::Floor);
+        let events = record_plain(&value);
+        assert_eq!(distribution(&events), &[Observation::Unsigned(960)]);
+    }
+
+    #[test]
+    fn quantized_derefs_to_the_unmodified_value() {
+        let bits = SignificantBits::new(4).unwrap();
+        let mut value = 1000u64.quantized(bits, Rounding::Floor);
+
+        // `Deref` and `DerefMut` see the true value, not the quantized one.
+        assert_eq!(*value, 1000);
+        *value += 1;
+        assert_eq!(*value, 1001);
+        assert_eq!(value.into_inner(), 1001);
+    }
+
+    #[test]
+    fn quantized_from_type_level_bits() {
+        use crate::quantize::{Bits, rounding as tag};
+
+        let midpoint: Quantized<u64, Bits<4>> = 1000u64.into();
+        assert_eq!(
+            distribution(&record_plain(&midpoint)),
+            &[Observation::Unsigned(992)]
+        );
+
+        let floor: Quantized<u64, Bits<4, tag::Floor>> = 1000u64.into();
+        assert_eq!(
+            distribution(&record_plain(&floor)),
+            &[Observation::Unsigned(960)]
+        );
+
+        let ceil: Quantized<u64, Bits<4, tag::Ceil>> = 1000u64.into();
+        assert_eq!(
+            distribution(&record_plain(&ceil)),
+            &[Observation::Unsigned(1024)]
+        );
+    }
+
+    #[test]
+    fn type_level_bits_are_zero_sized() {
+        use crate::quantize::Bits;
+        // The whole point of the type-level form: the settings cost no space.
+        assert_eq!(
+            std::mem::size_of::<Quantized<u64, Bits<8>>>(),
+            std::mem::size_of::<u64>()
+        );
+    }
+
+    #[test]
+    fn quantized_preserves_shape_and_unit() {
+        use crate::quantize::Bits;
+        use std::time::Duration;
+
+        assert_eq!(
+            <Quantized<Duration> as Value>::UNIT,
+            <Duration as Value>::UNIT
+        );
+        assert_eq!(
+            <Quantized<u64, Bits<8>> as Value>::UNIT,
+            <u64 as Value>::UNIT
+        );
+
+        // `FieldShape` is not `PartialEq`, so compare the rendered form.
+        assert_eq!(
+            format!("{:?}", <Quantized<Duration> as Value>::SHAPE),
+            format!("{:?}", <Duration as Value>::SHAPE)
+        );
+        assert_eq!(
+            format!("{:?}", <Quantized<u64, Bits<8>> as Value>::SHAPE),
+            format!("{:?}", <u64 as Value>::SHAPE)
+        );
+    }
+
+    #[test]
+    fn quantized_map_value_keeps_the_quantizer() {
+        let bits = SignificantBits::new(4).unwrap();
+        let value = 1000u64.quantized(bits, Rounding::Floor);
+        let mapped = value.map_value(|v| v * 2);
+
+        assert_eq!(*mapped, 2000);
+        assert_eq!(
+            distribution(&record_plain(&mapped)),
+            &[Observation::Unsigned(1920)]
+        );
+    }
+
+    #[test]
+    fn converting_the_unit_before_quantizing_applies_the_bound_in_that_unit() {
+        use crate::unit::{Microsecond, UnitTag as _};
+        use std::time::Duration;
+
+        let bits = SignificantBits::new(8).unwrap();
+
+        // Convert first: 3ms becomes 3000us, then quantizing at 8 bits lands on 2992.
+        let converted_then_quantized = Duration::from_millis(3)
+            .with_unit::<Microsecond>()
+            .quantized(bits, Rounding::Floor);
+        let events = record_plain(&converted_then_quantized);
+        match &events[0] {
+            Event::Metric {
+                distribution, unit, ..
+            } => {
+                assert_eq!(distribution, &[Observation::Floating(2992.0)]);
+                assert_eq!(*unit, Microsecond::UNIT);
+            }
+            other => panic!("expected a metric, got {other:?}"),
+        }
+
+        // Quantize first: 3 (milliseconds) already fits in 8 bits, so nothing is discarded and
+        // the conversion then yields an unreduced 3000us. This is why the docs tell callers to
+        // convert before quantizing.
+        let quantized_then_converted = Duration::from_millis(3)
+            .quantized(bits, Rounding::Floor)
+            .with_unit::<Microsecond>();
+        let events = record_plain(&quantized_then_converted);
+        assert_eq!(
+            distribution(&events),
+            &[Observation::Floating(3000.0)],
+            "quantizing before converting should leave the value unreduced"
+        );
+    }
+
+    #[test]
+    fn quantized_composes_with_dimensions() {
+        use crate::value::WithDimension;
+
+        let bits = SignificantBits::new(4).unwrap();
+        let value = WithDimension::new(1000u64.quantized(bits, Rounding::Floor), "Op", "Count");
+        let events = record_plain(&value);
+
+        match &events[0] {
+            Event::Metric {
+                distribution,
+                dimensions,
+                ..
+            } => {
+                assert_eq!(distribution, &[Observation::Unsigned(960)]);
+                assert_eq!(dimensions, &[("Op".to_string(), "Count".to_string())]);
+            }
+            other => panic!("expected a metric, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quantized_lists_are_forwarded_natively() {
+        // `Vec` is a `Value` but not a `MetricValue`, so it has no `.quantized()` builder;
+        // wrap it directly.
+        let bits = SignificantBits::new(4).unwrap();
+        let value = Quantized::new(
+            vec![1000u64, 2000u64],
+            Quantizer::new(bits, Rounding::Floor),
+        );
+        let events = record_plain(&value);
+
+        assert_eq!(
+            events,
+            [
+                Event::ValuesStart,
+                Event::Metric {
+                    distribution: vec![Observation::Unsigned(960)],
+                    unit: Unit::None,
+                    dimensions: vec![],
+                },
+                Event::Metric {
+                    distribution: vec![Observation::Unsigned(1920)],
+                    unit: Unit::None,
+                    dimensions: vec![],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn quantized_option_skips_none() {
+        let bits = SignificantBits::new(4).unwrap();
+        assert_eq!(
+            record_plain(&Some(1000u64).quantized(bits, Rounding::Floor)).len(),
+            1
+        );
+        assert_eq!(
+            record_plain(&None::<u64>.quantized(bits, Rounding::Floor)),
+            []
+        );
+    }
+
+    #[test]
+    fn quantized_in_an_entry_leaves_other_fields_alone() {
+        use crate::quantize::{Bits, rounding as tag};
+        use crate::{Entry, EntryConfig, EntryWriter};
+        use std::borrow::Cow;
+        use std::time::SystemTime;
+
+        // Written by hand rather than with `derive(Entry)`: this crate's own lib tests pull in
+        // a second copy of `metrique-writer-core` through the `metrique-writer` dev-dependency,
+        // so the derive resolves `Value` to the other copy and cannot see impls defined here.
+        // `metrique-writer/tests/quantize.rs` covers the derive path, where only one copy
+        // exists.
+        struct TestEntry {
+            quantized_latency: Quantized<u64, Bits<4, tag::Floor>>,
+            exact_latency: u64,
+            request_count: u64,
+        }
+
+        impl Entry for TestEntry {
+            fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+                writer.timestamp(SystemTime::UNIX_EPOCH);
+                writer.value("QuantizedLatency", &self.quantized_latency);
+                writer.value("ExactLatency", &self.exact_latency);
+                writer.value("RequestCount", &self.request_count);
+            }
+        }
+
+        /// Collects each field's name and the single unsigned observation it wrote.
+        struct Collector<'a>(&'a mut Vec<(String, u64)>, bool);
+
+        impl<'a> EntryWriter<'a> for Collector<'_> {
+            fn timestamp(&mut self, _timestamp: SystemTime) {
+                self.1 = true;
+            }
+
+            fn value(&mut self, name: impl Into<Cow<'a, str>>, value: &(impl Value + ?Sized)) {
+                let mut events = Vec::new();
+                value.write(Recorder(&mut events));
+                if let Event::Metric { distribution, .. } = &events[0]
+                    && let Observation::Unsigned(written) = distribution[0]
+                {
+                    self.0.push((name.into().into_owned(), written));
+                }
+            }
+
+            fn config(&mut self, _config: &'a dyn EntryConfig) {}
+        }
+
+        let entry = TestEntry {
+            quantized_latency: 1000u64.into(),
+            exact_latency: 1000,
+            request_count: 1000,
+        };
+
+        let mut fields = Vec::new();
+        let mut collector = Collector(&mut fields, false);
+        entry.write(&mut collector);
+        let saw_timestamp = collector.1;
+
+        assert!(saw_timestamp, "the timestamp should still be written");
+        assert_eq!(
+            fields,
+            [
+                // Only the quantized field moved.
+                ("QuantizedLatency".to_string(), 960),
+                ("ExactLatency".to_string(), 1000),
+                ("RequestCount".to_string(), 1000),
+            ]
+        );
+    }
+
+    #[test]
+    fn quantized_source_is_readable() {
+        let bits = SignificantBits::new(11).unwrap();
+        let expected = Quantizer::new(bits, Rounding::Ceil);
+        let value = 1u64.quantized(bits, Rounding::Ceil);
+        assert_eq!(*value.source(), expected);
+    }
+}

--- a/metrique-writer/src/entry/mod.rs
+++ b/metrique-writer/src/entry/mod.rs
@@ -5,5 +5,7 @@
 
 mod dimensions;
 mod map;
+mod quantized;
 pub use dimensions::WithGlobalDimensions;
 pub use map::EnumMapEntry;
+pub use quantized::{QuantizationPolicy, QuantizedEntry};

--- a/metrique-writer/src/entry/quantized.rs
+++ b/metrique-writer/src/entry/quantized.rs
@@ -1,0 +1,213 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Applying a quantizer to a whole stream of entries.
+
+use std::{
+    borrow::Cow,
+    collections::HashSet,
+    fmt,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+    time::SystemTime,
+};
+
+use metrique_writer_core::{
+    Entry, EntryConfig, EntryWriter, Value, quantize::Quantizer, value::Quantized,
+};
+
+use crate::CowStr;
+
+/// Chooses which metrics a [`QuantizationPolicy`] applies to.
+///
+/// Kept private so that new selection strategies can be added without a breaking change; build
+/// one with [`QuantizationPolicy::for_metrics`] or [`QuantizationPolicy::matching`].
+#[derive(Clone)]
+enum MetricFilter {
+    Names(HashSet<CowStr>),
+    Predicate(Arc<dyn Fn(&str) -> bool + Send + Sync>),
+}
+
+impl fmt::Debug for MetricFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MetricFilter::Names(names) => f.debug_tuple("Names").field(names).finish(),
+            MetricFilter::Predicate(_) => f.write_str("Predicate(..)"),
+        }
+    }
+}
+
+/// Which metrics to quantize on a stream, and how.
+///
+/// A policy pairs a [`Quantizer`] with a filter naming the metrics it applies to. There is
+/// deliberately **no** "quantize everything" constructor: a stream carries counts that must
+/// reconcile exactly, identifiers that happen to be numeric, and other values whose precision
+/// is load-bearing. Reducing those silently would be a bug, so the set of metrics to quantize
+/// has to be stated.
+///
+/// Timestamps need no filtering. An entry's timestamp travels through
+/// [`EntryWriter::timestamp`], never through [`EntryWriter::value`], so a decorator that only
+/// intercepts values cannot reach it.
+///
+/// # Examples
+///
+/// Quantize two named latency metrics and nothing else:
+///
+/// ```
+/// use metrique_writer::quantize::{Quantizer, Rounding, SignificantBits};
+/// use metrique_writer::stream::QuantizationPolicy;
+///
+/// let quantizer = Quantizer::new(SignificantBits::new(8).unwrap(), Rounding::Midpoint);
+/// let policy = QuantizationPolicy::for_metrics(quantizer, ["LatencyNanos", "DownstreamNanos"]);
+///
+/// assert!(policy.applies_to("LatencyNanos"));
+/// assert!(!policy.applies_to("RequestCount"));
+/// ```
+///
+/// Or select by a predicate, when the metric names follow a convention:
+///
+/// ```
+/// use metrique_writer::quantize::Quantizer;
+/// use metrique_writer::stream::QuantizationPolicy;
+///
+/// let policy = QuantizationPolicy::matching(Quantizer::default(), |name| {
+///     name.ends_with("Nanos") || name.ends_with("Bytes")
+/// });
+///
+/// assert!(policy.applies_to("LatencyNanos"));
+/// assert!(policy.applies_to("PayloadBytes"));
+/// assert!(!policy.applies_to("RequestCount"));
+/// ```
+#[derive(Clone, Debug)]
+pub struct QuantizationPolicy {
+    quantizer: Quantizer,
+    filter: MetricFilter,
+}
+
+impl QuantizationPolicy {
+    /// Quantize exactly the named metrics, matched by their emitted name.
+    ///
+    /// Names are compared after any renaming the entry applies, so they should match what
+    /// appears in the output.
+    pub fn for_metrics(
+        quantizer: Quantizer,
+        names: impl IntoIterator<Item = impl Into<CowStr>>,
+    ) -> Self {
+        Self {
+            quantizer,
+            filter: MetricFilter::Names(names.into_iter().map(Into::into).collect()),
+        }
+    }
+
+    /// Quantize the metrics whose emitted name satisfies `predicate`.
+    ///
+    /// The predicate is consulted once per value written, so it should be cheap.
+    pub fn matching(
+        quantizer: Quantizer,
+        predicate: impl Fn(&str) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            quantizer,
+            filter: MetricFilter::Predicate(Arc::new(predicate)),
+        }
+    }
+
+    /// The quantizer this policy applies.
+    pub fn quantizer(&self) -> Quantizer {
+        self.quantizer
+    }
+
+    /// Whether the metric named `name` will be quantized.
+    pub fn applies_to(&self, name: &str) -> bool {
+        match &self.filter {
+            MetricFilter::Names(names) => names.contains(name),
+            MetricFilter::Predicate(predicate) => predicate(name),
+        }
+    }
+}
+
+/// An [`Entry`] whose matching values are reduced in precision as they are written.
+///
+/// Produced by [`EntryIoStreamExt::with_quantization`] and
+/// [`FormatExt::with_quantization`]; see [`QuantizationPolicy`].
+///
+/// [`EntryIoStreamExt::with_quantization`]: crate::stream::EntryIoStreamExt::with_quantization
+/// [`FormatExt::with_quantization`]: crate::format::FormatExt::with_quantization
+#[derive(Clone, Debug)]
+pub struct QuantizedEntry<E> {
+    entry: E,
+    policy: QuantizationPolicy,
+}
+
+impl<E> QuantizedEntry<E> {
+    /// Reduce the precision of `entry`'s matching values when it is written.
+    pub fn new(entry: E, policy: QuantizationPolicy) -> Self {
+        Self { entry, policy }
+    }
+
+    /// The policy being applied.
+    pub fn policy(&self) -> &QuantizationPolicy {
+        &self.policy
+    }
+}
+
+impl<E> Deref for QuantizedEntry<E> {
+    type Target = E;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entry
+    }
+}
+
+impl<E> DerefMut for QuantizedEntry<E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entry
+    }
+}
+
+impl<E: Entry> Entry for QuantizedEntry<E> {
+    fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
+        struct Wrapper<'a, W> {
+            writer: W,
+            policy: &'a QuantizationPolicy,
+        }
+
+        impl<'a, W: EntryWriter<'a>> EntryWriter<'a> for Wrapper<'_, W> {
+            fn timestamp(&mut self, timestamp: SystemTime) {
+                // Forwarded untouched. Quantizing an epoch value would move it by hours, and
+                // there is no path by which this decorator could do so: timestamps do not go
+                // through `value()`.
+                self.writer.timestamp(timestamp);
+            }
+
+            fn value(&mut self, name: impl Into<Cow<'a, str>>, value: &(impl Value + ?Sized)) {
+                let name: Cow<'a, str> = name.into();
+                if self.policy.applies_to(&name) {
+                    self.writer
+                        .value(name, &Quantized::new(value, self.policy.quantizer()));
+                } else {
+                    self.writer.value(name, value);
+                }
+            }
+
+            fn config(&mut self, config: &'a dyn EntryConfig) {
+                self.writer.config(config);
+            }
+        }
+
+        self.entry.write(&mut Wrapper {
+            writer,
+            policy: &self.policy,
+        })
+    }
+
+    fn sample_group(
+        &self,
+    ) -> impl Iterator<Item = metrique_writer_core::entry::SampleGroupElement> {
+        self.entry.sample_group()
+    }
+
+    fn descriptors(&self) -> metrique_writer_core::Descriptors<'_> {
+        self.entry.descriptors()
+    }
+}

--- a/metrique-writer/src/entry/quantized.rs
+++ b/metrique-writer/src/entry/quantized.rs
@@ -24,7 +24,9 @@ use crate::CowStr;
 /// one with [`QuantizationPolicy::for_metrics`] or [`QuantizationPolicy::matching`].
 #[derive(Clone)]
 enum MetricFilter {
-    Names(HashSet<CowStr>),
+    // Both variants are behind an `Arc` so that cloning a `QuantizationPolicy` is a refcount
+    // bump rather than a rehash of every name. Policies are cheap to share across streams.
+    Names(Arc<HashSet<CowStr>>),
     Predicate(Arc<dyn Fn(&str) -> bool + Send + Sync>),
 }
 
@@ -95,7 +97,7 @@ impl QuantizationPolicy {
     ) -> Self {
         Self {
             quantizer,
-            filter: MetricFilter::Names(names.into_iter().map(Into::into).collect()),
+            filter: MetricFilter::Names(Arc::new(names.into_iter().map(Into::into).collect())),
         }
     }
 
@@ -133,25 +135,28 @@ impl QuantizationPolicy {
 ///
 /// [`EntryIoStreamExt::with_quantization`]: crate::stream::EntryIoStreamExt::with_quantization
 /// [`FormatExt::with_quantization`]: crate::format::FormatExt::with_quantization
-#[derive(Clone, Debug)]
-pub struct QuantizedEntry<E> {
+/// The policy is borrowed rather than owned so that wrapping an entry costs nothing. A stream
+/// builds one of these per entry, and cloning a policy per entry would put a refcount bump (or,
+/// before the filter was `Arc`-backed, a full rehash of the name set) on the hot path.
+#[derive(Clone, Copy, Debug)]
+pub struct QuantizedEntry<'a, E> {
     entry: E,
-    policy: QuantizationPolicy,
+    policy: &'a QuantizationPolicy,
 }
 
-impl<E> QuantizedEntry<E> {
+impl<'a, E> QuantizedEntry<'a, E> {
     /// Reduce the precision of `entry`'s matching values when it is written.
-    pub fn new(entry: E, policy: QuantizationPolicy) -> Self {
+    pub fn new(entry: E, policy: &'a QuantizationPolicy) -> Self {
         Self { entry, policy }
     }
 
     /// The policy being applied.
-    pub fn policy(&self) -> &QuantizationPolicy {
-        &self.policy
+    pub fn policy(&self) -> &'a QuantizationPolicy {
+        self.policy
     }
 }
 
-impl<E> Deref for QuantizedEntry<E> {
+impl<E> Deref for QuantizedEntry<'_, E> {
     type Target = E;
 
     fn deref(&self) -> &Self::Target {
@@ -159,13 +164,13 @@ impl<E> Deref for QuantizedEntry<E> {
     }
 }
 
-impl<E> DerefMut for QuantizedEntry<E> {
+impl<E> DerefMut for QuantizedEntry<'_, E> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.entry
     }
 }
 
-impl<E: Entry> Entry for QuantizedEntry<E> {
+impl<E: Entry> Entry for QuantizedEntry<'_, E> {
     fn write<'a>(&'a self, writer: &mut impl EntryWriter<'a>) {
         struct Wrapper<'a, W> {
             writer: W,
@@ -197,7 +202,7 @@ impl<E: Entry> Entry for QuantizedEntry<E> {
 
         self.entry.write(&mut Wrapper {
             writer,
-            policy: &self.policy,
+            policy: self.policy,
         })
     }
 

--- a/metrique-writer/src/format.rs
+++ b/metrique-writer/src/format.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 use crate::{
     CowStr,
     entry::WithGlobalDimensions,
-    stream::{MergeGlobalDimensions, MergeGlobals},
+    stream::{MergeGlobalDimensions, MergeGlobals, QuantizationPolicy, Quantize},
 };
 
 /// Extension trait for [`Format`]. This adds methods that use types not
@@ -247,6 +247,51 @@ pub trait FormatExt: Format {
             global_dimensions_denylist: global_dimensions_denylist.unwrap_or_default(),
         }
     }
+
+    /// Reduce the precision of the metrics selected by `policy`, for every entry this format
+    /// writes.
+    ///
+    /// This is the stream-wide counterpart to `#[metrics(quantize(..))]`, for turning
+    /// quantization on without editing field declarations. There is intentionally both a
+    /// [`FormatExt::with_quantization`] and an [`EntryIoStreamExt::with_quantization`], which do
+    /// the same thing, so it can be used with interfaces that accept either a [`Format`] or an
+    /// [`EntryIoStream`].
+    ///
+    /// The policy must name the metrics it applies to; see [`QuantizationPolicy`] for why there
+    /// is no "quantize everything" option. Entry timestamps are never affected.
+    ///
+    /// ```
+    /// # use metrique_writer::{
+    /// #    EntryIoStream, format::FormatExt as _,
+    /// #    quantize::{Quantizer, Rounding, SignificantBits},
+    /// #    stream::QuantizationPolicy,
+    /// # };
+    /// # use metrique_writer_format_emf::Emf;
+    /// # use std::io;
+    /// fn set_up_emf(out: impl io::Write) -> impl EntryIoStream {
+    ///     let quantizer = Quantizer::new(
+    ///         SignificantBits::new(8).unwrap(),
+    ///         Rounding::Midpoint,
+    ///     );
+    ///
+    ///     Emf::all_validations("MyApp".into(), vec![vec![]])
+    ///         .with_quantization(QuantizationPolicy::matching(quantizer, |name| {
+    ///             name.ends_with("Nanos")
+    ///         }))
+    ///         .output_to(out)
+    /// }
+    /// ```
+    ///
+    /// [`EntryIoStreamExt::with_quantization`]: crate::stream::EntryIoStreamExt::with_quantization
+    fn with_quantization(self, policy: QuantizationPolicy) -> Quantize<Self>
+    where
+        Self: Sized,
+    {
+        Quantize {
+            stream: self,
+            policy,
+        }
+    }
 }
 impl<T: Format + ?Sized> FormatExt for T {}
 
@@ -295,6 +340,39 @@ impl<F: Format, const N: usize> Format for MergeGlobalDimensions<F, N> {
             );
             self.stream.format(&entry_with_global_dimensions, output)
         }
+    }
+}
+
+impl<F: Format> Format for Quantize<F> {
+    fn format(
+        &mut self,
+        entry: &impl Entry,
+        output: &mut impl io::Write,
+    ) -> Result<(), IoStreamError> {
+        self.stream.format(
+            &crate::entry::QuantizedEntry::new(entry, self.policy.clone()),
+            output,
+        )
+    }
+}
+
+impl<F: metrique_writer_core::sample::SampledFormat> metrique_writer_core::sample::SampledFormat
+    for Quantize<F>
+{
+    fn format_with_sample_rate(
+        &mut self,
+        entry: &impl Entry,
+        output: &mut impl io::Write,
+        rate: f32,
+    ) -> Result<(), IoStreamError> {
+        // Implemented so that quantization can be applied either side of sampling. The two
+        // orders are equivalent: quantizing changes values, sampling chooses which entries are
+        // written, and neither depends on the other.
+        self.stream.format_with_sample_rate(
+            &crate::entry::QuantizedEntry::new(entry, self.policy.clone()),
+            output,
+            rate,
+        )
     }
 }
 

--- a/metrique-writer/src/format.rs
+++ b/metrique-writer/src/format.rs
@@ -349,10 +349,8 @@ impl<F: Format> Format for Quantize<F> {
         entry: &impl Entry,
         output: &mut impl io::Write,
     ) -> Result<(), IoStreamError> {
-        self.stream.format(
-            &crate::entry::QuantizedEntry::new(entry, self.policy.clone()),
-            output,
-        )
+        let Self { stream, policy } = self;
+        stream.format(&crate::entry::QuantizedEntry::new(entry, policy), output)
     }
 }
 
@@ -368,8 +366,9 @@ impl<F: metrique_writer_core::sample::SampledFormat> metrique_writer_core::sampl
         // Implemented so that quantization can be applied either side of sampling. The two
         // orders are equivalent: quantizing changes values, sampling chooses which entries are
         // written, and neither depends on the other.
-        self.stream.format_with_sample_rate(
-            &crate::entry::QuantizedEntry::new(entry, self.policy.clone()),
+        let Self { stream, policy } = self;
+        stream.format_with_sample_rate(
+            &crate::entry::QuantizedEntry::new(entry, policy),
             output,
             rate,
         )

--- a/metrique-writer/src/lib.rs
+++ b/metrique-writer/src/lib.rs
@@ -35,6 +35,7 @@ pub use metrique_writer_core as core;
 
 pub use format::FormatExt;
 pub use metrique_writer_core::global::{AttachGlobalEntrySink, ShutdownFn};
+pub use metrique_writer_core::quantize;
 pub use metrique_writer_core::unit;
 pub use stream::EntryIoStreamExt;
 

--- a/metrique-writer/src/stream.rs
+++ b/metrique-writer/src/stream.rs
@@ -10,6 +10,9 @@ use smallvec::SmallVec;
 
 use crate::{CowStr, entry::WithGlobalDimensions};
 
+#[doc(inline)]
+pub use crate::entry::{QuantizationPolicy, QuantizedEntry};
+
 pub use metrique_writer_core::{EntryIoStream, IoStreamError};
 
 /// Extension trait for [`EntryIoStream`]. This adds methods that use types not
@@ -111,6 +114,54 @@ pub trait EntryIoStreamExt: EntryIoStream {
         Self: Sized,
     {
         tee(self, other)
+    }
+
+    /// Reduce the precision of the metrics selected by `policy`, for every entry written to this
+    /// stream.
+    ///
+    /// This is the stream-wide counterpart to `#[metrics(quantize(..))]`, for turning
+    /// quantization on without editing field declarations. There is intentionally both an
+    /// [`EntryIoStreamExt::with_quantization`] and a [`FormatExt::with_quantization`], which
+    /// do the same thing, so it can be used with interfaces that accept either an
+    /// [`EntryIoStream`] or a [`Format`].
+    ///
+    /// The policy must name the metrics it applies to; see [`QuantizationPolicy`] for why there
+    /// is no "quantize everything" option. Entry timestamps are never affected.
+    ///
+    /// ```
+    /// # use metrique_writer::{
+    /// #    Entry, EntryIoStream, EntryIoStreamExt, format::FormatExt as _,
+    /// #    quantize::{Quantizer, Rounding, SignificantBits},
+    /// #    stream::QuantizationPolicy,
+    /// # };
+    /// # use metrique_writer_format_emf::Emf;
+    /// # use std::io;
+    /// fn set_up_emf(out: impl io::Write) -> impl EntryIoStream {
+    ///     let quantizer = Quantizer::new(
+    ///         SignificantBits::new(8).unwrap(),
+    ///         Rounding::Midpoint,
+    ///     );
+    ///
+    ///     Emf::all_validations("MyApp".into(), vec![vec![]])
+    ///         .output_to(out)
+    ///         // Latencies lose precision; counts do not.
+    ///         .with_quantization(QuantizationPolicy::for_metrics(
+    ///             quantizer,
+    ///             ["LatencyNanos", "DownstreamNanos"],
+    ///         ))
+    /// }
+    /// ```
+    ///
+    /// [`Format`]: crate::format::Format
+    /// [`FormatExt::with_quantization`]: crate::format::FormatExt::with_quantization
+    fn with_quantization(self, policy: QuantizationPolicy) -> Quantize<Self>
+    where
+        Self: Sized,
+    {
+        Quantize {
+            stream: self,
+            policy,
+        }
     }
 
     /// Report an error message to the relevant log streams in a way that
@@ -220,6 +271,29 @@ impl<S: EntryIoStream, const N: usize> EntryIoStream for MergeGlobalDimensions<S
             );
             self.stream.next(&entry_with_global_dimensions)
         }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stream.flush()
+    }
+}
+
+/// See [`EntryIoStreamExt::with_quantization`] or [`FormatExt::with_quantization`].
+///
+/// [`EntryIoStreamExt::with_quantization`]: crate::stream::EntryIoStreamExt::with_quantization
+/// [`FormatExt::with_quantization`]: crate::format::FormatExt::with_quantization
+#[derive(Clone, Debug)]
+pub struct Quantize<S> {
+    pub(crate) stream: S,
+    pub(crate) policy: QuantizationPolicy,
+}
+
+impl<S: EntryIoStream> EntryIoStream for Quantize<S> {
+    fn next(&mut self, entry: &impl Entry) -> Result<(), IoStreamError> {
+        self.stream.next(&crate::entry::QuantizedEntry::new(
+            entry,
+            self.policy.clone(),
+        ))
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/metrique-writer/src/stream.rs
+++ b/metrique-writer/src/stream.rs
@@ -290,10 +290,10 @@ pub struct Quantize<S> {
 
 impl<S: EntryIoStream> EntryIoStream for Quantize<S> {
     fn next(&mut self, entry: &impl Entry) -> Result<(), IoStreamError> {
-        self.stream.next(&crate::entry::QuantizedEntry::new(
-            entry,
-            self.policy.clone(),
-        ))
+        // Destructured so the shared borrow of `policy` and the mutable borrow of `stream` are
+        // of disjoint fields. Wrapping the entry then costs nothing per entry.
+        let Self { stream, policy } = self;
+        stream.next(&crate::entry::QuantizedEntry::new(entry, policy))
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/metrique-writer/src/value/mod.rs
+++ b/metrique-writer/src/value/mod.rs
@@ -13,4 +13,5 @@ pub use metrique_writer_core::value::{
 };
 pub use metrique_writer_core::value::{MetricFlags, MetricOptions, MetricValue};
 pub use metrique_writer_core::value::{Observation, Value, ValueWriter};
+pub use metrique_writer_core::value::{Quantized, QuantizingValueWriter, quantize_observation};
 pub use metrique_writer_core::value::{WithDimension, WithDimensions, WithVecDimensions};

--- a/metrique-writer/tests/quantize.rs
+++ b/metrique-writer/tests/quantize.rs
@@ -1,0 +1,137 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for quantized values inside a derived [`Entry`].
+
+use std::time::{Duration, SystemTime};
+
+use metrique_writer::quantize::{Bits, Rounding, SignificantBits, rounding};
+use metrique_writer::unit::Microsecond;
+use metrique_writer::value::{MetricValue as _, Quantized};
+use metrique_writer::{Entry, test_util::to_test_entry};
+
+#[derive(Entry)]
+#[entry(rename_all = "PascalCase")]
+struct RequestMetrics {
+    #[entry(timestamp)]
+    timestamp: SystemTime,
+
+    /// Eight significant bits, default midpoint rounding.
+    latency_nanos: Quantized<u64, Bits<8>>,
+
+    /// Four significant bits, never overstating.
+    payload_bytes: Quantized<u64, Bits<4, rounding::Floor>>,
+
+    /// Not quantized: an exact count.
+    request_count: u64,
+
+    /// Not quantized: an exact latency, for comparison.
+    exact_nanos: u64,
+}
+
+#[test]
+fn only_quantized_fields_are_reduced() {
+    let entry = RequestMetrics {
+        timestamp: SystemTime::UNIX_EPOCH,
+        latency_nanos: 1_234_567u64.into(),
+        payload_bytes: 1000u64.into(),
+        request_count: 1000,
+        exact_nanos: 1_234_567,
+    };
+
+    let entry = to_test_entry(&entry);
+
+    // 1_234_567 at 8 significant bits, midpoint.
+    assert_eq!(entry.metrics["LatencyNanos"], 1_232_896);
+    // 1000 at 4 significant bits, floor.
+    assert_eq!(entry.metrics["PayloadBytes"], 960);
+    // Untouched.
+    assert_eq!(entry.metrics["RequestCount"], 1000);
+    assert_eq!(entry.metrics["ExactNanos"], 1_234_567);
+
+    assert!(entry.timestamp.is_some(), "the timestamp must survive");
+}
+
+#[test]
+fn quantized_values_stay_within_their_documented_bound() {
+    let bits = SignificantBits::new(8).unwrap();
+    let bound = bits.max_relative_error(Rounding::Midpoint);
+
+    for raw in [1u64, 255, 256, 1000, 99_999, 1_234_567, 8_589_934_591] {
+        #[derive(Entry)]
+        struct Single {
+            value: Quantized<u64, Bits<8>>,
+        }
+
+        let entry = to_test_entry(&Single { value: raw.into() });
+        let emitted = entry.metrics["value"].as_u64();
+
+        let error = (emitted as f64 - raw as f64).abs() / raw as f64;
+        assert!(
+            error <= bound,
+            "raw={raw} emitted={emitted} error={error} bound={bound}"
+        );
+    }
+}
+
+#[test]
+fn builder_method_matches_the_type_level_form() {
+    #[derive(Entry)]
+    struct ViaType {
+        value: Quantized<u64, Bits<8, rounding::Floor>>,
+    }
+
+    #[derive(Entry)]
+    struct ViaBuilder {
+        value: Quantized<u64>,
+    }
+
+    let bits = SignificantBits::new(8).unwrap();
+
+    let by_type = to_test_entry(&ViaType {
+        value: 1_234_567u64.into(),
+    });
+    let by_builder = to_test_entry(&ViaBuilder {
+        value: 1_234_567u64.quantized(bits, Rounding::Floor),
+    });
+
+    assert_eq!(by_type.metrics["value"], by_builder.metrics["value"]);
+}
+
+#[test]
+fn converting_the_unit_first_applies_the_bound_in_that_unit() {
+    #[derive(Entry)]
+    struct Converted {
+        // 3ms expressed in microseconds, then quantized: 3000us -> 2992us at 8 bits, floor.
+        value: Quantized<
+            metrique_writer::unit::WithUnit<Duration, Microsecond>,
+            Bits<8, rounding::Floor>,
+        >,
+    }
+
+    let entry = to_test_entry(&Converted {
+        value: Duration::from_millis(3).with_unit::<Microsecond>().into(),
+    });
+
+    assert_eq!(entry.metrics["value"], 2992);
+}
+
+#[test]
+fn quantized_optional_fields_are_skipped_when_absent() {
+    #[derive(Entry)]
+    struct Optional {
+        present: Option<Quantized<u64, Bits<4, rounding::Floor>>>,
+        absent: Option<Quantized<u64, Bits<4, rounding::Floor>>>,
+    }
+
+    let entry = to_test_entry(&Optional {
+        present: Some(1000u64.into()),
+        absent: None,
+    });
+
+    assert_eq!(entry.metrics["present"], 960);
+    assert!(
+        !entry.metrics.contains_key("absent"),
+        "an absent optional should emit nothing"
+    );
+}

--- a/metrique-writer/tests/quantize_stream.rs
+++ b/metrique-writer/tests/quantize_stream.rs
@@ -43,7 +43,7 @@ fn only_named_metrics_are_quantized() {
         ["LatencyNanos", "DownstreamNanos"],
     );
 
-    let entry = to_test_entry(QuantizedEntry::new(sample(), policy));
+    let entry = to_test_entry(QuantizedEntry::new(sample(), &policy));
 
     // 1_234_567 at 4 bits, floor.
     assert_eq!(entry.metrics["LatencyNanos"], 1_179_648);
@@ -59,7 +59,7 @@ fn a_predicate_policy_selects_by_name() {
         name.ends_with("Nanos")
     });
 
-    let entry = to_test_entry(QuantizedEntry::new(sample(), policy));
+    let entry = to_test_entry(QuantizedEntry::new(sample(), &policy));
 
     assert_eq!(entry.metrics["LatencyNanos"], 1_179_648);
     assert_eq!(entry.metrics["DownstreamNanos"], 960);
@@ -72,7 +72,7 @@ fn an_empty_policy_quantizes_nothing() {
     let policy =
         QuantizationPolicy::for_metrics(quantizer(1, Rounding::Floor), Vec::<String>::new());
 
-    let entry = to_test_entry(QuantizedEntry::new(sample(), policy));
+    let entry = to_test_entry(QuantizedEntry::new(sample(), &policy));
 
     assert_eq!(entry.metrics["LatencyNanos"], 1_234_567);
     assert_eq!(entry.metrics["DownstreamNanos"], 1000);
@@ -88,7 +88,7 @@ fn the_timestamp_is_never_quantized_even_when_the_filter_matches_everything() {
     let policy = QuantizationPolicy::matching(quantizer(1, Rounding::Floor), |_| true);
 
     let original = to_test_entry(sample());
-    let quantized = to_test_entry(QuantizedEntry::new(sample(), policy));
+    let quantized = to_test_entry(QuantizedEntry::new(sample(), &policy));
 
     assert_eq!(
         original.timestamp, quantized.timestamp,
@@ -120,7 +120,7 @@ fn a_policy_matching_everything_still_leaves_small_values_exact() {
             two_fifty_five: 255,
             two_fifty_six: 256,
         },
-        policy,
+        &policy,
     ));
 
     assert_eq!(entry.metrics["one"], 1);
@@ -137,6 +137,46 @@ fn policy_reports_what_it_applies_to() {
     assert!(policy.applies_to("B"));
     assert!(!policy.applies_to("C"));
     assert_eq!(policy.quantizer(), quantizer(8, Rounding::Ceil));
+}
+
+#[test]
+fn wrapping_an_entry_does_not_clone_the_policy() {
+    // `QuantizedEntry` can only be `Copy` while it *borrows* the policy: an owned
+    // `QuantizationPolicy` contains an `Arc` and is therefore not `Copy`. Asserting `Copy` here
+    // pins the design, so switching the field back to an owned policy — which would put a clone
+    // on the per-entry path — fails to compile rather than quietly costing an allocation per
+    // entry.
+    fn assert_copy<T: Copy>() {}
+    assert_copy::<QuantizedEntry<'_, &RequestMetrics>>();
+
+    // And a single policy can back many wrapped entries at once, which would not typecheck if
+    // each wrapper took ownership.
+    let policy =
+        QuantizationPolicy::for_metrics(quantizer(8, Rounding::Midpoint), ["LatencyNanos"]);
+    let first = sample();
+    let second = sample();
+    let wrapped = [
+        QuantizedEntry::new(&first, &policy),
+        QuantizedEntry::new(&second, &policy),
+    ];
+    assert_eq!(wrapped.len(), 2);
+}
+
+#[test]
+fn one_policy_can_be_shared_across_several_streams() {
+    // Cloning a policy is a refcount bump on the shared name set rather than a rehash, so
+    // configuring several streams from one policy is cheap.
+    let policy = QuantizationPolicy::for_metrics(
+        quantizer(4, Rounding::Floor),
+        (0..64).map(|i| format!("Metric{i:03}")),
+    );
+
+    let clones: Vec<_> = (0..8).map(|_| policy.clone()).collect();
+    for clone in &clones {
+        assert!(clone.applies_to("Metric007"));
+        assert!(!clone.applies_to("RequestCount"));
+        assert_eq!(clone.quantizer(), policy.quantizer());
+    }
 }
 
 #[test]
@@ -168,7 +208,7 @@ fn nested_entries_are_quantized_through_flatten() {
                 inner_count: 1000,
             },
         },
-        policy,
+        &policy,
     ));
 
     assert_eq!(entry.metrics["OuterNanos"], 960);

--- a/metrique-writer/tests/quantize_stream.rs
+++ b/metrique-writer/tests/quantize_stream.rs
@@ -1,0 +1,256 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the stream-level quantization decorator.
+
+use std::time::{Duration, SystemTime};
+
+use metrique_writer::quantize::{Quantizer, Rounding, SignificantBits};
+use metrique_writer::stream::QuantizationPolicy;
+use metrique_writer::test_util::to_test_entry;
+use metrique_writer::{Entry, entry::QuantizedEntry};
+
+fn quantizer(bits: u8, rounding: Rounding) -> Quantizer {
+    Quantizer::new(SignificantBits::new(bits).unwrap(), rounding)
+}
+
+#[derive(Entry)]
+#[entry(rename_all = "PascalCase")]
+struct RequestMetrics {
+    #[entry(timestamp)]
+    timestamp: SystemTime,
+    latency_nanos: u64,
+    downstream_nanos: u64,
+    request_count: u64,
+    fault_count: u64,
+}
+
+fn sample() -> RequestMetrics {
+    RequestMetrics {
+        // A real epoch timestamp: quantizing this would move it by years.
+        timestamp: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000),
+        latency_nanos: 1_234_567,
+        downstream_nanos: 1000,
+        request_count: 1000,
+        fault_count: 1000,
+    }
+}
+
+#[test]
+fn only_named_metrics_are_quantized() {
+    let policy = QuantizationPolicy::for_metrics(
+        quantizer(4, Rounding::Floor),
+        ["LatencyNanos", "DownstreamNanos"],
+    );
+
+    let entry = to_test_entry(QuantizedEntry::new(sample(), policy));
+
+    // 1_234_567 at 4 bits, floor.
+    assert_eq!(entry.metrics["LatencyNanos"], 1_179_648);
+    assert_eq!(entry.metrics["DownstreamNanos"], 960);
+    // Not named, so untouched.
+    assert_eq!(entry.metrics["RequestCount"], 1000);
+    assert_eq!(entry.metrics["FaultCount"], 1000);
+}
+
+#[test]
+fn a_predicate_policy_selects_by_name() {
+    let policy = QuantizationPolicy::matching(quantizer(4, Rounding::Floor), |name| {
+        name.ends_with("Nanos")
+    });
+
+    let entry = to_test_entry(QuantizedEntry::new(sample(), policy));
+
+    assert_eq!(entry.metrics["LatencyNanos"], 1_179_648);
+    assert_eq!(entry.metrics["DownstreamNanos"], 960);
+    assert_eq!(entry.metrics["RequestCount"], 1000);
+    assert_eq!(entry.metrics["FaultCount"], 1000);
+}
+
+#[test]
+fn an_empty_policy_quantizes_nothing() {
+    let policy =
+        QuantizationPolicy::for_metrics(quantizer(1, Rounding::Floor), Vec::<String>::new());
+
+    let entry = to_test_entry(QuantizedEntry::new(sample(), policy));
+
+    assert_eq!(entry.metrics["LatencyNanos"], 1_234_567);
+    assert_eq!(entry.metrics["DownstreamNanos"], 1000);
+    assert_eq!(entry.metrics["RequestCount"], 1000);
+    assert_eq!(entry.metrics["FaultCount"], 1000);
+}
+
+#[test]
+fn the_timestamp_is_never_quantized_even_when_the_filter_matches_everything() {
+    // A policy that matches every name, including whatever the timestamp field is called.
+    // Timestamps travel through `EntryWriter::timestamp`, not `value`, so the decorator has no
+    // way to reach one.
+    let policy = QuantizationPolicy::matching(quantizer(1, Rounding::Floor), |_| true);
+
+    let original = to_test_entry(sample());
+    let quantized = to_test_entry(QuantizedEntry::new(sample(), policy));
+
+    assert_eq!(
+        original.timestamp, quantized.timestamp,
+        "the timestamp must be identical"
+    );
+    assert!(quantized.timestamp.is_some());
+
+    // The values, by contrast, were reduced.
+    assert_eq!(quantized.metrics["LatencyNanos"], 1_048_576);
+}
+
+#[test]
+fn a_policy_matching_everything_still_leaves_small_values_exact() {
+    // `exact_below` at 8 bits is 256: values *strictly below* 256 are returned unchanged even
+    // under a policy that matches them. 256 itself is 9 bits wide, so it does get quantized —
+    // this test pins that boundary.
+    let policy = QuantizationPolicy::matching(quantizer(8, Rounding::Midpoint), |_| true);
+
+    #[derive(Entry)]
+    struct Small {
+        one: u64,
+        two_fifty_five: u64,
+        two_fifty_six: u64,
+    }
+
+    let entry = to_test_entry(QuantizedEntry::new(
+        Small {
+            one: 1,
+            two_fifty_five: 255,
+            two_fifty_six: 256,
+        },
+        policy,
+    ));
+
+    assert_eq!(entry.metrics["one"], 1);
+    assert_eq!(entry.metrics["two_fifty_five"], 255);
+    // 256 is 0b100000000: one bit too wide, so midpoint moves it half a step to 257.
+    assert_eq!(entry.metrics["two_fifty_six"], 257);
+}
+
+#[test]
+fn policy_reports_what_it_applies_to() {
+    let policy = QuantizationPolicy::for_metrics(quantizer(8, Rounding::Ceil), ["A", "B"]);
+
+    assert!(policy.applies_to("A"));
+    assert!(policy.applies_to("B"));
+    assert!(!policy.applies_to("C"));
+    assert_eq!(policy.quantizer(), quantizer(8, Rounding::Ceil));
+}
+
+#[test]
+fn nested_entries_are_quantized_through_flatten() {
+    #[derive(Entry)]
+    #[entry(rename_all = "PascalCase")]
+    struct Outer {
+        outer_nanos: u64,
+        #[entry(flatten)]
+        inner: Inner,
+    }
+
+    #[derive(Entry)]
+    #[entry(rename_all = "PascalCase")]
+    struct Inner {
+        inner_nanos: u64,
+        inner_count: u64,
+    }
+
+    let policy = QuantizationPolicy::matching(quantizer(4, Rounding::Floor), |name| {
+        name.ends_with("Nanos")
+    });
+
+    let entry = to_test_entry(QuantizedEntry::new(
+        Outer {
+            outer_nanos: 1000,
+            inner: Inner {
+                inner_nanos: 1000,
+                inner_count: 1000,
+            },
+        },
+        policy,
+    ));
+
+    assert_eq!(entry.metrics["OuterNanos"], 960);
+    assert_eq!(entry.metrics["InnerNanos"], 960);
+    assert_eq!(entry.metrics["InnerCount"], 1000);
+}
+
+#[test]
+fn stream_and_format_decorators_agree() {
+    use metrique_writer::{EntryIoStream, EntryIoStreamExt, FormatExt};
+    use metrique_writer_format_emf::Emf;
+
+    let policy = QuantizationPolicy::matching(quantizer(4, Rounding::Floor), |name| {
+        name.ends_with("Nanos")
+    });
+
+    // Applied to the stream, after formatting is bound.
+    let mut via_stream = Vec::new();
+    {
+        let mut stream = Emf::builder("Test".to_string(), vec![vec![]])
+            .build()
+            .output_to(&mut via_stream)
+            .with_quantization(policy.clone());
+        stream.next(&sample()).unwrap();
+    }
+
+    // Applied to the format, before it is bound to an output.
+    let mut via_format = Vec::new();
+    {
+        let mut stream = Emf::builder("Test".to_string(), vec![vec![]])
+            .build()
+            .with_quantization(policy)
+            .output_to(&mut via_format);
+        stream.next(&sample()).unwrap();
+    }
+
+    assert_eq!(
+        String::from_utf8(via_stream).unwrap(),
+        String::from_utf8(via_format).unwrap(),
+    );
+}
+
+#[test]
+fn composes_with_sampling_in_either_order() {
+    use metrique_writer::sample::SampledFormatExt;
+    use metrique_writer::{EntryIoStream, EntryIoStreamExt, FormatExt};
+    use metrique_writer_format_emf::Emf;
+
+    let policy = QuantizationPolicy::matching(quantizer(4, Rounding::Floor), |name| {
+        name.ends_with("Nanos")
+    });
+
+    // Sample first, then quantize the resulting stream.
+    let mut buf = Vec::new();
+    {
+        let mut stream = Emf::builder("Test".to_string(), vec![vec![]])
+            .build()
+            .with_sampling()
+            // Rate 1.0 keeps every entry, so the two orders are directly comparable.
+            .sample_by_fixed_fraction(1.0)
+            .output_to(&mut buf)
+            .with_quantization(policy.clone());
+        stream.next(&sample()).unwrap();
+    }
+    let sampled_then_quantized = String::from_utf8(buf).unwrap();
+
+    // Quantize first, then sample. This relies on `Quantize` implementing `SampledFormat`.
+    let mut buf = Vec::new();
+    {
+        let mut stream = Emf::builder("Test".to_string(), vec![vec![]])
+            .build()
+            .with_sampling()
+            .with_quantization(policy)
+            .sample_by_fixed_fraction(1.0)
+            .output_to(&mut buf);
+        stream.next(&sample()).unwrap();
+    }
+    let quantized_then_sampled = String::from_utf8(buf).unwrap();
+
+    assert!(
+        sampled_then_quantized.contains("1179648"),
+        "expected a quantized latency, got {sampled_then_quantized}"
+    );
+    assert_eq!(sampled_then_quantized, quantized_then_sampled);
+}

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -694,7 +694,7 @@ pub mod writer {
 
     pub use metrique_writer::AttachGlobalEntrySinkExt;
     pub use metrique_writer::{AttachGlobalEntrySink, EntryIoStreamExt, FormatExt, ShutdownFn};
-    pub use metrique_writer::{entry, format, sample, sink, stream, value};
+    pub use metrique_writer::{entry, format, quantize, sample, sink, stream, value};
 
     #[cfg(feature = "test-util")]
     #[doc(hidden)] // prefer the metrique::test_util re-export

--- a/metrique/tests/quantize_attr.rs
+++ b/metrique/tests/quantize_attr.rs
@@ -1,0 +1,38 @@
+use metrique::unit::Microsecond;
+use metrique::unit_of_work::metrics;
+use metrique_writer::test_util::test_metric;
+use std::time::Duration;
+
+#[metrics(rename_all = "PascalCase")]
+struct RequestMetrics {
+    #[metrics(quantize(bits = 8))]
+    latency_nanos: u64,
+
+    #[metrics(quantize(bits = 4, rounding = floor))]
+    payload_bytes: u64,
+
+    #[metrics(quantize(bits = 4, rounding = ceil))]
+    queue_depth: u64,
+
+    #[metrics(unit = Microsecond, quantize(bits = 8, rounding = floor))]
+    downstream_time: Duration,
+
+    request_count: u64,
+}
+
+#[test]
+fn attribute_quantizes_only_annotated_fields() {
+    let entry = test_metric(RequestMetrics {
+        latency_nanos: 1_234_567,
+        payload_bytes: 1000,
+        queue_depth: 1000,
+        downstream_time: Duration::from_millis(3),
+        request_count: 1000,
+    });
+
+    assert_eq!(entry.metrics["LatencyNanos"], 1_232_896); // 8 bits, midpoint default
+    assert_eq!(entry.metrics["PayloadBytes"], 960); // 4 bits, floor
+    assert_eq!(entry.metrics["QueueDepth"], 1024); // 4 bits, ceil
+    assert_eq!(entry.metrics["DownstreamTime"], 2992); // 3000us at 8 bits, floor
+    assert_eq!(entry.metrics["RequestCount"], 1000); // untouched
+}

--- a/metrique/tests/ui/fail/bad_quantize.rs
+++ b/metrique/tests/ui/fail/bad_quantize.rs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use metrique::unit_of_work::metrics;
+
+#[metrics]
+struct BitsOutOfRange {
+    // 53 is above the ceiling, because an f64 significand holds 53 bits.
+    #[metrics(quantize(bits = 53))]
+    too_many: u64,
+
+    #[metrics(quantize(bits = 0))]
+    too_few: u64,
+}
+
+#[metrics]
+struct UnknownRounding {
+    #[metrics(quantize(bits = 8, rounding = nearest))]
+    unknown_mode: u64,
+}
+
+#[metrics]
+struct DecimalDigitsInsteadOfBits {
+    // Readers coming from decimal significant digits reach for this; the diagnostic should
+    // name the equivalent bit count rather than just rejecting the key.
+    #[metrics(quantize(digits = 2))]
+    digits: u64,
+}
+
+#[metrics]
+struct MissingBits {
+    #[metrics(quantize(rounding = floor))]
+    no_bits: u64,
+}
+
+#[metrics]
+struct UnknownOption {
+    #[metrics(quantize(bits = 8, precision = 2))]
+    unknown_key: u64,
+}
+
+#[metrics]
+struct NotAList {
+    #[metrics(quantize = 8)]
+    not_a_list: u64,
+}
+
+#[metrics]
+struct QuantizeOnTimestamp {
+    // Quantizing a timestamp would move it by hours; it must be rejected.
+    #[metrics(timestamp, quantize(bits = 8))]
+    timestamp: std::time::SystemTime,
+}
+
+#[metrics]
+struct QuantizeOnFlatten {
+    #[metrics(flatten, quantize(bits = 8))]
+    nested: Nested,
+}
+
+#[metrics(subfield)]
+struct Nested {
+    inner: u64,
+}
+
+fn main() {}

--- a/metrique/tests/ui/fail/bad_quantize.stderr
+++ b/metrique/tests/ui/fail/bad_quantize.stderr
@@ -1,0 +1,53 @@
+error: quantize bits must be in 1..=52, got 53. The ceiling is 52 because metric values are carried as f64 in places and an f64 significand holds 53 bits
+ --> tests/ui/fail/bad_quantize.rs:9:31
+  |
+9 |     #[metrics(quantize(bits = 53))]
+  |                               ^^
+
+error: quantize bits must be in 1..=52, got 0. The ceiling is 52 because metric values are carried as f64 in places and an f64 significand holds 53 bits
+  --> tests/ui/fail/bad_quantize.rs:12:31
+   |
+12 |     #[metrics(quantize(bits = 0))]
+   |                               ^
+
+error: unknown rounding mode `nearest`, expected floor, ceil, or midpoint
+  --> tests/ui/fail/bad_quantize.rs:18:45
+   |
+18 |     #[metrics(quantize(bits = 8, rounding = nearest))]
+   |                                             ^^^^^^^
+
+error: quantize takes a bit count, not decimal digits. For 2 significant decimal digits, use `bits = 8`
+  --> tests/ui/fail/bad_quantize.rs:26:24
+   |
+26 |     #[metrics(quantize(digits = 2))]
+   |                        ^^^^^^
+
+error: quantize requires `bits = N`, for example quantize(bits = 8)
+  --> tests/ui/fail/bad_quantize.rs:32:15
+   |
+32 |     #[metrics(quantize(rounding = floor))]
+   |               ^^^^^^^^
+
+error: unknown quantize option `precision`, expected `bits` or `rounding`
+  --> tests/ui/fail/bad_quantize.rs:38:34
+   |
+38 |     #[metrics(quantize(bits = 8, precision = 2))]
+   |                                  ^^^^^^^^^
+
+error: expected quantize(bits = N) or quantize(bits = N, rounding = floor|ceil|midpoint)
+  --> tests/ui/fail/bad_quantize.rs:44:15
+   |
+44 |     #[metrics(quantize = 8)]
+   |               ^^^^^^^^
+
+error: Cannot combine `timestamp` with `quantize`
+  --> tests/ui/fail/bad_quantize.rs:51:42
+   |
+51 |     #[metrics(timestamp, quantize(bits = 8))]
+   |                                          ^
+
+error: Cannot combine `flatten` with `quantize`
+  --> tests/ui/fail/bad_quantize.rs:57:40
+   |
+57 |     #[metrics(flatten, quantize(bits = 8))]
+   |                                        ^


### PR DESCRIPTION
## What this adds

Opt-in quantization that reduces the precision of metric values as they are written, trading a precisely bounded amount of accuracy for a much smaller set of distinct emitted values — which makes a metric stream both cheaper to store and substantially more compressible.

A quantizer retains the leading `N` significant bits of each observation and clears the rest, equivalent to rounding to the nearest value representable with an `N`-bit significand. Because the discarded bits are always the least significant ones, the error is bounded *relative* to the value rather than in absolute terms, which suits quantities spanning many orders of magnitude such as latencies and byte sizes.

> [!NOTE]
> Opening as a **draft** because `CONTRIBUTING.md` asks that significant work be discussed in an issue first, and this adds new public API across four crates. Happy to split it up, move things, or rework the API shape — the pieces are independent. Please tell me if you'd prefer an issue first and I'll close this.

## API

The core is dependency-light and lives in `metrique-writer-core` so it can be reused without taking on the value model. `metrique-writer-core` was chosen as the home because it is the lightest crate that could host it (`metrique-core` and `metrique-util` both depend on it) and it already owns `Value`/`ValueWriter`/`Observation`.

```rust
pub struct SignificantBits(u8);          // 1..=52, DEFAULT = 8
pub enum Rounding { Floor, Ceil, Midpoint }   // Default: Midpoint
pub struct Quantizer { /* .. */ }        // quantize_u64, quantize_f64
pub struct Bits<const N: u8, R = rounding::Midpoint>;  // settings as a type
```

Three ways to apply it, in increasing order of blast radius:

```rust
// 1. One field, declared in the struct
#[metrics(rename_all = "PascalCase")]
struct RequestMetrics {
    #[metrics(quantize(bits = 8))]                      // within 0.390625%
    latency_nanos: u64,
    #[metrics(quantize(bits = 4, rounding = floor))]    // within 6.25%, never over
    payload_bytes: u64,
    request_count: u64,                                 // left exact
}

// 2. One value, when the bit count comes from configuration
let latency = 1_234_567u64.quantized(bits, Rounding::Midpoint);

// 3. A whole stream, without touching field declarations
Emf::all_validations("MyApp".into(), vec![vec![]])
    .output_to(out)
    .with_quantization(QuantizationPolicy::for_metrics(quantizer, ["LatencyNanos"]))
```

## Error bounds

Every bound is a power of two, so these are exact rather than rounded. `SignificantBits::max_relative_error` returns them programmatically.

| significant bits | `Floor` / `Ceil` (`< 2^(1-N)`) | `Midpoint` (`<= 2^-N`) | exact below |
|---|---|---|---|
| 1 | 100% | 50% | 2 |
| 2 | 50% | 25% | 4 |
| 3 | 25% | 12.5% | 8 |
| 4 | 12.5% | 6.25% | 16 |
| 6 | 3.125% | 1.5625% | 64 |
| 8 (default) | 0.78125% | 0.390625% | 256 |
| 11 | 0.09765625% | 0.048828125% | 2048 |
| 16 | 0.0030517578125% | 0.00152587890625% | 65536 |

## Design decisions worth reviewing

**`Midpoint` is the default.** It maps a whole bucket onto a single representative just as `Floor` does, so it produces the same number of distinct values and the same value-histogram entropy, while halving the worst-case error and largely cancelling the directional bias the one-sided modes introduce into aggregates. Measured on a 300k-value corpus of synthetic latencies, sizes, and counters, `Floor` and `Midpoint` produced identical distinct counts and identical entropy at every bit width (at 8 bits: both 3192 distinct, 10.519 bits/value); `Midpoint`'s gzipped output was ~1.6% larger because floor representatives carry more trailing decimal zeros.

**The 52-bit ceiling.** Two of three `Observation` variants carry values as `f64`, whose significand is 53 bits. Allowing more than 52 would silently no-op on those variants while still altering `Unsigned(u64)`, making the documented bound untrue for some values but not others. Out-of-range input is rejected rather than clamped.

**`Midpoint` is applied unconditionally, `Ceil` is not.** Returning a lattice-exact value untouched under `Midpoint` would reduce its error to zero but make the bucket produce two distinct outputs instead of one, working against the goal. `Ceil` must special-case them, both to keep its error tight and to stay idempotent — without it, `8 → 12 → 16` diverges.

**Timestamps are excluded structurally, not by name.** `EntryWriter` exposes `timestamp()`, `value()`, and `config()`; timestamps never flow through `value()`, so a decorator intercepting only values provably cannot reach one. A test asserts this holds even under a policy matching every name.

**`Repeated.occurrences` is always left exact.** Formats divide by it to recover an average, so quantizing it would corrupt that average by an amount unrelated to the error bound. Only `total` is reduced.

**The stream policy has no "quantize everything" constructor.** A stream carries counts that must reconcile and identifiers that happen to be numeric, so the metrics to quantize have to be named.

**Subnormal `f64` values pass through untouched.** A subnormal already carries fewer than 53 significant bits, so masking could erase it outright and report a 100% error. Passing them through keeps the documented bound true of every value the function actually modifies.

## Properties, all covered by tests

- **Idempotent** in every mode: `q(q(v)) == q(v)`.
- **Monotonic**: `a <= b` implies `q(a) <= q(b)`.
- **Never panics**: arithmetic saturates at `u64::MAX` / `f64::MAX`, which still satisfies the `Ceil` guarantee.
- Values below `exact_below()` are returned unchanged, so small counters are never disturbed.
- `NaN`, the infinities, and both signed zeros pass through unchanged.
- On negative values the one-sided modes swap, so each mode's promise holds against the true value rather than its magnitude.
- `quantize_u64` and `quantize_f64` agree exactly at and above `exact_below()`.

## Testing

- 68 unit tests on the quantizer, including a cross-check against a deliberately naive reference implementation (division loop and `u128` arithmetic, sharing no arithmetic with the shift-and-mask path) across every bit width in `1..=52`.
- 27 unit tests on the value wrapper and writer, including that a list-valued field still emits a native array with each element quantized — the regression `ValueWriter`'s trait docs warn about when `values()` isn't forwarded.
- 21 doc tests, plus `compile_fail` tests for `Bits<0>` and `Bits<53>`.
- 14 integration tests across `metrique-writer` and `metrique`.
- A `trybuild` case covering 9 macro diagnostics, including a pointed message when someone reaches for `digits = 2` instead of `bits = 8`.
- Full workspace suite passes (1027 tests). `cargo clippy --workspace --all-features --all-targets` reports zero warnings in any file this PR touches, and `RUSTDOCFLAGS="-D warnings" cargo doc` is clean. `cargo fmt --all` applied.


## Review
- The primary file to review is: https://github.com/MikeDombo/metrique/blob/b9a8ef49a40f45636ecf4270de31b910e7781e19/metrique-writer-core/src/quantize.rs