### PR TITLE
Preserve exact prefixes on enum tag names

### DIFF
--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -677,23 +677,15 @@ pub(crate) enum Tag {
 }
 
 impl Tag {
-    /// Get the tag field name, applying inflection if using inflectable variant
-    pub(crate) fn field_name(&self, root_attrs: &RootAttributes) -> String {
-        match self {
-            Tag::Inflectable { name, .. } => root_attrs
-                .prefix
-                .as_ref()
-                .map(|p| p.apply(name, root_attrs.rename_all))
-                .unwrap_or_else(|| root_attrs.rename_all.apply(name)),
-            Tag::Exact { name, .. } => name.clone(),
-        }
-    }
-
     /// Get the tag field name as rendered under a propagated name style.
     /// `name_exact` tags are style-invariant: the name is emitted verbatim.
     pub(crate) fn styled_name(&self, root_attrs: &RootAttributes, style: NameStyle) -> String {
         match self {
-            Tag::Inflectable { .. } => style.apply(&self.field_name(root_attrs)),
+            Tag::Inflectable { name, .. } => root_attrs
+                .prefix
+                .as_ref()
+                .map(|prefix| prefix.apply(name, style))
+                .unwrap_or_else(|| style.apply(name)),
             Tag::Exact { name, .. } => name.clone(),
         }
     }

--- a/metrique/tests/descriptor.rs
+++ b/metrique/tests/descriptor.rs
@@ -2080,6 +2080,28 @@ fn enum_tag_name_inflects_with_propagated_style() {
     assert_eq!(descriptor_order(&entry), write_order(&entry));
 }
 
+#[metrics(
+    exact_prefix = "API_",
+    rename_all = "PascalCase",
+    tag(name = "operation_type")
+)]
+enum ExactPrefixTagStyleEnum {
+    DoThing { some_field: u64 },
+}
+
+#[test]
+fn enum_tag_exact_prefix_is_preserved_in_descriptor() {
+    let m = ExactPrefixTagStyleEnum::DoThing { some_field: 1 };
+    let closed = metrique::CloseValue::close(m);
+    let entry = metrique::RootEntry::new(closed);
+
+    let expected = vec!["API_OperationType".to_owned(), "API_SomeField".to_owned()];
+    assert_eq!(
+        (write_order(&entry), descriptor_order(&entry)),
+        (expected.clone(), expected)
+    );
+}
+
 #[metrics(subfield, tag(name_exact = "raw_name"))]
 pub enum ExactTagStyleEnum {
     DoThing { some_field: u64 },

--- a/metrique/tests/enum_tag.rs
+++ b/metrique/tests/enum_tag.rs
@@ -36,6 +36,27 @@ fn tag_field_name_respects_inflection() {
     assert_eq!(entry.metrics["api_count"], 42);
 }
 
+#[metrics(
+    exact_prefix = "API_",
+    rename_all = "PascalCase",
+    tag(name = "operation_type", sample_group)
+)]
+enum WithExactPrefixInflectableTag {
+    DoThing { some_field: u64 },
+}
+
+#[test]
+fn exact_prefix_is_preserved_on_tag_names() {
+    let entry = test_metric(WithExactPrefixInflectableTag::DoThing { some_field: 1 });
+
+    assert_eq!(entry.values["API_OperationType"], "DoThing");
+    assert_eq!(entry.metrics["API_SomeField"], 1);
+
+    let entry = RootEntry::new(WithExactPrefixInflectableTag::DoThing { some_field: 1 }.close());
+    let sample_group: Vec<_> = entry.sample_group().collect();
+    assert_eq!(sample_group[0].0, "API_OperationType");
+}
+
 // Tag with variant name override
 #[metrics(tag(name = "op"))]
 enum CustomName {


### PR DESCRIPTION
📬 *Issue #, if available:*

Fixes #351

✍️ *Description of changes:*

Enum tag names were applying the selected naming style after the exact prefix had already been attached. This caused prefixes such as `API_` to become `Api`.

This change applies the naming style to the tag name first, then attaches the exact prefix without modifying it.

Tests cover emitted field names, sample-group names, and entry descriptors.

Testing:

- `cargo +1.91.0 test -p metrique --test enum_tag --test descriptor`
- `cargo +1.91.0 test -p metrique-macro --lib`
- `CARGO_BUILD_JOBS=1 NEXTEST_TEST_THREADS=2 RUST_TEST_THREADS=2 ./scripts/ci-local.sh`

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
