### PR TITLE
fix(metrique-macro): reject unknown #[aggregate(...)] flags instead of silently accepting typos

### DIFF
--- a/metrique-macro/src/lib.rs
+++ b/metrique-macro/src/lib.rs
@@ -517,6 +517,44 @@ pub fn metrics(attr: TokenStream, input: proc_macro::TokenStream) -> proc_macro:
     base_token_stream.into()
 }
 
+/// Parses the `#[aggregate(...)]` struct-level flag list (`direct`, `ref`) into
+/// `(has_direct, has_ref)`, rejecting anything else instead of silently ignoring it.
+///
+/// A naive `attr_str != "direct"` / `attr_str.contains("ref")` check (the previous
+/// implementation) accepts any typo as "not direct" and can accidentally enable
+/// `ref` mode via substring match (e.g. a typo like `direfc`). Parsing the flags
+/// as a real comma-separated identifier list catches both failure modes at
+/// compile time. `ref` is a Rust keyword, so `Ident::parse_any` is required to
+/// accept it as a bare identifier here.
+fn parse_aggregate_attr_flags(attr: Ts2) -> syn::Result<(bool, bool)> {
+    use syn::ext::IdentExt;
+    use syn::parse::Parser;
+    use syn::punctuated::Punctuated;
+
+    let parser = |input: syn::parse::ParseStream| {
+        Punctuated::<Ident, syn::Token![,]>::parse_terminated_with(input, Ident::parse_any)
+    };
+    let idents = parser.parse2(attr)?;
+
+    let mut has_direct = false;
+    let mut has_ref = false;
+    for ident in &idents {
+        match ident.to_string().as_str() {
+            "direct" => has_direct = true,
+            "ref" => has_ref = true,
+            other => {
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    format!(
+                        "unknown #[aggregate(...)] flag '{other}'; expected `direct` and/or `ref`"
+                    ),
+                ));
+            }
+        }
+    }
+    Ok((has_direct, has_ref))
+}
+
 /// Generates aggregation support for metrics structs.
 ///
 /// This macro enables combining multiple observations of the same metric into a single aggregated
@@ -658,9 +696,11 @@ pub fn metrics(attr: TokenStream, input: proc_macro::TokenStream) -> proc_macro:
 #[proc_macro_attribute]
 pub fn aggregate(attr: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let attr_str = attr.to_string();
-    let entry_mode = attr.is_empty() || attr_str.trim() != "direct";
-    let enable_merge_ref = attr_str.contains("ref");
+    let (has_direct, enable_merge_ref) = match parse_aggregate_attr_flags(Ts2::from(attr)) {
+        Ok(flags) => flags,
+        Err(e) => return TokenStream::from(e.to_compile_error()),
+    };
+    let entry_mode = !has_direct;
 
     let mut output = Ts2::new();
 
@@ -2808,5 +2848,32 @@ mod tests {
 
         let parsed_file = metrics_impl_string(input, quote!(metrics(rename_all = "PascalCase")));
         assert_snapshot!("enum_with_timestamp_and_unit", parsed_file);
+    }
+
+    #[test]
+    fn test_aggregate_attr_flags_valid() {
+        use crate::parse_aggregate_attr_flags;
+        use assert2::check;
+
+        check!(parse_aggregate_attr_flags(quote!()).unwrap() == (false, false));
+        check!(parse_aggregate_attr_flags(quote!(direct)).unwrap() == (true, false));
+        check!(parse_aggregate_attr_flags(quote!(ref)).unwrap() == (false, true));
+        check!(parse_aggregate_attr_flags(quote!(direct, ref)).unwrap() == (true, true));
+        check!(parse_aggregate_attr_flags(quote!(ref, direct)).unwrap() == (true, true));
+    }
+
+    #[test]
+    fn test_aggregate_attr_flags_rejects_typo() {
+        use crate::parse_aggregate_attr_flags;
+        use assert2::check;
+
+        // A typo of `direct` must be rejected, not silently treated as "not direct".
+        let err = parse_aggregate_attr_flags(quote!(diretc)).unwrap_err();
+        check!(err.to_string().contains("unknown #[aggregate(...)] flag 'diretc'"));
+
+        // A typo that happens to contain the substring "ref" must not silently
+        // enable MergeRef via substring match.
+        let err = parse_aggregate_attr_flags(quote!(direfc)).unwrap_err();
+        check!(err.to_string().contains("unknown #[aggregate(...)] flag 'direfc'"));
     }
 }


### PR DESCRIPTION
📬 *Issue #, if available:* Fixes #388

✍️ *Description of changes:*

`#[aggregate(...)]` parsed its struct-level flag list with two ad-hoc string checks:

```rust
let entry_mode = attr.is_empty() || attr_str.trim() != "direct";
let enable_merge_ref = attr_str.contains("ref");
```

Both are silently wrong on a typo, exactly as described in the issue:
- `#[aggregate(diretc)]` doesn't match `"direct"`, so it falls through to entry mode instead of erroring — the user thinks they wrote direct mode but didn't.
- `#[aggregate(direfc)]` contains the substring `"ref"`, so it silently enables `MergeRef` even though the user never wrote `ref`.

This replaces both checks with a real parse of the flag list as a comma-separated identifier list (`direct`, `ref`, both, or empty), using `Ident::parse_any` since `ref` is a Rust keyword. Anything else is now a compile error naming the bad flag, e.g.:

```
unknown #[aggregate(...)] flag 'diretc'; expected `direct` and/or `ref`
```

Added `test_aggregate_attr_flags_valid` and `test_aggregate_attr_flags_rejects_typo` covering both typos from the issue plus the four valid combinations (`direct`, `ref`, both, neither).

Ran `cargo test -p metrique-macro --lib` and `cargo test -p metrique-aggregation` (unit, integration, doctests, cross-crate coherence) — all green, no behavior change on valid input.

🔏 *By submitting this pull request*

- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.