### PR TITLE
Warn when append-on-drop guards are unused

### DIFF
--- a/metrique-aggregation/examples/histogram.rs
+++ b/metrique-aggregation/examples/histogram.rs
@@ -32,7 +32,7 @@ fn main() {
     metrics.size.add_value(2048u32);
     metrics.size.add_value(2048u32);
 
-    metrics.append_on_drop(sink.sink);
+    drop(metrics.append_on_drop(sink.sink));
 
     let entries = sink.inspector.entries();
     println!("{:?}", entries[0].metrics);

--- a/metrique-aggregation/tests/histogram.rs
+++ b/metrique-aggregation/tests/histogram.rs
@@ -57,7 +57,7 @@ fn test_histogram() {
     metrics.size.add_value(2048u32);
     metrics.size.add_value(2048u32);
 
-    metrics.append_on_drop(sink.sink);
+    drop(metrics.append_on_drop(sink.sink));
 
     let entries = sink.inspector.entries();
     check!(entries.len() == 1);
@@ -128,7 +128,7 @@ fn test_sort_and_merge() {
     metrics.latency.add_value(Duration::from_millis(5));
     metrics.latency.add_value(Duration::from_millis(15));
 
-    metrics.append_on_drop(sink.sink);
+    drop(metrics.append_on_drop(sink.sink));
 
     let entries = sink.inspector.entries();
     check!(entries.len() == 1);
@@ -186,7 +186,7 @@ fn test_sort_and_merge_merges_duplicates() {
     metrics.latency.add_value(Duration::from_millis(3));
     metrics.latency.add_value(Duration::from_millis(3));
 
-    metrics.append_on_drop(sink.sink);
+    drop(metrics.append_on_drop(sink.sink));
 
     let entries = sink.inspector.entries();
     check!(entries.len() == 1);
@@ -238,7 +238,7 @@ fn test_atomic_histogram() {
     metrics.latency.add_value(Duration::from_millis(15));
     metrics.latency.add_value(Duration::from_millis(25));
 
-    metrics.append_on_drop(sink.sink);
+    drop(metrics.append_on_drop(sink.sink));
 
     let entries = sink.inspector.entries();
     check!(entries.len() == 1);
@@ -291,7 +291,7 @@ fn test_histogram_with_dimensions() {
     metrics.latency.add_value(Duration::from_millis(5));
     metrics.latency.add_value(Duration::from_millis(15));
 
-    metrics.append_on_drop(sink.sink);
+    drop(metrics.append_on_drop(sink.sink));
 
     let entries = sink.inspector.entries();
     check!(entries.len() == 1);
@@ -320,7 +320,7 @@ fn test_sort_and_merge_with_nan() {
     metrics.latency.add_value(f64::NAN);
     metrics.latency.add_value(15.0);
 
-    metrics.append_on_drop(sink.sink);
+    drop(metrics.append_on_drop(sink.sink));
 
     let entries = sink.inspector.entries();
     check!(entries.len() == 1);

--- a/metrique/src/lib.rs
+++ b/metrique/src/lib.rs
@@ -219,6 +219,7 @@ pub type DefaultSink = metrique_writer_core::sink::BoxEntrySink;
 /// // When `metrics` is dropped, it will be closed and appended to the sink
 /// # }
 /// ```
+#[must_use = "use `drop(metric.append_on_drop(sink))` to emit immediately, or `let _metric = metric.append_on_drop(sink);` to emit at the end of the current scope"]
 pub struct AppendAndCloseOnDrop<E: CloseEntry, S: EntrySink<RootMetric<E>>> {
     inner: Option<(E, S)>,
     promoted: LazyPromotionSlot<Parent<PendingEmit<E, S>>>,

--- a/metrique/tests/kitchen-sink.rs
+++ b/metrique/tests/kitchen-sink.rs
@@ -264,7 +264,7 @@ fn flatten_flush_as_expected_snake() {
 #[test]
 fn flatten_flush_as_expected_mixed_prefix_casing() {
     let vec_sink = VecEntrySink::new();
-    PrefixSnake3::default().append_on_drop(vec_sink.clone());
+    drop(PrefixSnake3::default().append_on_drop(vec_sink.clone()));
     let entries = vec_sink.drain();
     let entry = test_util::to_test_entry(&entries[0]);
 
@@ -276,7 +276,7 @@ fn flatten_flush_as_expected_mixed_prefix_casing() {
 #[test]
 fn flatten_flush_as_expected_mixed_prefix_casing_exact() {
     let vec_sink = VecEntrySink::new();
-    ExactPrefix3a::default().append_on_drop(vec_sink.clone());
+    drop(ExactPrefix3a::default().append_on_drop(vec_sink.clone()));
     let entries = vec_sink.drain();
     let entry = test_util::to_test_entry(&entries[0]);
 
@@ -287,7 +287,7 @@ fn flatten_flush_as_expected_mixed_prefix_casing_exact() {
 #[test]
 fn flatten_flush_as_expected_mixed_prefix_root_and_name() {
     let vec_sink = VecEntrySink::new();
-    Outer::default().append_on_drop(vec_sink.clone());
+    drop(Outer::default().append_on_drop(vec_sink.clone()));
     let entries = vec_sink.drain();
     let entry = test_util::to_test_entry(&entries[0]);
 
@@ -422,11 +422,13 @@ struct WithVecProperty {
 #[test]
 fn vec_property_comma_joins_in_default_format() {
     let vec_sink = VecEntrySink::new();
-    WithVecProperty {
-        plugins: vec!["auth".into(), "logging".into(), "cache".into()],
-        count: 42,
-    }
-    .append_on_drop(vec_sink.clone());
+    drop(
+        WithVecProperty {
+            plugins: vec!["auth".into(), "logging".into(), "cache".into()],
+            count: 42,
+        }
+        .append_on_drop(vec_sink.clone()),
+    );
     let entries = vec_sink.drain();
     let entry = test_util::to_test_entry(&entries[0]);
     assert_eq!(entry.values["Plugins"], "auth,logging,cache");
@@ -436,11 +438,13 @@ fn vec_property_comma_joins_in_default_format() {
 #[test]
 fn empty_vec_property_emits_empty_string() {
     let vec_sink = VecEntrySink::new();
-    WithVecProperty {
-        plugins: vec![],
-        count: 0,
-    }
-    .append_on_drop(vec_sink.clone());
+    drop(
+        WithVecProperty {
+            plugins: vec![],
+            count: 0,
+        }
+        .append_on_drop(vec_sink.clone()),
+    );
     let entries = vec_sink.drain();
     let entry = test_util::to_test_entry(&entries[0]);
     assert_eq!(entry.values["Plugins"], "");
@@ -455,10 +459,12 @@ struct WithOptionalVecProperty {
 #[test]
 fn vec_with_none_elements_skips_them_in_default_format() {
     let vec_sink = VecEntrySink::new();
-    WithOptionalVecProperty {
-        tags: vec![Some("a".into()), None, Some("c".into())],
-    }
-    .append_on_drop(vec_sink.clone());
+    drop(
+        WithOptionalVecProperty {
+            tags: vec![Some("a".into()), None, Some("c".into())],
+        }
+        .append_on_drop(vec_sink.clone()),
+    );
     let entries = vec_sink.drain();
     let entry = test_util::to_test_entry(&entries[0]);
     assert_eq!(entry.values["Tags"], "a,c");

--- a/metrique/tests/ui/fail/append_on_drop_must_use.rs
+++ b/metrique/tests/ui/fail/append_on_drop_must_use.rs
@@ -1,0 +1,17 @@
+#![deny(unused_must_use)]
+
+use metrique::ServiceMetrics;
+use metrique::unit_of_work::metrics;
+use metrique::writer::GlobalEntrySink;
+
+#[metrics]
+struct MyMetrics {
+    operation: &'static str,
+}
+
+fn main() {
+    MyMetrics {
+        operation: "example",
+    }
+    .append_on_drop(ServiceMetrics::sink());
+}

--- a/metrique/tests/ui/fail/append_on_drop_must_use.stderr
+++ b/metrique/tests/ui/fail/append_on_drop_must_use.stderr
@@ -1,0 +1,19 @@
+error: unused `AppendAndCloseOnDrop` that must be used
+  --> tests/ui/fail/append_on_drop_must_use.rs:13:5
+   |
+13 | /     MyMetrics {
+14 | |         operation: "example",
+15 | |     }
+16 | |     .append_on_drop(ServiceMetrics::sink());
+   | |___________________________________________^
+   |
+   = note: use `drop(metric.append_on_drop(sink))` to emit immediately, or `let _metric = metric.append_on_drop(sink);` to emit at the end of the current scope
+note: the lint level is defined here
+  --> tests/ui/fail/append_on_drop_must_use.rs:1:9
+   |
+ 1 | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the resulting value
+   |
+13 |     let _ = MyMetrics {
+   |     +++++++


### PR DESCRIPTION
## Summary

- mark `AppendAndCloseOnDrop` as `must_use` so unused guards produce a warning
- make existing immediate emissions explicit with `drop`
- add a compile-fail test for the warning and its guidance

Fixes #364

## Testing

- `cargo +1.91 nextest run`
- `cargo +1.91.0 test -p metrique --test ui`
- `cargo +1.91 clippy --workspace --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
