### PR TITLE
feat(metrique-writer): re-export SampleGroup from the sample module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(metrique-writer)* re-export `SampleGroup` from `metrique_writer::sample` so it can be implemented for custom sample-group keys without depending on the doc-hidden `core` path
+
 ## [0.1.30](https://github.com/awslabs/metrique/compare/metrique-v0.1.29...metrique-v0.1.30) - 2026-08-12
 
 ### Added

--- a/metrique-writer/src/sample/mod.rs
+++ b/metrique-writer/src/sample/mod.rs
@@ -26,7 +26,7 @@ use std::{io, marker::PhantomData, time::Duration};
 use metrique_writer_core::{Entry, IoStreamError, format::Format};
 use rand::{Rng, RngCore, rngs::ThreadRng};
 
-pub use metrique_writer_core::sample::SampledFormat;
+pub use metrique_writer_core::sample::{SampleGroup, SampledFormat};
 
 mod congress;
 pub use congress::{CongressSample, CongressSampleBuilder};


### PR DESCRIPTION
📬 *Issue #, if available:*

N/A

✍️ *Description of changes:*

SampleGroup was only reachable through the doc-hidden `metrique_writer::core`
(and `metrique::writer::core`) alias.
Re-export it from `metrique_writer::sample` alongside SampledFormat/CongressSample
(and thus `metrique::writer::sample`), giving a stable, non-hidden path to
implement the trait.


🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
