### PR TITLE
Improve subfield_owned diagnostics with a marker type

### DIFF
--- a/metrique-core/src/lib.rs
+++ b/metrique-core/src/lib.rs
@@ -147,8 +147,21 @@ pub trait CloseValue {
     fn close(self) -> Self::Closed;
 }
 
-/// Diagnostic bridge for `#[metrics(subfield)]` fields that only close by value.
-#[doc(hidden)]
+/// A diagnostic marker for metric fields that must be closed by value.
+///
+/// `#[metrics(subfield)]` closes fields by reference. When a field implements
+/// [`CloseValue`] only by value, compiler errors mention this type to point to
+/// `#[metrics(subfield_owned)]` as the alternative.
+///
+/// For example, a subfield containing a `String` must close by value:
+///
+/// ```
+/// # use metrique::unit_of_work::metrics;
+/// #[metrics(subfield_owned)]
+/// struct ChildMetrics {
+///     field: String,
+/// }
+/// ```
 pub struct IfYouSeeThisUseSubfieldOwned<T>(pub T);
 
 impl<T: CloseValue> CloseValue for IfYouSeeThisUseSubfieldOwned<T> {

--- a/metrique-core/src/lib.rs
+++ b/metrique-core/src/lib.rs
@@ -137,8 +137,7 @@ pub use namestyle::{
     label = "This type must implement `CloseValue`",
     message = "CloseValue is not implemented for {Self}",
     note = "You may need to add `#[metrics]` to `{Self}` or implement `CloseValue` directly.",
-    note = "if {Self} implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`",
-    note = "If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`."
+    note = "if {Self} implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`"
 )]
 pub trait CloseValue {
     /// The type produced by closing this value
@@ -146,6 +145,18 @@ pub trait CloseValue {
 
     /// Close the value
     fn close(self) -> Self::Closed;
+}
+
+/// Diagnostic bridge for `#[metrics(subfield)]` fields that only close by value.
+#[doc(hidden)]
+pub struct IfYouSeeThisUseSubfieldOwned<T>(pub T);
+
+impl<T: CloseValue> CloseValue for IfYouSeeThisUseSubfieldOwned<T> {
+    type Closed = T::Closed;
+
+    fn close(self) -> Self::Closed {
+        self.0.close()
+    }
 }
 
 mod private {

--- a/metrique-macro/src/enums.rs
+++ b/metrique-macro/src/enums.rs
@@ -421,9 +421,18 @@ fn generate_close_value_impl_for_enum(
                     .map(|(i, td)| {
                         let binding = quote::format_ident!("v{}", i);
                         let close_expr = if td.close {
-                            quote::quote_spanned!(variant.ident.span()=>
-                                ::metrique::CloseValue::close(#binding)
-                            )
+                            match root_attrs.ownership_kind() {
+                                crate::OwnershipKind::ByValue => {
+                                    quote::quote_spanned!(variant.ident.span()=>
+                                        ::metrique::CloseValue::close(#binding)
+                                    )
+                                }
+                                crate::OwnershipKind::ByRef => crate::close_value_expr(
+                                    quote::quote_spanned!(variant.ident.span()=> #binding),
+                                    variant.ident.span(),
+                                    crate::OwnershipKind::ByRef,
+                                ),
+                            }
                         } else {
                             quote::quote_spanned!(variant.ident.span()=> #binding)
                         };
@@ -441,7 +450,10 @@ fn generate_close_value_impl_for_enum(
                     .iter()
                     .map(|f| {
                         let ident: &Ts2 = &f.ident;
-                        f.close_field_expr(quote::quote_spanned! {f.span=> #ident })
+                        f.close_field_expr(
+                            quote::quote_spanned! {f.span=> #ident },
+                            root_attrs.ownership_kind(),
+                        )
                     })
                     .collect();
                 quote::quote_spanned!(variant.ident.span()=>

--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -1637,14 +1637,14 @@ impl MetricsField {
             OwnershipKind::ByValue => quote_spanned! {span=> __metrique_self_expr!().#ident },
             OwnershipKind::ByRef => quote_spanned! {span=> &__metrique_self_expr!().#ident },
         };
-        self.close_field_expr(field_expr)
+        self.close_field_expr(field_expr, ownership_kind)
     }
 
-    pub(crate) fn close_field_expr(&self, field_expr: Ts2) -> Ts2 {
+    pub(crate) fn close_field_expr(&self, field_expr: Ts2, ownership_kind: OwnershipKind) -> Ts2 {
         let ident = &self.ident;
         let span = self.span;
         let base = if self.attrs.close {
-            quote_spanned! {span=> metrique::CloseValue::close(#field_expr) }
+            close_value_expr(field_expr, span, ownership_kind)
         } else {
             field_expr
         };
@@ -1677,6 +1677,19 @@ impl MetricsField {
 
         let cfg_attrs = self.cfg_attrs();
         quote! { #(#cfg_attrs)* #ident: #base }
+    }
+}
+
+pub(crate) fn close_value_expr(field_expr: Ts2, span: Span, ownership_kind: OwnershipKind) -> Ts2 {
+    match ownership_kind {
+        OwnershipKind::ByValue => {
+            quote_spanned! {span=> metrique::CloseValue::close(#field_expr) }
+        }
+        OwnershipKind::ByRef => quote_spanned! {span=>
+            metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(#field_expr)
+            )
+        },
     }
 }
 

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum.snap
@@ -118,7 +118,9 @@ impl metrique::CloseValue for &'_ Nested {
         }
         #[allow(deprecated)]
         NestedEntry {
-            value: metrique::CloseValue::close(&__metrique_self_expr!().value),
+            value: metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(&__metrique_self_expr!().value),
+            ),
         }
     }
 }
@@ -421,17 +423,30 @@ impl metrique::CloseValue for &'_ Status {
         match __metrique_self_expr!() {
             Status::Active { count, latency } => {
                 StatusEntry::Active {
-                    count: metrique::CloseValue::close(count),
-                    latency: metrique::CloseValue::close(latency).into(),
+                    count: metrique::CloseValue::close(
+                        ::metrique::IfYouSeeThisUseSubfieldOwned(count),
+                    ),
+                    latency: metrique::CloseValue::close(
+                            ::metrique::IfYouSeeThisUseSubfieldOwned(latency),
+                        )
+                        .into(),
                 }
             }
             Status::Pending(v0) => {
-                StatusEntry::Pending(::metrique::CloseValue::close(v0))
+                StatusEntry::Pending(
+                    metrique::CloseValue::close(
+                        ::metrique::IfYouSeeThisUseSubfieldOwned(v0),
+                    ),
+                )
             }
             Status::Multi(v0, v1) => {
                 StatusEntry::Multi(
-                    ::metrique::CloseValue::close(v0),
-                    ::metrique::CloseValue::close(v1),
+                    metrique::CloseValue::close(
+                        ::metrique::IfYouSeeThisUseSubfieldOwned(v0),
+                    ),
+                    metrique::CloseValue::close(
+                        ::metrique::IfYouSeeThisUseSubfieldOwned(v1),
+                    ),
                 )
             }
         }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__entry_enum_tag.snap
@@ -118,7 +118,9 @@ impl metrique::CloseValue for &'_ Nested {
         }
         #[allow(deprecated)]
         NestedEntry {
-            value: metrique::CloseValue::close(&__metrique_self_expr!().value),
+            value: metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(&__metrique_self_expr!().value),
+            ),
         }
     }
 }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_entry_enum.snap
@@ -288,8 +288,16 @@ impl metrique::CloseValue for &'_ Metadata {
         }
         #[allow(deprecated)]
         MetadataEntry {
-            operation: metrique::CloseValue::close(&__metrique_self_expr!().operation),
-            request_id: metrique::CloseValue::close(&__metrique_self_expr!().request_id),
+            operation: metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(
+                    &__metrique_self_expr!().operation,
+                ),
+            ),
+            request_id: metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(
+                    &__metrique_self_expr!().request_id,
+                ),
+            ),
         }
     }
 }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_value_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__sample_group_metrics_value_struct.snap
@@ -40,7 +40,9 @@ impl metrique::CloseValue for &'_ RequestValue {
         }
         #[allow(deprecated)]
         RequestValueValue {
-            value: metrique::CloseValue::close(&__metrique_self_expr!().value),
+            value: metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(&__metrique_self_expr!().value),
+            ),
         }
     }
 }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_struct.snap
@@ -34,7 +34,9 @@ impl metrique::CloseValue for &'_ RequestValue {
         }
         #[allow(deprecated)]
         RequestValueValue {
-            value: metrique::CloseValue::close(&__metrique_self_expr!().value),
+            value: metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(&__metrique_self_expr!().value),
+            ),
         }
     }
 }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_unnamed_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__simple_metrics_value_unnamed_struct.snap
