### PR TITLE
chore(deps): update h2 to 0.4.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,9 +1197,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Bumps h2 from 0.4.16 to 0.4.19, the latest patch in the 0.4 line. RUSTSEC-2026-0258 was already resolved by the earlier bump to 0.4.16 (#374); this just keeps us on the newest patch release.

📬 *Issue #, if available:*

✍️ *Description of changes:*

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