@@ -31,7 +31,9 @@ impl metrique::CloseValue for &'_ RequestValue {
         }
         #[allow(deprecated)]
         RequestValueValue {
-            1: metrique::CloseValue::close(&__metrique_self_expr!().1),
+            1: metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(&__metrique_self_expr!().1),
+            ),
         }
     }
 }

--- a/metrique-macro/src/snapshots/metrique_macro__tests__subfield_struct.snap
+++ b/metrique-macro/src/snapshots/metrique_macro__tests__subfield_struct.snap
@@ -119,7 +119,11 @@ impl metrique::CloseValue for &'_ NestedMetrics {
         }
         #[allow(deprecated)]
         NestedMetricsEntry {
-            counter: metrique::CloseValue::close(&__metrique_self_expr!().counter),
+            counter: metrique::CloseValue::close(
+                ::metrique::IfYouSeeThisUseSubfieldOwned(
+                    &__metrique_self_expr!().counter,
+                ),
+            ),
         }
     }
 }

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -102,7 +102,9 @@ pub use metrique_core::{
 };
 
 #[doc(hidden)]
-pub use metrique_core::{Identity, KebabCase, PascalCase, SnakeCase, Styles};
+pub use metrique_core::{
+    Identity, IfYouSeeThisUseSubfieldOwned, KebabCase, PascalCase, SnakeCase, Styles,
+};
 
 /// Unit types and utilities for metrics.
 ///

--- a/metrique/tests/ui/fail/bad_metrics_value.stderr
+++ b/metrique/tests/ui/fail/bad_metrics_value.stderr
@@ -139,8 +139,5 @@ error[E0277]: CloseValue is not implemented for &std::string::String
    = help: the trait `CloseValue` is not implemented for `&std::string::String`
    = note: You may need to add `#[metrics]` to `&std::string::String` or implement `CloseValue` directly.
    = note: if &std::string::String implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
-help: consider dereferencing here
-   |
-78 |     *field: String,
-   |     +
+   = help: the trait `CloseValue` is implemented for `std::string::String`
+   = note: required for `IfYouSeeThisUseSubfieldOwned<&std::string::String>` to implement `CloseValue`

--- a/metrique/tests/ui/fail/enum_kitchen_sink.stderr
+++ b/metrique/tests/ui/fail/enum_kitchen_sink.stderr
@@ -85,8 +85,8 @@ error[E0277]: CloseValue is not implemented for &TimestampOnClose
    = help: the trait `CloseValue` is not implemented for `&TimestampOnClose`
    = note: You may need to add `#[metrics]` to `&TimestampOnClose` or implement `CloseValue` directly.
    = note: if &TimestampOnClose implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
    = help: the trait `CloseValue` is implemented for `TimestampOnClose`
+   = note: required for `IfYouSeeThisUseSubfieldOwned<&TimestampOnClose>` to implement `CloseValue`
 
 error[E0277]: CloseValue is not implemented for &std::string::String
   --> tests/ui/fail/enum_kitchen_sink.rs:96:5
@@ -97,11 +97,8 @@ error[E0277]: CloseValue is not implemented for &std::string::String
    = help: the trait `CloseValue` is not implemented for `&std::string::String`
    = note: You may need to add `#[metrics]` to `&std::string::String` or implement `CloseValue` directly.
    = note: if &std::string::String implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
-help: consider dereferencing here
-   |
-96 |     *value: String,
-   |     +
+   = help: the trait `CloseValue` is implemented for `std::string::String`
+   = note: required for `IfYouSeeThisUseSubfieldOwned<&std::string::String>` to implement `CloseValue`
 
 error[E0277]: CloseValue is not implemented for &TimestampOnClose
    --> tests/ui/fail/enum_kitchen_sink.rs:101:14
@@ -112,5 +109,5 @@ error[E0277]: CloseValue is not implemented for &TimestampOnClose
     = help: the trait `CloseValue` is not implemented for `&TimestampOnClose`
     = note: You may need to add `#[metrics]` to `&TimestampOnClose` or implement `CloseValue` directly.
     = note: if &TimestampOnClose implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-    = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
     = help: the trait `CloseValue` is implemented for `TimestampOnClose`
+    = note: required for `IfYouSeeThisUseSubfieldOwned<&TimestampOnClose>` to implement `CloseValue`

--- a/metrique/tests/ui/fail/subfield_no_metric.stderr
+++ b/metrique/tests/ui/fail/subfield_no_metric.stderr
@@ -11,7 +11,6 @@ help: the trait `CloseValue` is not implemented for `ChildMetrics`
    | ^^^^^^^^^^^^^^^^^^^
    = note: You may need to add `#[metrics]` to `ChildMetrics` or implement `CloseValue` directly.
    = note: if ChildMetrics implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
    = help: the following other types implement trait `CloseValue`:
              &AtomicBool
              &AtomicU16
@@ -36,7 +35,6 @@ help: within `RootMetricsEntry`, the trait `CloseValue` is not implemented for `
    | ^^^^^^^^^^^^^^^^^^^
    = note: You may need to add `#[metrics]` to `ChildMetrics` or implement `CloseValue` directly.
    = note: if ChildMetrics implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
    = help: the following other types implement trait `CloseValue`:
              &AtomicBool
              &AtomicU16
@@ -71,7 +69,6 @@ help: within `RootMetricsEntry`, the trait `CloseValue` is not implemented for `
    | ^^^^^^^^^^^^^^^^^^^
    = note: You may need to add `#[metrics]` to `ChildMetrics` or implement `CloseValue` directly.
    = note: if ChildMetrics implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
    = help: the following other types implement trait `CloseValue`:
              &AtomicBool
              &AtomicU16
@@ -103,7 +100,6 @@ help: within `RootMetricsEntry`, the trait `CloseValue` is not implemented for `
    | ^^^^^^^^^^^^^^^^^^^
    = note: You may need to add `#[metrics]` to `ChildMetrics` or implement `CloseValue` directly.
    = note: if ChildMetrics implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
    = help: the following other types implement trait `CloseValue`:
              &AtomicBool
              &AtomicU16
@@ -140,7 +136,6 @@ help: the trait `CloseValue` is not implemented for `ChildMetrics`
    | ^^^^^^^^^^^^^^^^^^^
    = note: You may need to add `#[metrics]` to `ChildMetrics` or implement `CloseValue` directly.
    = note: if ChildMetrics implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
    = help: the following other types implement trait `CloseValue`:
              &AtomicBool
              &AtomicU16
@@ -165,7 +160,6 @@ help: the trait `CloseValue` is not implemented for `ChildMetrics`
    | ^^^^^^^^^^^^^^^^^^^
    = note: You may need to add `#[metrics]` to `ChildMetrics` or implement `CloseValue` directly.
    = note: if ChildMetrics implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
    = help: the following other types implement trait `CloseValue`:
              &AtomicBool
              &AtomicU16
@@ -191,7 +185,6 @@ help: within `RootMetricsEntry`, the trait `CloseValue` is not implemented for `
    | ^^^^^^^^^^^^^^^^^^^
    = note: You may need to add `#[metrics]` to `ChildMetrics` or implement `CloseValue` directly.
    = note: if ChildMetrics implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
-   = note: If this type is `&T`, is closed inside a flattened entry, and `T` implements `CloseValue`, consider using `#[metrics(subfield_owned)]`.
    = help: the following other types implement trait `CloseValue`:
              &AtomicBool
              &AtomicU16

--- a/metrique/tests/ui/fail/subfield_owned_suggestion.rs
+++ b/metrique/tests/ui/fail/subfield_owned_suggestion.rs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use metrique::{CloseValue, unit_of_work::metrics};
+
+struct OwnedOnly;
+
+impl CloseValue for OwnedOnly {
+    type Closed = u64;
+
+    fn close(self) -> Self::Closed {
+        0
+    }
+}
+
+#[metrics(subfield)]
+struct StructSubfield {
+    value: OwnedOnly,
+}
+
+#[metrics(subfield)]
+enum EnumSubfield {
+    Struct {
+        value: OwnedOnly,
+    },
+}
+
+fn main() {}

--- a/metrique/tests/ui/fail/subfield_owned_suggestion.stderr
+++ b/metrique/tests/ui/fail/subfield_owned_suggestion.stderr
@@ -1,0 +1,23 @@
+error[E0277]: CloseValue is not implemented for &OwnedOnly
+  --> tests/ui/fail/subfield_owned_suggestion.rs:18:5
+   |
+18 |     value: OwnedOnly,
+   |     ^^^^^ This type must implement `CloseValue`
+   |
+   = help: the trait `CloseValue` is not implemented for `&OwnedOnly`
+   = note: You may need to add `#[metrics]` to `&OwnedOnly` or implement `CloseValue` directly.
+   = note: if &OwnedOnly implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
+   = help: the trait `CloseValue` is implemented for `OwnedOnly`
+   = note: required for `IfYouSeeThisUseSubfieldOwned<&OwnedOnly>` to implement `CloseValue`
+
+error[E0277]: CloseValue is not implemented for &OwnedOnly
+  --> tests/ui/fail/subfield_owned_suggestion.rs:24:9
+   |
+24 |         value: OwnedOnly,
+   |         ^^^^^ This type must implement `CloseValue`
+   |
+   = help: the trait `CloseValue` is not implemented for `&OwnedOnly`
+   = note: You may need to add `#[metrics]` to `&OwnedOnly` or implement `CloseValue` directly.
+   = note: if &OwnedOnly implements `Value` but not `CloseValue`, add `#[metrics(no_close)]`
+   = help: the trait `CloseValue` is implemented for `OwnedOnly`
+   = note: required for `IfYouSeeThisUseSubfieldOwned<&OwnedOnly>` to implement `CloseValue`


### PR DESCRIPTION
📬 *Issue #, if available:*

Fixes #164

✍️ *Description of changes:*

Some field types can only be closed by value. If one of these fields uses `#[metrics(subfield)]`, the user needs to change it to `#[metrics(subfield_owned)]`.

Previously, Metrique suggested `subfield_owned` for every `CloseValue` error, including unrelated errors. This change limits that clue to errors produced by borrowed subfields. In those cases, the compiler diagnostic now includes `IfYouSeeThisUseSubfieldOwned`.

This does not change the behavior of code that already compiles. It only improves compiler diagnostics.

Tests cover the diagnostic for both structs and enums.

Testing:

- `CARGO_BUILD_JOBS=1 NEXTEST_TEST_THREADS=2 RUST_TEST_THREADS=2 ./scripts/ci-local.sh`

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
